### PR TITLE
Update Toronto Rehab link on Success Stories

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -71,7 +71,7 @@ lang: bg
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/de/documentation/success-stories/index.md
+++ b/de/documentation/success-stories/index.md
@@ -61,7 +61,7 @@ Projekten, die Ruby nutzen.
 
 
 [1]: http://www.motorola.com
-[2]: http://www.torontorehab.on.ca/
+[2]: http://www.torontorehab.com
 [3]: http://www.morpha.de/php_d/index.php3
 [4]: http://ods.org/
 [5]: http://www.lucent.com/

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -84,7 +84,7 @@ you’ll find a small sample of real world usage of Ruby.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -76,7 +76,7 @@ témoignages du « monde réel. »
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
-[5]: http://www.torontorehab.on.ca/
+[5]: http://www.torontorehab.com
 [6]: http://www.morpha.de/php_e/index.php3
 [7]: http://ods.org/
 [8]: http://www.lucent.com/

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -104,7 +104,7 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 [12]: http://www.bluefountain.com/casestudies/bfs-deliver-a-2nd-sequence-production-system-for-toyota/
 [13]: http://www.larc.nasa.gov/
 [14]: http://www.motorola.com
-[15]: http://www.torontorehab.on.ca/
+[15]: http://www.torontorehab.com
 [16]: http://www.morpha.de/php_e/index.php3
 [17]: http://ods.org/
 [18]: http://www.lucent.com/

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -70,7 +70,7 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
-[5]: http://www.torontorehab.on.ca/
+[5]: http://www.torontorehab.com
 [6]: http://www.morpha.de/php_e/index.php3
 [7]: http://ods.org/
 [8]: http://www.lucent.com/

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -97,7 +97,7 @@ Rubiego w rzeczywistości.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -76,7 +76,7 @@ diversos projectos.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -85,7 +85,7 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.sketchup.com/
-[3]: http://www.torontorehab.on.ca/
+[3]: http://www.torontorehab.com
 [4]: http://www.morpha.de/php_e/index.php3
 [5]: http://ods.org/
 [6]: http://www.lucent.com/

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -79,7 +79,7 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/zh_cn/documentation/success-stories/index.md
+++ b/zh_cn/documentation/success-stories/index.md
@@ -71,7 +71,7 @@ you’ll find a small sample of real world usage of Ruby.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -60,7 +60,7 @@ lang: zh_tw
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.on.ca/
+[4]: http://www.torontorehab.com
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/


### PR DESCRIPTION
Toronto Rehab is now apart of the University Health Network (UHN) and the website http://www.torontorehab.on.ca does not exist anymore, verified with Lois Ward, Research Operations Manager for Toronto Rehab.

Updated Toronto Rehab link to http://www.torontorehab.com
