### PR TITLE
"Deleted references to del.icio.us ruby tags on /en/community/weblogs/"

### DIFF
--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -10,11 +10,6 @@ describing new techniques, or speculating on Ruby’s future.
 
 ### Mining for Ruby Blogs
 
-[**Ruby on del.icio.us**][1]\: Ruby and Rails are consistently one of
-the top fifty tags on del.icio.us, a popular link sharing site. Watch
-the [ruby][1] tag for incoming obscure links and its [popularity
-chart][2] for recent upcomers in the Ruby community.
-
 **Planets**\: some planets (online specialized feeds agregators) have been running for years now. A few of them providing convenient content:
 
 * [Ruby Corner][4]


### PR DESCRIPTION
Hi - the reason I suggest removing reference to the del.icio.us blog is that if you search their site for either "ruby" or "rails" (e.g. https://delicious.com/tag/ruby) there are currently NO results being returned. 

Maybe this is short-term, but I know the site has been in flux w/r/t ownership. If nothing else, please consider "demoting" the reference to Delcious since it's not showing up any relevant content.

Also, this is my first contribution so apologies in advance if I'm doing anything wrong or stepping on any toes!

Warm regards,
Chris
