### PR TITLE
remove Search button's fixed width

### DIFF
--- a/stylesheets/high.css
+++ b/stylesheets/high.css
@@ -421,7 +421,6 @@ body {
   height: 20px;
 }
 #search-form .button {
-  width: 74px;
   height: 24px;
 }
 #foot { clear: both; }


### PR DESCRIPTION
Search button's width is a bit too short for french `Recherche` (we see `Recherch` and no right-padding), we'd need 90px.
Better still, we could get rid of any fixed-width rule.

`74px`, `90px` or no directive are all OK for`bg`, `de`, `en`, `es`, `id`, `it`, `ja`, `ko`, `pl`, `pt`, `tr`, `zh_cn`.
No directive or `90px` would fix `fr`.

Also: untranslated in `zh_tw` yet, can't find the responsible for this locale in
https://github.com/ruby/www.ruby-lang.org/wiki/Team#i18n-maintainers
would @andorchen, @bovi or @chenyukang know how to fix this in `zh_tw`?
