### PR TITLE
Improve instructions for mailing lists (en)

### DIFF
--- a/en/community/mailing-lists/manual-instructions/index.md
+++ b/en/community/mailing-lists/manual-instructions/index.md
@@ -4,8 +4,9 @@ title: "Manual Mailing List Instructions"
 lang: en
 ---
 
-To subscribe to a mailing list, please send a mail with the following
-mail body (not the subject) to the automated “controller” address:
+To subscribe to a mailing list, please send a plain text mail
+with the following mail body (not the subject) to the automated
+“controller” address:
 
     subscribe Your-First-Name Your-Last-Name
 {: .code}
@@ -50,7 +51,9 @@ Ruby-CVS
 ### Unsubscribing
 
 To unsubscribe from a list, send a mail which body is “unsubscribe” to
-the controller address.
+the **controller address**.
+
+Make sure to send a plain text mail, an HTML mail might not work.
 
 ### Getting Help
 


### PR DESCRIPTION
Especially unsubscribing seems to be difficult, judging from the respective posts on ruby-talk that pop up time and again. Trying to make the instructions a bit clearer:
- Put emphasis on controller address;
- add hint to use plain text emails.

What do you think?
