### PR TITLE
Add translations for news posts related to end of Ruby 1.8.7 (id)

### DIFF
--- a/id/news/_posts/2011-10-06-plans-for-1-8-7.md
+++ b/id/news/_posts/2011-10-06-plans-for-1-8-7.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "Rencana Untuk 1.8.7"
+author: "Urabe Shyouhei"
+translator: "catcyborg"
+lang: id
+---
+
+Halo, dan terima kasih untuk bergabung bersama komunitas kami.
+
+Saya mengetahui sebagian dari Anda kurang lebih menggunakan Ruby
+versi 1.8.7 hari ini. Versi tersebut dirilis tahun 2008 dan itu merupakan
+salah satu rilis Ruby terbaik dulu. -- Saya bangga untuk mengatakan bahwa
+itu tidak lagi benar. Para pengembang utama Ruby aktif bekerja pada versi
+baru Ruby, 1.9, dan mereka akan merilis versi 1.9.3. Saya telah menggunakan
+1.9 bertahun-tahun dan saya tidak dapat kembali ke hari-hari tanpa versi itu.
+Fitur-fitur kaya. Eksekusi lebih cepat. Terintegrasi dengan Rubygem. Rails
+bekerja dengan sempurna. Saya hanya dapat mengatakan versi itu sangat indah.
+Semuanya, harap gunakan Ruby 1.9.
+
+Tetapi pada saat yang sama, saya mengetahui Anda tidak dapat beralih ke 1.9
+sekarang karena berbagai alasan. Mungkin Anda telah men-deploy aplikasi Anda
+dengan 1.8.7. Mungkin Anda menggunakan library pihak ketiga yang hanya untuk
+1.8.7. Atau mungkin distribusi Linux Anda hanya mendukung 1.8.7. Maka, dengan
+ini saya mengumumkan berapa lama Anda dapat tetap menggunakannya. Anda boleh
+menggunakan 1.8.7 hari ini, tetapi setelah beberapa saat versi tersebut
+akan dinonaktifkan.
+
+Harap bersiap-siap.
+
+Jadwal:
+
+* Kami tetap menyediakan maintenance normal untuk 1.8.7 seperti biasa hingga
+  Juni 2012. Anda dapat menganggap kami menyediakan perbaikan bug dan
+  tidak ada ketidakcocokan baru.
+
+* Setelah itu, kami berhentikan perbaikan bug. Kami tetap menyediakan perbaikan
+  keamanan hingga Juni 2013, untuk jaga-jaga kalau Anda masih menggunakan 1.8.7.
+
+* Kami tidak akan mendukung 1.8.7 sama sekali setelah Juni 2013.
+

--- a/id/news/_posts/2013-06-30-we-retire-1-8-7.md
+++ b/id/news/_posts/2013-06-30-we-retire-1-8-7.md
@@ -1,0 +1,45 @@
+---
+layout: news_post
+title:  "Kami Pensiunkan Ruby 1.8.7"
+author: "shyouhei"
+translator: "catcyborg"
+date:   2013-06-30 23:59:59 UTC
+lang:   id
+---
+
+Saya harap saya dapat mengatakan sesuatu yang epik tetapi sayangnya kemampuan Bahasa
+Inggris saya sangat terbatas, jadi saya katakan apa yang harus saya katakan:
+ini adalah akhirnya, [seperti yang telah direncanakan][1].
+
+[1]: /id/news/2011/10/06/plans-for-1-8-7/
+
+## Tentang Ruby 1.8.7
+
+Sekarang, mayoritas dari Anda menggunakan Ruby 1.9.x atau 2.0.0 (**JIKA BELUM TOLONG GUNAKAN**).
+Dulu, ada versi lain seperti 1.4.x, 1.6.x, dan 1.8.x.
+Mereka adalah turunan langsung dari Ruby 1.0 yang asli, yang disebut juga MRI.
+Ketika Matz merilis 1.8.0, itu salah satu rilis Ruby terbaik. 1.8.7 merupakan
+turunan akhir dari grup itu.
+
+Secara teknis, 1 dekade telah berlalu sejak kami merilis 1.8.0, dan 5 tahun
+sejak kami merilis 1.8.7. Saat itu, Ruby digunakan untuk menulis skrip CGI.
+Kemudian, situasi berubah secara dramatis dengan bangkitnya Rails.
+Banyak sekali pengguna mulai menggunakan Ruby. Dan secara internal, kami
+akhirnya menggabungkan engine baru ko1 (yang dahulu disebut YARV).
+Engine tersebut menjadi Ruby yang Anda gunakan hari ini.
+
+Jadi, setelah 10 tahun, saya sangat senang bahwa saya dapat mengatakan 1.8.7
+menjadi sebuah peninggalan. Versi itu membuat sejarah, juga mengubah hidup kita.
+Dan untuk melanjutkan perubahan, kita melangkah maju. Ruby 2.0.0 hebat, tetapi
+untuk membuat 2.1 mendatang lebih mempesona, saya akan memberhentikan dukungan
+1.8.7 dan fokus pada Ruby trunk terbaru.
+
+Terima kasih 1.8.7, itu kehidupan yang baik untuk sebuah program.
+
+## Tentang Ruby 1.8.7 ANDA
+
+Anda mungkin masih memiliki Ruby 1.8.7 executable di sistem Anda. Tergantung bagaimana
+cara menginstalnya, Ruby 1.8.7 Anda mungkin atau mungkin tidak didukung oleh yang lain,
+karena ada beberapa pihak ketiga yang melanjutkan dukungan 1.8.7. Yang hanya dapat saya
+katakan adalah _saya_ tidak akan mendukungnya lagi. Jadi, jika Anda mengunakan rilis saya,
+berhati-hatilah dan harap mencari solusi yang cocok dengan situasi Anda.


### PR DESCRIPTION
This pull request contains translations for news posts (on 2013-06-03 and 2011-10-06) which are related to end of Ruby 1.8.7.
