### PR TITLE
Redirect to /en/ if javascript is not enabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,5 +31,8 @@ layout: nil
 
       document.location = "/" + language;
     </script>
+    <noscript>
+      <meta http-equiv="refresh" content="0;/en/" />
+    </noscript>
   </head>
 </html>


### PR DESCRIPTION
Right now ruby-lang.org white screens for anyone who doesn't have JavaScript enabled.

This pull request falls back to English if JavaScript is disabled.
