### PR TITLE
Replaced Ruby application archive with Ruby Toolbox reference.

### DIFF
--- a/en/libraries/index.md
+++ b/en/libraries/index.md
@@ -41,9 +41,11 @@ popular home for Ruby libraries, but last years saw the rise of
 often a gem source code will be hosted on GitHub while being published
 as a fully-fledged gem to RubyGems.org.
 
-The [Ruby Application Archive][6] (or RAA) is a directory of all manner
-of Ruby software, categorized by function, but it is not quite used
-anymore. You probably don’t want to go there.
+[**The Ruby Toolbox**][6] is a project that makes it easy to explore open source
+Ruby projects. It has categories for various common development tasks, collects
+a lot of information about the projects like release and commit activity, dependencies
+and rates projects based on their popularity on Rubygems and Github.
+The search makes it easy to find what you're looking for.
 
 ### A few more words about RubyGems
 
@@ -124,7 +126,7 @@ application’s dependencies and may be used along RubyGems.
 [3]: http://rubygems.org
 [4]: http://rubyforge.org/
 [5]: http://github.com
-[6]: http://raa.ruby-lang.org/
+[6]: https://www.ruby-toolbox.com
 [7]: http://docs.rubygems.org/
 [8]: http://guides.rubygems.org
 [9]: http://gembundler.com


### PR DESCRIPTION
Disclosure: Ruby Toolbox guy here ;)

RAA is down, and I think the toolbox has pretty much taken over it's purpose in the community.

Somewhat related to #98
