### PR TITLE
Translate Fastly CDN news (id)

### DIFF
--- a/id/news/_posts/2013-09-07-we-use-fastly-cdn.md
+++ b/id/news/_posts/2013-09-07-we-use-fastly-cdn.md
@@ -1,0 +1,19 @@
+---
+layout: news_post
+title:  "Kami mulai mendistribusikan paket melalui Fastly"
+author: "hsbt"
+translator: "gozali"
+date:   2013-09-07 11:30:00 UTC
+lang:   id
+---
+
+ruby-lang.org mulai menyediakan http://cache.ruby-lang.org untuk
+mendistribusikan paket sumber Ruby resmi.
+Kami sekarang dapat secara cepat mendistribusikan paket ke seluruh dunia
+menggunakan content delivery network (CDN).
+
+CDN ini tersedia dengan menggunakan paket open source dari [Fastly][1].
+Terima kasih banyak untuk Fastly atas dukungan mereka.
+
+[1]: http://www.fastly.com
+ 


### PR DESCRIPTION
Translated Fastly CDN news to Bahasa Indonesia
