### PR TITLE
Improve translation of quickstart (tr)

### DIFF
--- a/tr/documentation/quickstart/2/index.md
+++ b/tr/documentation/quickstart/2/index.md
@@ -18,7 +18,7 @@ header: |
 ---
 
 Eğer parmaklarımızı çok yormadan defalarca “Hello” demek istersek ? Bir
-metod tanımlamamız gerekiyor!
+metot tanımlamamız gerekiyor!
 
 {% highlight ruby %}
 irb(main):010:0> def h
@@ -27,14 +27,14 @@ irb(main):012:1> end
 => nil
 {% endhighlight %}
 
-`def h` kodu ile metod tanımlaması başlar. Bu Ruby’ye adı `h` olan bir
-metod tanıtımı (definition) başlattığımızı bildirir. Sonraki satır
+`def h` kodu ile metot tanımlaması başlar. Bu Ruby’ye adı `h` olan bir
+metot tanıtımı (definition) başlattığımızı bildirir. Sonraki satır
 metodun gövdesini oluşturur. Daha önce gördüğümüz gibi: `puts "Hello
-World"`. Son satırdaki `end` Ruby’ye metod tanımlamasını bitirdiğimizi
-belirtir. Ruby’nin `=> nil` cevabı da metod tanımlamamızı algıladığını
+World"`. Son satırdaki `end` Ruby’ye metot tanımlamasını bitirdiğimizi
+belirtir. Ruby’nin `=> nil` cevabı da metot tanımlamamızı algıladığını
 belirtir.
 
-## Kısaca Bir Metod Defalarca Yaşar
+## Kısaca Bir Metot Defalarca Yaşar
 
 Şimdi bu metodu birkaç defa çalıştıralım:
 
@@ -47,10 +47,10 @@ Hello World!
 => nil
 {% endhighlight %}
 
-Pekala, bu kolaydı. Ruby’de metodları çağırmak için adlarını Ruby’ye
-söylemek yeterli. Eğer metod bir parametre almıyorsa tüm yapmanız
+Pekala, bu kolaydı. Ruby’de metotları çağırmak için adlarını Ruby’ye
+söylemek yeterli. Eğer metot bir parametre almıyorsa tüm yapmanız
 gereken bundan ibaret. Eğer isterseniz boş parantezlerle parametresiz
-bir metod çağırdığınızı belirtebilirsiniz, ama gereği yok.
+bir metot çağırdığınızı belirtebilirsiniz, ama gereği yok.
 
 Eğer dünyaya değil de bir kişiye merhaba demek istersek ne olacak? Hemen
 `h` metodunu bu sefer parametre alacak şekilde tekrar tanımlayalım.
@@ -71,7 +71,7 @@ Hello Matz!
 
 `#{name}` kısmı nedir? Bu bir string içine birşeyler eklemenin Ruby
 yoludur. Süslü parantez içindeki kısım stringe çevrilir ve ana string
-içine bu noktada eklenir. Bunu verilen isimin ilk harfinin büyük
+içine bu noktada eklenir. Bunu verilen ismin ilk harfinin büyük
 olduğundan emin olmak için kullanabilirsiniz:
 
 {% highlight ruby %}
@@ -88,9 +88,9 @@ Hello World!
 {% endhighlight %}
 
 Burda birkaç diğer şekil görünüyor. Biri metodu parantez kullanmadan
-çağırıyoruz. Parantezler keyfe bağlı kullanılır görsel olarak isterseniz
-kullanırsınız. Diğer şekil default parametre değeri `World`. Bunun
-anlamı eğer parametre verilmediyse `name` değeri default olarak
+çağırıyoruz. Parantezler keyfe bağlı kullanılır, görsel olarak isterseniz
+kullanırsınız. Diğer şekil varsayılan parametre değeri `World`. Bunun
+anlamı eğer parametre verilmediyse `name` değeri varsayılan olarak
 `"World"` alınacaktır.
 
 ## Bir Selamlayıcıya Dönüştürmek
@@ -115,10 +115,9 @@ irb(main):034:1> end
 {% endhighlight %}
 
 Buradaki yeni kelime `class`. Bu Greeter adı verilen bir nesne ve içinde
-birkaç metod tanımlar. Ayrıca dikkat ederseniz `@name` bu sınıfın bir
-oluşum değişkeni. Göreceğiniz gibi `say_hi` ve `say_bye` metodları
+birkaç metot tanımlar. Ayrıca dikkat ederseniz `@name` bu sınıfın bir
+örnek değişkeni. Göreceğiniz gibi `say_hi` ve `say_bye` metotları
 içinde kullanılıyor.
 
 Peki bu Greeter sınıfını nasıl çalıştıracağız? [Bir nesne
 üretin.](../3/)
