### PR TITLE
Typo in /fr page "from python to ruby"

### DIFF
--- a/fr/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
+++ b/fr/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
@@ -17,7 +17,7 @@ Tout comme en Python, en Ruby…
   `irb`) ;
 * la documentation est accessible dans le terminal par la commande `ri`,
   à l’instar de `pydoc` ;
-* il n’ai pas besoin de signe particulier pour marquer la fin des
+* il n’est pas besoin de signe particulier pour marquer la fin des
   lignes, si ce n’est passer à la ligne suivante ;
 * les chaînes peuvent s’étaler sur plusieurs lignes, comme avec le
   système de *triple-quote* de Python ;


### PR DESCRIPTION
The sentence was using "n'ai" (have not) before, replaced by "n'est" (is not) which is the correct usage here.

Might need a little tweaking to give a better translation from /en tho.
