### PR TITLE
Change "Available languages" text (en)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1853,7 +1853,7 @@ locales:
 
   languages_heading:
     de: "Diese Website in anderen Sprachen:"
-    en: "Content available in:"
+    en: "This site in other languages:"
 
   credits:
     bg: |


### PR DESCRIPTION
@chikamichi @postmodern

What do you think about _"This site in other languages:"_ as the introductory text for the available translations section in the footer? Seems more accurate to me, since the links go to the site root, not to the translated content of the current page.
