### PR TITLE
Search button's fixed width becomes min-width

### DIFF
--- a/stylesheets/high.css
+++ b/stylesheets/high.css
@@ -421,7 +421,7 @@ body {
   height: 20px;
 }
 #search-form .button {
-  width: 74px;
+  min-width: 74px;
   height: 24px;
 }
 #foot { clear: both; }


### PR DESCRIPTION
As mentioned by @stomar on this PR I just closed
https://github.com/ruby/www.ruby-lang.org/pull/186
I've replaced the search button's fixed "width" to a friendlier "min-width".
