### PR TITLE
Use Ruby logo as a link to the site root

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
     <div id="page">
       <div id="header">
         <div id="logo">
-          <img src="/images/logo.gif" width="331" height="119" alt="Ruby - A Programmer's Best Friend" title="">
+          <a href="/{{ page.lang }}/"><img src="/images/logo.gif" width="331" height="119" alt="Ruby - A Programmer's Best Friend" title=""></a>
         </div>
         <div class="site-links">
           {% include sitelinks.html %}


### PR DESCRIPTION
At the moment there is no link from subpages to the site home.
