### PR TITLE
Update MORPHA project link on Success Stories

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -72,7 +72,7 @@ lang: bg
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/de/documentation/success-stories/index.md
+++ b/de/documentation/success-stories/index.md
@@ -62,7 +62,7 @@ Projekten, die Ruby nutzen.
 
 [1]: http://www.motorola.com
 [2]: http://www.torontorehab.on.ca/
-[3]: http://www.morpha.de/php_e/
+[3]: http://www.morpha.de/php_d/index.php3
 [4]: http://ods.org/
 [5]: http://www.lucent.com/
 [6]: http://www.level3.com/

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -85,7 +85,7 @@ you’ll find a small sample of real world usage of Ruby.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -77,7 +77,7 @@ témoignages du « monde réel. »
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
 [5]: http://www.torontorehab.on.ca/
-[6]: http://www.morpha.de/php_e/
+[6]: http://www.morpha.de/php_e/index.php3
 [7]: http://ods.org/
 [8]: http://www.lucent.com/
 [9]: http://www.level3.com/

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -105,7 +105,7 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 [13]: http://www.larc.nasa.gov/
 [14]: http://www.motorola.com
 [15]: http://www.torontorehab.on.ca/
-[16]: http://www.morpha.de/php_e/
+[16]: http://www.morpha.de/php_e/index.php3
 [17]: http://ods.org/
 [18]: http://www.lucent.com/
 [19]: http://www.level3.com/

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -71,7 +71,7 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
 [5]: http://www.torontorehab.on.ca/
-[6]: http://www.morpha.de/php_e/
+[6]: http://www.morpha.de/php_e/index.php3
 [7]: http://ods.org/
 [8]: http://www.lucent.com/
 [9]: http://www.level3.com/

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -98,7 +98,7 @@ Rubiego w rzeczywistości.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -77,7 +77,7 @@ diversos projectos.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -86,7 +86,7 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.sketchup.com/
 [3]: http://www.torontorehab.on.ca/
-[4]: http://www.morpha.de/php_e/
+[4]: http://www.morpha.de/php_e/index.php3
 [5]: http://ods.org/
 [6]: http://www.lucent.com/
 [7]: http://www.level3.com/

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -80,7 +80,7 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/zh_cn/documentation/success-stories/index.md
+++ b/zh_cn/documentation/success-stories/index.md
@@ -72,7 +72,7 @@ you’ll find a small sample of real world usage of Ruby.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -61,7 +61,7 @@ lang: zh_tw
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.on.ca/
-[5]: http://www.morpha.de/php_e/
+[5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/


### PR DESCRIPTION
Getting an Apache directory listing when visiting: http://www.morpha.de/php_e/

![screen shot of morpha 2013-09-04 at 2 35 34 am](https://f.cloud.github.com/assets/360276/1074300/73645d6a-14b7-11e3-9525-8624c140455f.png)

Updated MORPHA links to http://www.morpha.de/php_e/index.php3 for all "Success Stories" pages expect for the German translated page, which links to http://www.morpha.de/php_d/index.php3.
