### PR TITLE
Removed dead blog links (en)

### DIFF
--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -28,27 +28,23 @@ the most recent posts across the blogs covered in its index.
 A few notable blogs stand out for the frequency and immediacy of their
 updates.
 
-* [**O’Reilly Ruby**][8] is a group blog with pertinent Ruby tutorials
-  and interviews with interesting folks from around the community.
-* [**Riding Rails**][9] is the official group blog of the Ruby on Rails
+* [**Riding Rails**][8] is the official group blog of the Ruby on Rails
   team. If you are running Rails, this blog is essential for
   notification of security updates and an overall view of the wide Rails
   community.
-* [**Ruby Inside**][10] announces interesting applications and libraries
+* [**Ruby Inside**][9] announces interesting applications and libraries
   from throughout the world, both Ruby and Rails.
-* [**Matz’ Blog**][11] is a Japanese blog written by Ruby’s creator.
-  Even if you can’t read all of it, it’s good to know he’s right there!
 
 ### Spreading the Word
 
 If you’ve got a Ruby blog you’ve started, it’s wise to link the blog on
-[del.icio.us][12] with the *ruby* tag. You might also contact the
+[del.icio.us][10] with the *ruby* tag. You might also contact the
 weblogs above, if you are covering a topic they’d be interested in.
 (Obviously, if it’s not Rails-related, then the *Riding Rails* crew may
 not be as interested—but you never know.)
 
-Ruby is also a common topic on [Digg][13], [Slashdot][14], [reddit][15],
-and [Hacker News][16], in their respective programming news. If you find
+Ruby is also a common topic on [Digg][11], [Slashdot][12], [reddit][13],
+and [Hacker News][14], in their respective programming news. If you find
 some brilliant code out there, be sure to let them know!
 
 
@@ -60,12 +56,10 @@ some brilliant code out there, be sure to let them know!
 [5]: http://planetruby.0x42.net/
 [6]: http://www.planetrubyonrails.org/
 [7]: http://www.planetrubyonrails.com/
-[8]: http://oreillynet.com/ruby/
-[9]: http://weblog.rubyonrails.org/
-[10]: http://www.rubyinside.com/
-[11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
-[13]: http://digg.com/programming
-[14]: http://developers.slashdot.org/
-[15]: http://www.reddit.com/r/ruby
-[16]: http://news.ycombinator.com/
+[8]: http://weblog.rubyonrails.org/
+[9]: http://www.rubyinside.com/
+[10]: http://del.icio.us
+[11]: http://digg.com/programming
+[12]: http://developers.slashdot.org/
+[13]: http://www.reddit.com/r/ruby
+[14]: http://news.ycombinator.com/


### PR DESCRIPTION
The list of blogs was outdated: The latest post on "O’Reilly Ruby" was from 2008 and
"Matz’ Blog" was not reachable at all.

I removed these dead entries.
