### PR TITLE
pygments no longer show on jekyll site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Please help us stay on top of things by following our
 
 ## Get It!
 
-In order to generate the site locally, you need to have
-[Pygments installed](http://jekyllrb.com/docs/extras/) on your system.
-
 Bundler will take care of the rest of the dependencies, so unless you
 already have done so, you might need to install bundler with:
 


### PR DESCRIPTION
instead, the pygment.rb gem is automatically included in the bundle install
