### PR TITLE
Bind ontouchstart in menu:

### DIFF
--- a/javascripts/page.js
+++ b/javascripts/page.js
@@ -12,7 +12,7 @@ var Page = {
     },
 
     menu: function() {
-      $("#header div.site-links a.selected").click(function(event) {
+      $("#header div.site-links a.selected").on('click touchstart', function(event) {
         $(this).closest("div.site-links").toggleClass("open");
         event.preventDefault();
       });


### PR DESCRIPTION
iOS/Android has a 300ms lag for onclick events in case the user intended
to scroll. If we bind on ontouchstart in addition to onclick, the menu
will drop down instantly on iOS. Considering the size and position of
the menu icon it doesn't seem likely that a touch on the menu icon is
the start of a scroll gesture, so I don't think this will be confusing.
