### PR TITLE
Ruby logo download link should be available on ruby-lang.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1933,3 +1933,7 @@ locales:
       本網站使用 Ruby 套件 <a href="http://www.jekyllrb.com/">Jekyll</a> 產生，並由引以為傲的 Ruby 社群成員共同維護。
       請至 <a href="https://github.com/ruby/www.ruby-lang.org/">GitHub</a> 幫忙貢獻。關於本站的問題與意見，
       請聯絡<a href="mailto:webmaster@ruby-lang.org">網站管理員</a>。
+
+  logo_credit:
+    en: |
+      <a href="/en/about/logo/">The Ruby Logo</a> is Copyright &copy; 2006, Yukihiro Matsumoto; licensed under the terms of the <a href="http://creativecommons.org/licenses/by-sa/2.5/">CC BY-SA 2.5</a>.

--- a/_includes/credits.html
+++ b/_includes/credits.html
@@ -1,3 +1,8 @@
+{% if site.locales.logo_credit[page.lang] %}
+  <p>{{ site.locales.logo_credit[page.lang] }}</p>
+{% else %}
+  <p>{{ site.locales.logo_credit['en'] }}</p>
+{% endif %}
 {% if site.locales.credits[page.lang] %}
   <p>{{ site.locales.credits[page.lang] }}</p>
 {% else %}

--- a/en/about/logo.md
+++ b/en/about/logo.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: "Ruby Logo"
+lang: en
+---
+
+![The Ruby Logo](/images/header-ruby-logo@2x.png)
+
+The Ruby Logo is Copyright &copy; 2006, Yukihiro Matsumoto.
+
+It is licensed under the terms of the [Creative Commons Attribution-ShareAlike 2.5 License][1] agreement.
+
+## Download
+
+Ruby Logo Kit is available here: <http://cache.ruby-lang.org/pub/misc/logo/ruby-logo-kit.zip>
+
+It contains the Ruby Logo in several formats (PNG, PDF, SVG, AI, etc.)
+
+[1]: http://creativecommons.org/licenses/by-sa/2.5/


### PR DESCRIPTION
As I remembered, ruby-lang's logo image files (PDF, PNG, SVG, AI, etc) are available on rubyidentity.org, but it seems unavailable for now.

So, I think it should be available on ruby-lang.org... Doesn't it?

(I have zip file that was available on rubyidentity.org and I can provide it.

(Update: I was not on the ruby-vit team http://twitter.com/_zzak/status/410058249384124418 )
