### PR TITLE
Fix typo: pirority => priority

### DIFF
--- a/en/news/_posts/2013-06-27-ruby-2-0-0-p247-is-released.md
+++ b/en/news/_posts/2013-06-27-ruby-2-0-0-p247-is-released.md
@@ -45,7 +45,7 @@ See [tickets](https://bugs.ruby-lang.org/projects/ruby-200/issues?set_filter=1&a
 
 ### keyword arguments
 
-* [#8040](https://bugs.ruby-lang.org/issues/8040) change pirority between keyword arguments and mandatory arguments.
+* [#8040](https://bugs.ruby-lang.org/issues/8040) change priority between keyword arguments and mandatory arguments.
 * [#8416](https://bugs.ruby-lang.org/issues/8416) super does not forward either named or anonymous **
 * [#8463](https://bugs.ruby-lang.org/issues/8463) Proc auto-splat bug with named arguments
 

--- a/ja/news/_posts/2013-06-27-ruby-2-0-0-p247-is-released.md
+++ b/ja/news/_posts/2013-06-27-ruby-2-0-0-p247-is-released.md
@@ -42,7 +42,7 @@ Ruby 2.0.0-p247 をリリースします。
 
 ### キーワード引数
 
-* [#8040](https://bugs.ruby-lang.org/issues/8040) change pirority between keyword arguments and mandatory arguments.
+* [#8040](https://bugs.ruby-lang.org/issues/8040) change priority between keyword arguments and mandatory arguments.
 * [#8416](https://bugs.ruby-lang.org/issues/8416) super does not forward either named or anonymous **
 * [#8463](https://bugs.ruby-lang.org/issues/8463) Proc auto-splat bug with named arguments
 


### PR DESCRIPTION
I have fixed a few typos. I'm happy to use new Ruby 2.0.0-p247 :cat: 
