### PR TITLE
Ignored bundler and rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-language: ruby
-rvm: 2.0.0
-cache: bundler
+install: true
+script: true
 deploy:
   provider: heroku
   buildpack: https://github.com/ruby/heroku-buildpack-ruby-jekyll.git


### PR DESCRIPTION
www.ruby-lang.org doesn't use bundler and rake task. I ignored it.
