### PR TITLE
Updated to explicitly set liquid gem version required. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem 'rake',   '~> 10.0'
 gem 'jekyll', '>= 1.0.2'
+gem 'liquid', '>= 2.5.3'
 gem 'kramdown'
 
 # for heroku

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       redcarpet (~> 2.3.0)
       safe_yaml (~> 0.7.0)
     kramdown (1.2.0)
-    liquid (2.5.2)
+    liquid (2.5.3)
     maruku (0.6.1)
       syntax (>= 1.0.0)
     mina (0.3.0)
@@ -58,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (>= 1.0.2)
   kramdown
+  liquid (>= 2.5.3)
   mina
   rack-jekyll
   rake (~> 10.0)


### PR DESCRIPTION
This was to fix error at bundle install 'Could not find liquid-2.5.2 in any of the sources'.  Checking on RubyGems, the 2.5.2 version was yanked.
