### PR TITLE
Add translator variable for news posts?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,7 @@ namespace :new_post do
       layout: news_post
       title: "#{title}"
       author: "Unknown Author"
+      translator:
       date: #{creation_time}
       lang: #{lang}
       ---

--- a/_config.yml
+++ b/_config.yml
@@ -346,6 +346,22 @@ locales:
     zh_cn: "由 AUTHOR 发表于 %Y-%m-%d"
 #   zh_tw:
 
+  translated_by:
+    bg: "Превод от"
+    de: "Übersetzt von"
+    en: "Translated by"
+    es: "Traducción de"
+    fr: "Traduit par"
+    id: "Diterjemahkan oleh"
+    it: "Tradotto da"
+#   ja:
+    ko: "번역자:"
+    pl: "Tłumaczone przez"
+    pt: "Traduzido por"
+    tr: "Çeviri:"
+#   zh_cn:
+#   zh_tw:
+
   feed:
     bg:
       title: Ruby новини

--- a/_layouts/news_post.html
+++ b/_layouts/news_post.html
@@ -2,13 +2,20 @@
 layout: default
 ---
 
+{% if site.locales.translated_by[page.lang] %}
+  {% assign translated_by = site.locales.translated_by[page.lang] %}
+{% else %}
+  {% assign translated_by = site.locales.translated_by['en'] %}
+{% endif %}
+
 <div id="content-wrapper">
   {% include title.html %}
 
   <div id="content">
     {{ content }}
 
-    <p class="post-info">{{ page.date | posted_by:page.author }}</p>
+    <p class="post-info">{{ page.date | posted_by:page.author }}{% if page.translator %}<br />
+                         {{ translated_by }} {{ page.translator }}{% endif %}</p>
   </div>
 </div>
 <hr class="hidden-modern" />

--- a/de/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
+++ b/de/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
@@ -2,6 +2,7 @@
 layout: news_post
 title: "Ruby 1.9.3-p429 veröffentlicht"
 author: "usa"
+translator: "Marcus Stollsteimer"
 date: 2013-05-14 17:00:00 UTC
 lang: de
 ---

--- a/en/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
+++ b/en/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
@@ -2,6 +2,7 @@
 layout: news_post
 title: "Ruby 1.9.3-p429 is released"
 author: "usa"
+translator:
 date: 2013-05-14 17:00:00 UTC
 lang: en
 ---

--- a/fr/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
+++ b/fr/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
@@ -2,6 +2,7 @@
 layout: news_post
 title: "Sortie de Ruby 1.9.3-p429"
 author: "usa"
+translator: "Jean-Denis Vauguet"
 date: 2013-05-14 17:00:00 UTC
 lang: fr
 ---

--- a/ja/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
+++ b/ja/news/_posts/2013-05-14-ruby-1-9-3-p429-is-released.md
@@ -2,6 +2,7 @@
 layout: news_post
 title: "Ruby 1.9.3-p429 リリース"
 author: "usa"
+translator:
 date: 2013-05-14 17:00:00 UTC
 lang: ja
 ---


### PR DESCRIPTION
**Not for merging**, only for tests and as basis for discussion.

There might be a need for a `translator` variable in news posts, to give credits to the contributors that translate posts, see #145. I personally don't care, but why not, since it's easy to implement.

I added the information in one of the recent posts (Ruby 1.9.3-p429), with translations for `de` and `fr`. @chikamichi I didn't provide a french translation for "translation" on purpose, to test the defaulting to en :) If provided, the translator is printed below the author line at the bottom of the post, like

```
Posted by usa on 14 May 2013
Translation: John Doe
```

What do you think?
