### PR TITLE
Remove old references links

### DIFF
--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -8,23 +8,23 @@ lang: ja
 
 ## マニュアル
 
-各環境にRubyをインストールする方法は、 [インストールガイド][2] で解説しています。
+各環境にRubyをインストールする方法は、 [インストールガイド][1] で解説しています。
 
-また、現在有志の手により[リファレンスマニュアルの整備][3]が進行中です。
-作業途中の成果物を[&lt;URL:http://doc.ruby-lang.org/ja/&gt;][4]から閲覧できます。
+また、現在有志の手により[リファレンスマニュアルの整備][2]が進行中です。
+作業途中の成果物を[&lt;URL:http://doc.ruby-lang.org/ja/&gt;][3]から閲覧できます。
 
-* [Rubyリファレンスマニュアル Ruby 1.8.7版][5]
-* [Rubyリファレンスマニュアル Ruby 1.9.3版][6]
-* [Rubyリファレンスマニュアル Ruby 2.0.0版][7]
-* [るりまサーチ][8]
+* [Rubyリファレンスマニュアル Ruby 1.8.7版][4]
+* [Rubyリファレンスマニュアル Ruby 1.9.3版][5]
+* [Rubyリファレンスマニュアル Ruby 2.0.0版][6]
+* [るりまサーチ][7]
 
 またこのリファレンスマニュアルをまとめてダウンロードすることもできます。
 
-* [Rubyリファレンスマニュアル刷新計画 パッケージ版 1.8.7/1.9.3用 (tar.xz形式)][9]
-  \|[(tar.gz形式)][10] \|[(zip形式)][11]
-* [Rubyリファレンスマニュアル刷新計画 chm版 1.8.7用][12] \|[1.9.2用][13]
+* [Rubyリファレンスマニュアル刷新計画 パッケージ版 1.8.7/1.9.3用 (tar.xz形式)][8]
+  \|[(tar.gz形式)][9] \|[(zip形式)][10]
+* [Rubyリファレンスマニュアル刷新計画 chm版 1.8.7用][11] \|[1.9.2用][12]
 
-ドキュメントは全て [&lt;URL:http://doc.okkez.net/&gt;][14] でもミラーされています
+ドキュメントは全て [&lt;URL:http://doc.okkez.net/&gt;][13] でもミラーされています
 
 ### 旧版
 
@@ -32,38 +32,35 @@ lang: ja
 古いバージョンを含め、ダウンロードは可能です。
 
 * [旧リファレンスマニュアル
-  20051029版(HTML/tar.gz形式)][17]\|[(HTML/tar.bz2形式)][18]\|[(HTML/zip形式)][19]\|[(RD/tar.gz形式)][20]\|[(RD/tar.bz2形式)][21]\|[(RD/zip形式)][22]
-* [Ruby 1.6.6 リファレンスマニュアル(日本語版)][23]
-* [Ruby 1.4.6 リファレンスマニュアル(日本語版)][24]
-* [Ruby 1.4.6 リファレンスマニュアル(英語版)][25]
+  20051029版(HTML/tar.gz形式)][14]\|[(HTML/tar.bz2形式)][15]\|[(HTML/zip形式)][16]\|[(RD/tar.gz形式)][17]\|[(RD/tar.bz2形式)][18]\|[(RD/zip形式)][19]
+* [Ruby 1.6.6 リファレンスマニュアル(日本語版)][20]
+* [Ruby 1.4.6 リファレンスマニュアル(日本語版)][21]
+* [Ruby 1.4.6 リファレンスマニュアル(英語版)][22]
 
 Posted by Shugo Maeda on 26 May 2006
 {: .post-info}
 
 
 
-[1]: /ja/old-man/html/Ruby_FAQ.html
-[2]: /ja/install.cgi?cmd=view;name=top
-[3]: https://bugs.ruby-lang.org/projects/rurema/wiki
-[4]: http://doc.ruby-lang.org/ja/
-[5]: http://doc.ruby-lang.org/ja/1.8.7/doc/index.html
-[6]: http://doc.ruby-lang.org/ja/1.9.3/doc/index.html
-[7]: http://doc.ruby-lang.org/ja/2.0.0/doc/index.html
-[8]: http://doc.ruby-lang.org/ja/search/
-[9]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.tar.xz
-[10]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.tar.gz
-[11]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.zip
-[12]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.8.7-20120829.chm
-[13]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-20120829.chm
-[14]: http://doc.okkez.net/
-[15]: /ja/old-man/?cmd=view;name=Ruby%A5%EA%A5%D5%A5%A1%A5%EC%A5%F3%A5%B9%A5%DE%A5%CB%A5%E5%A5%A2%A5%EB
-[16]: /ja/old-man/man-rd-ja.tar.gz
-[17]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.tar.gz
-[18]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.tar.bz2
-[19]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.zip
-[20]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.tar.gz
-[21]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.tar.bz2
-[22]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.zip
-[23]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-1.6.6-20011225-rd.tar.gz
-[24]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-1.4.6-jp.tar.gz
-[25]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-1.4.6.tar.gz
+[1]: /ja/install.cgi?cmd=view;name=top
+[2]: https://bugs.ruby-lang.org/projects/rurema/wiki
+[3]: http://doc.ruby-lang.org/ja/
+[4]: http://doc.ruby-lang.org/ja/1.8.7/doc/index.html
+[5]: http://doc.ruby-lang.org/ja/1.9.3/doc/index.html
+[6]: http://doc.ruby-lang.org/ja/2.0.0/doc/index.html
+[7]: http://doc.ruby-lang.org/ja/search/
+[8]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.tar.xz
+[9]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.tar.gz
+[10]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-dynamic-20120829.zip
+[11]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.8.7-20120829.chm
+[12]: http://doc.ruby-lang.org/archives/201208/ruby-refm-1.9.3-20120829.chm
+[13]: http://doc.okkez.net/
+[14]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.tar.gz
+[15]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.tar.bz2
+[16]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-html-20051029.zip
+[17]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.tar.gz
+[18]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.tar.bz2
+[19]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-rd-20051029.zip
+[20]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-ja-1.6.6-20011225-rd.tar.gz
+[21]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-1.4.6-jp.tar.gz
+[22]: ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-man-1.4.6.tar.gz


### PR DESCRIPTION
Removes old reference links can't redirect new references.
And removes old reference index page.
But left old reference archive download links.