-

--- a/tr/documentation/quickstart/3/index.md
+++ b/tr/documentation/quickstart/3/index.md
@@ -30,7 +30,7 @@ Bye Pat, come back soon.
 => nil
 {% endhighlight %}
 
-Birkez `g` nesnesi üretildimi, ismin Pat olduğunu hep hatırlayacaktır.
+Birkez `g` nesnesi üretildi mi, ismin Pat olduğunu hep hatırlayacaktır.
 Hımm, peki ismi direk olarak almak istersek nolcak?
 
 {% highlight ruby %}
@@ -44,12 +44,12 @@ Yok, yapamadık.
 
 ## Nesnenin Derisinin Altında
 
-Oluşum değişkenleri nesnenin içinde gizli kalırlar. Mutlak olarak gizli
-değillerdir, onlara erişmenin diğer başka yolları vardır, fakat Ruby
+Örnek değişkenleri nesnenin içinde gizli kalırlar. Mutlak olarak gizli
+değillerdir, onlara erişmenin başka yolları vardır, fakat Ruby
 verileri dışardan erişime gizleyecek çeşitli nesne yönelimli teknikler
 kullanır.
 
-Pekala Greeter nesnesinin ne metodları mevcut?
+Pekala Greeter nesnesinin ne metotları mevcut?
 
 {% highlight ruby %}
 irb(main):039:0> Greeter.instance_methods
@@ -65,19 +65,19 @@ irb(main):039:0> Greeter.instance_methods
     "instance_variables", "instance_of?"]
 {% endhighlight %}
 
-Waw, bir sürü metod varmış. Biz sadece iki metod tanımladık. Burda neler
-oluyor? Pekala bunlar Greeter nesnesinin tüm metodları, kalıtımdan
-gelenler dahil. Eğer kalıtımdan gelen atalarının metodlarını görmek
-itemezsek az evvelki çağrıyı `false` prametresiyle yapmalıyız. Bunun
-anlamı kalıtımsal metodları istemediğimizdir.
+Vay, bir sürü metot varmış. Biz sadece iki metot tanımladık. Burada neler
+oluyor? Pekala bunlar Greeter nesnesinin tüm metotları, kalıtımdan
+gelenler dahil. Eğer kalıtımdan gelen atalarının metotlarını görmek
+istemezsek az evvelki çağrıyı `false` prametresiyle yapmalıyız. Bunun
+anlamı kalıtımsal metotları istemediğimizdir.
 
 {% highlight ruby %}
 irb(main):040:0> Greeter.instance_methods(false)
 => ["say_bye", "say_hi"]
 {% endhighlight %}
 
-Ah, şimdi daha iyi. Haydi şimdide selamlayıcı nesnemizin hangi metodlara
-cevap veriyor bulalım:
+Ah, şimdi daha iyi. Haydi şimdide selamlayıcı nesnemiz hangi metotlara
+cevap veriyor, bulalım:
 
 {% highlight ruby %}
 irb(main):041:0> g.respond_to?("name")
@@ -88,12 +88,12 @@ irb(main):043:0> g.respond_to?("to_s")
 => true
 {% endhighlight %}
 
-Gördüğünüz gibi `say_hi` ve `to_s` (birşeyi stringe çevirme emridir)
+Gördüğünüz gibi `say_hi` ve `to_s` (bir şeyi stringe çevirme emridir)
 kelimelerinin anlamını biliyor, fakat `name` anlamını bilmiyor.
 
 ## Sınıfları Değiştirmek—Asla Çok Geç Değildir
 
-Fakat eğer isimi görmek ve değiştirmek isterseniz ne olacak? Ruby
+Fakat eğer ismi görmek ve değiştirmek isterseniz ne olacak? Ruby
 nesnenin değişkenlerine erişmek için kolay bir yol sunar.
 
 {% highlight ruby %}
@@ -103,7 +103,7 @@ irb(main):046:1> end
 => nil
 {% endhighlight %}
 
-Ruby’de, sınıfı tekrar açıp değiştirebilirsiniz. Yapılan değişiklikler
+Ruby’de bir sınıfı tekrar açıp değiştirebilirsiniz. Yapılan değişiklikler
 yeni üretilecek nesnelerde etkili olacağı gibi üretilmiş nesnelerde de
 etkilidir. Öyleyse yeni bir nesne üretelim ve onun `@name` özelliği ile
 biraz oynayalım.
