### PR TITLE
Fix redirect for i18n

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ layout: nil
         "zh-TW": "zh_tw"
       };
 
-      var code = window.navigator.language || "en";
+      var code = window.navigator.language || window.navigator.userLanguage || "en";
       if (code.substr(0,2) !== "zh") { code = code.substr(0,2); }
 
       var language = languages[code];

--- a/redirect.conf_
+++ b/redirect.conf_
@@ -1,7 +1,7 @@
 rewrite ^/bugreport\.html$ http://bugs.ruby-lang.org/ permanent;
 
 rewrite ^/ja/20030611\.html$ /ja/downloads permanent;
-rewrite ^/(en|ja)/install\.html$ /ja/downloads permanent;
+rewrite ^/(en|ja)/install\.html$ /$1/downloads permanent;
 rewrite ^/ja/install\.cgi$ /ja/downloads? permanent;
 
 rewrite ^/cgi-bin/cvsweb\.cgi/?$ http://svn.ruby-lang.org/ permanent;


### PR DESCRIPTION
`window.navigator.language` is return an `undefined` when browse in Internet Explorer.

and

https://www.ruby-lang.org/en/install.html is redirect to https://www.ruby-lang.org/ja/downloads/
