### PR TITLE
Fix for typos on 'Heap overflow' news post (fr)

### DIFF
--- a/fr/news/_posts/2013-11-22-heap-overflow-in-floating-point-parsing-cve-2013-4164.md
+++ b/fr/news/_posts/2013-11-22-heap-overflow-in-floating-point-parsing-cve-2013-4164.md
@@ -20,15 +20,15 @@ construite puisse provoquer un dépassement sur le tas. Cela peut conduire à
 une attaque de type déni de service, via des segmentation faults, et
 potentiellement à l'exécution de code arbitraire. Tout programme qui
 convertit des données provenant d'une source inconnue en nombres à virgule
-flottante (ce qui particulièrement fréquent quand il accepte du JSON) est
-touché par cette vulnérabilité.
+flottante (ce qui est particulièrement fréquent quand un programme accepte
+du JSON) est touché par cette vulnérabilité.
 
 Le code vulnérable est du type :
 
     untrusted_data.to_f
 
-Mais tout code qui produit des nombres à virgule flottante à partir de données
-externes est vulnérable, comme par exemple :
+Ainsi, tout code qui produit des nombres à virgule flottante à partir de
+données externes est vulnérable. Par exemple :
 
     JSON.parse untrusted_data
 


### PR DESCRIPTION
Hi @nono and @chikamichi

Here are some fixes on 'Heap overflow' French post.
I just added a missing 'est', reworded two sentences and removed a pleonasm (
"Comme par exemple" should be either "Comme" or "Par exemple").

Hope this helps