@@ -129,8 +129,8 @@ Hi Betty!
 => nil
 {% endhighlight %}
 
-`attr_accessor` kullanarak iki yeni metod tanımlanmış olur, değeri
-okumak için `name` ve değeri değiştirmek için `name=` metodları.
+`attr_accessor` kullanarak iki yeni metot tanımlanmış olur, değeri
+okumak için `name` ve değeri değiştirmek için `name=` metotları.
 
 ## Herşeyi ve Hiçbirşeyi Selamlamak, MegaGreeter Hiçbirini Atlamaz!
 
@@ -141,7 +141,7 @@ selamlayacak bir MegaGreeter istersek nasıl olacak?
 Bu seferki kodumuzu direk IRB’de yazmak yerine bir dosyaya yazarak
 saklayalım.
 
-IRB’den çıkmak için “quit”, “exit” yazın ya da sadece Control-D basın.
+IRB’den çıkmak için “quit” veya “exit” yazın ya da sadece Control-D basın.
 
 {% highlight ruby %}
 #!/usr/bin/env ruby
@@ -188,12 +188,12 @@ if __FILE__ == $0
   mg.say_hi
   mg.say_bye
 
-  # İsimi "Zeke" olarak değiştir
+  # İsmi "Zeke" olarak değiştir
   mg.names = "Zeke"
   mg.say_hi
   mg.say_bye
 
-  # İsimi bir isimler dizisine çevir
+  # İsmi bir isimler dizisine çevir
   mg.names = ["Albert", "Brenda", "Charles",
     "Dave", "Engelbert"]
   mg.say_hi
@@ -224,6 +224,5 @@ komutuyla çalıştırın. Çıktısı şöyle olmalı:
     ...
 {: .code}
 
