### PR TITLE
Remove rewrite rule for '/admin'

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -9,7 +9,6 @@ use Rack::Rewrite do
   r302 %r{^/ja/install\.cgi$}, "/ja/downloads"
 
   r302 %r{^/cgi-bin/cvsweb\.cgi/?$}, "http://svn.ruby-lang.org/"
-  r302 %r{^/admin$}, "https://github.com/ruby/www.ruby-lang.org"
 
   r302 %r{^/ja/man/archive/ruby-refm-1.8.6-chm.zip$}, "ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-refm-1.8.6-chm.zip"
   r302 %r{^/ja/man/archive/ruby-refm-1.9.0-chm.zip$}, "ftp://ftp.ruby-lang.org/pub/ruby/doc/ruby-refm-1.9.0-chm.zip"


### PR DESCRIPTION
@hsbt Since recently there is content on `/admin`, so this rule should be removed.

Had there been a specific reason for redirecting from /admin to this GitHub repo?
In other words: do you want to keep the redirection and instead move the /admin section to a different location?
