### PR TITLE
Add highlighting for news [en]

### DIFF
--- a/en/news/_posts/2013-05-14-taint-bypass-dl-fiddle-cve-2013-2065.md
+++ b/en/news/_posts/2013-05-14-taint-bypass-dl-fiddle-cve-2013-2065.md
@@ -18,29 +18,31 @@ accepted as input when a SecurityError exception should be raised.
 
 Impacted DL code will look something like this:
 
-    def my_function(user_input)
-      handle    = DL.dlopen(nil)
-      sys_cfunc = DL::CFunc.new(handle['system'], DL::TYPE_INT, 'system')
-      sys       = DL::Function.new(sys_cfunc, [DL::TYPE_VOIDP])
-      sys.call user_input
-    end
+{% highlight ruby %}
+def my_function(user_input)
+  handle    = DL.dlopen(nil)
+  sys_cfunc = DL::CFunc.new(handle['system'], DL::TYPE_INT, 'system')
+  sys       = DL::Function.new(sys_cfunc, [DL::TYPE_VOIDP])
+  sys.call user_input
+end
 
-    $SAFE = 1
-    my_function "uname -rs".taint
-{: .code}
+$SAFE = 1
+my_function "uname -rs".taint
+{% endhighlight %}
 
 Impacted Fiddle code will look something like this:
 
-    def my_function(user_input)
-      handle    = DL.dlopen(nil)
-      sys = Fiddle::Function.new(handle['system'],
-                              [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
-      sys.call user_input
-    end
+{% highlight ruby %}
+def my_function(user_input)
+  handle    = DL.dlopen(nil)
+  sys = Fiddle::Function.new(handle['system'],
+                             [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+  sys.call user_input
+end
 
-    $SAFE = 1
-    my_function "uname -rs".taint
-{: .code}
+$SAFE = 1
+my_function "uname -rs".taint
+{% endhighlight %}
 
 All users running an affected release should either upgrade or use one of the
 workarounds immediately.
@@ -49,26 +51,28 @@ Note that this *does not* prevent numeric memory offsets from being used as
 pointer values.  Numbers cannot be tainted, so code passing a numeric memory
 offset cannot be checked.  For example:
 
-    def my_function(input)
-      handle    = DL.dlopen(nil)
-      sys = Fiddle::Function.new(handle['system'],
-                              [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
-      sys.call input
-    end
+{% highlight ruby %}
+def my_function(input)
+  handle    = DL.dlopen(nil)
+  sys = Fiddle::Function.new(handle['system'],
+                             [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+  sys.call input
+end
 
-    $SAFE = 1
-    user_input = "uname -rs".taint
-    my_function DL::CPtr[user_input].to_i
-{: .code}
+$SAFE = 1
+user_input = "uname -rs".taint
+my_function DL::CPtr[user_input].to_i
+{% endhighlight %}
 
 In this case, the memory location is passed, and taintedness of the object
 cannot be determined by DL / Fiddle.  In this case, please check the tainting
 of the user input before passing the memory location:
 
-    user_input = "uname -rs".taint
-    raise if $SAFE >= 1 && user_input.tainted?
-    my_function DL::CPtr[user_input].to_i
-{: .code}
+{% highlight ruby %}
+user_input = "uname -rs".taint
+raise if $SAFE >= 1 && user_input.tainted?
+my_function DL::CPtr[user_input].to_i
+{% endhighlight %}
 
 ## Workarounds
 


### PR DESCRIPTION
For the "taint object cve" news the highlighting was omitted for the first code examples but not for the fix. Maybe there is a reason for it, I nevertheless added the highlighting if interested.
