### PR TITLE
Update about/index.md: comma to colon

### DIFF
--- a/en/about/index.md
+++ b/en/about/index.md
@@ -96,7 +96,7 @@ y = 5.plus 6
 Ruby’s operators are syntactic sugar for methods. You can redefine them
 as well.
 
-### Blocks, a Truly Expressive Feature
+### Blocks: a Truly Expressive Feature
 
 Ruby’s block are also seen as a source of great flexibility. A
 programmer can attach a closure to any method, describing how that


### PR DESCRIPTION
I believe that the correct punctuation for using a definition is a colon, not a comma.  The description is in apposition (both functioning as nominative subjects) to the term and seems to suggest an appositive use.