-Bu son örnekle birçok yeni şey ortaya çıktı, [daha bir derin
+Bu son örnekle birçok yeni şey ortaya çıktı, [daha derinden
 inceleyelim.](../4/)
-

--- a/tr/documentation/quickstart/4/index.md
+++ b/tr/documentation/quickstart/4/index.md
@@ -84,20 +84,17 @@ for (i=0; i<number_of_elements; i++)
 Bu kod çalışıyor ama şık bir görüntüsü yok. `i` gibi bir değişken
 üretmek zorundasınız, listenin uzunluğunu bulmak zorundasınız ve liste
 elemanlarının nasıl işleneceğini anlatmak zorundasınız. Ruby yolu çok
-daha yakışıklı, tüm ayrıntılar bir `each` kelimesinin içinde saklı ve
+daha zarif, tüm ayrıntılar bir `each` kelimesinin içinde saklı ve
 sadece her elemanı ne yapacağınızı anlatmak zorundasınız. Ayrıca daha
-okunaklı oluyor, Ruby yolu böyle olmalı. İçerde `each` metodu sırayla
+okunaklı oluyor, Ruby yolu böyle olmalı. İçeride `each` metodu sırayla
 `yield "Albert"` sonra `yield "Brenda"` sonra `yield "Charles"` şeklinde
 çalışmaktadır.
 
-## Bloklar, Ruby’nin en Işıldayan Özelliği
+## Bloklar, Ruby’nin En Işıldayan Özelliği
 
-Blokların birşeyleri işlemekteki gücü listelerden daha fazla
-karmaşıkdır. metodun içerisindekileri toparlamanın ötesinde The real
-power of blocks is when dealing with things that are more complicated
-than lists. Beyond handling simple housekeeping details within the
-method, you can also handle setup, teardown, and errors—all hidden away
-from the cares of the user.
+Blokların bir şeyleri işlemekteki gücü listelerden daha karmaşıktır.
+Metodun içerisindekileri toparlamanın ötesinde, ayrıca kullanıcı farkında
+olmadan ayarlarlar, parçalama ve hatalarla ilgilenebilirsiniz.
 
 {% highlight ruby %}
 # Herkese hoşçakal de
@@ -113,9 +110,9 @@ def say_bye
 end
 {% endhighlight %}
 
-`say_bye` metodu `each` kullanmaz onun yerine `@names` değişeninin
+`say_bye` metodu `each` kullanmaz onun yerine `@names` değişkeninin
 `join` metoduna cevap vermesini sınar ve kullanır. Diğer durumda liste
-değil de string olarak işlenir. Bu metod değişkenin orjinal *tipi* ile
+değil de string olarak işlenir. Bu metot, değişkenin orjinal *tipi* ile
 ilgilenmez `join` metoduna cevap veriyorsa `join` ile değişkeni işler,
 liste değil başka bir tipte değişken de `join` metoduna cevap verse onu
 da aynı şekilde işler. Buna “Duck Typing” denir, “eğer ördek gibi
@@ -140,8 +137,8 @@ içindeki blok çalışmayacaktır. Ancak ve ancak bu dosya tek başına
 
 ## Artık Kendinizi Tanışmış Kabul Edin
 
-Ruby’ye hızlı bakış bu kadar. Daha incelenebilecek Ruby’nin sunduğu
-değişik birçok kontrol yapıları var; blokların ve @yield@in kullanımı,
+Ruby’ye hızlı bakış bu kadar. Daha Ruby’nin sunduğu incelenebilecek
+birçok değişik kontrol yapıları var; blokların ve `yield`in kullanımı,
 modüller ve dahası. Umarız bu anlattıklarımız sizde Ruby hakkında daha
 fazla şeyler öğrenmek için bir arzu yaratmıştır.
 
@@ -149,7 +146,7 @@ Eğer öyleyse lütfen [Belgeler](/tr/documentation/) bölgesindeki ücretsiz
 el kitapları ve öğreticileri inceleyin.
 
 Ya da gerçekten kapsamlı bir kitap bakıyorsanız, [kitap listesinde][1]
-(off-site link) yararlı kitaplar bulabilirsiniz.
+(site-dışı link) yararlı kitaplar bulabilirsiniz.
 
 
 

--- a/tr/documentation/quickstart/index.md
+++ b/tr/documentation/quickstart/index.md
@@ -67,8 +67,8 @@ Hello World
 {% endhighlight %}
 
 `puts` Ruby’de çıktı almak için en basit bir komut. Fakat bu `=> nil` ne
-oluyor ki? Bu işlevin sonucudur. `puts` herzaman Ruby’de hiçbirşeyi
-ifade eden nil döner.
+oluyor ki? Bu işlevin sonucudur. `puts` her zaman Ruby’de hiçbir şeyi
+ifade eden nil değerini döndürür.
 
 ## Bedava Hesap Makinası Burada
 
@@ -107,20 +107,20 @@ irb(main):006:0> Math.sqrt(9)
 Tamam, bu ne demek sizce? Tahmin ederseniz dokuzun karekökü alınmış.
 Haklısınız fakat daha yakından inceleyelim, en başta bu `Math` ne ?
 
-## Modüller, Kodları başlıklar altında toplamak
+## Modüller, Kodları Başlıklar Altında Toplar
 
 `Math` matematik için bir dahili modüldür. Modüller Ruby’de iki hizmet
-sunarlar. Bir rolü şu: benzer görevler yapan metodları bir grup başlığı
+sunarlar. Bir rolü şu: benzer görevler yapan metotları bir grup başlığı
 altında toplamak. `Math` içinde ayrıca `sin()` ve `tan()` gibi işlevler
 de vardır.
 
 Sonraki bir nokta işareti, nokta ne yapıyor? Nokta size mesajın
-alıcısını gösteriyor. Burada mesaj `sqrt(9)` metod çağrısı, parametresi
+alıcısını gösteriyor. Burada mesaj `sqrt(9)` metot çağrısı, parametresi
 9 olan “karekök” alma komutu.
 
 Bu metodun cevabı `3.0` dır. Dikkat ettiyseniz sadece `3` değil. Çünkü
 birçok karekök işleminin sonucu tamsayı değildir. Bu yüzden işlev kayan
-noktalı bir sayı geri döner.
+noktalı bir sayı geri döndürür.
 
 Peki bazı matematik işlemlerimizin sonucunu hatırlamak istersek? Cevabı
 bir değişkene atama yaparız.
@@ -133,6 +133,6 @@ irb(main):008:0> b = 4 ** 2
 irb(main):009:0> Math.sqrt(a+b) => 5.0
 {% endhighlight %}
 
-Bir hsap makinası için oldukça yeterli. Klasik `Hello World` mesajından
+Bir hesap makinası için oldukça yeterli. Klasik `Hello World` mesajından
 uzaklaşmaya başladık, [geri dönelim.](2/)
 


### PR DESCRIPTION
Improved translation by correcting some spelling mistakes and typos.
