### PR TITLE
added auto-deployment configuration with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+deploy:
+  provider: heroku
+  api_key:
+    secure: gomai7JUOZCojr+yddMe8jQMQISUIg21VXVqEEqAJyOIsz+3kH6lR2lb1iYFKC88skeakKspJjYgQ+tSP/md0P+2JJzqbBCn1C/xuAuIrGGRVboOCAC9qsBg0kdNxGoKnJBtnJzAjdoADHu/kJvV1G0mIwzReCAehi+s9dogwj8=
+  app: staging-ruby-lang
+  on:
+    repo: ruby/www.ruby-lang.org


### PR DESCRIPTION
I prepared staging-ruby-lang.herokuapp.com. It is deployed by travis when pushed to master branch.
I'll move staging environment to this site on heroku and delete staging site of neon.ruby-lang.org after a few weeks.
