### PR TITLE
Fix 2.1.0 release entries (s/Decimal/Rational/g)

### DIFF
--- a/en/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
+++ b/en/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
@@ -37,7 +37,7 @@ The notable changes are:
 * RGenGC (See ko1's [RubyKaigi presentation](http://rubykaigi.org/2013/talk/S73) and [RubyConf 2013 presentation](http://www.atdot.net/~ko1/activities/rubyconf2013-ko1_pub.pdf))
 * refinements [#8481](https://bugs.ruby-lang.org/issues/8481) [#8571](https://bugs.ruby-lang.org/issues/8571)
 * syntax changes
-  * Decimal/Complex Literal [#8430](https://bugs.ruby-lang.org/issues/8430)
+  * Rational/Complex Literal [#8430](https://bugs.ruby-lang.org/issues/8430)
   * def's return value [#3753](https://bugs.ruby-lang.org/issues/3753)
 * Bignum
   * use GMP [#8796](https://bugs.ruby-lang.org/issues/8796)

--- a/ja/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
+++ b/ja/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
@@ -36,7 +36,7 @@ Ruby 2.1 では深刻な非互換もなく、速度の向上を含めた多く�
 * RGenGC (ささださんの[RubyKaigiのプレゼン資料](http://rubykaigi.org/2013/talk/S73) と [RubyConf 2013のプレゼン資料](http://www.atdot.net/~ko1/activities/rubyconf2013-ko1_pub.pdf)をご覧ください)
 * refinements [#8481](https://bugs.ruby-lang.org/issues/8481) [#8571](https://bugs.ruby-lang.org/issues/8571)
 * 文法の変更
-  * Decimal/Complex リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
+  * Rational/Complex リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
   * defの戻り値 [#3753](https://bugs.ruby-lang.org/issues/3753)
 * Bignum
   * GMP の利用 [#8796](https://bugs.ruby-lang.org/issues/8796)


### PR DESCRIPTION
One of new literals in 2.1.0 is not "Decimal" but "Rational".

https://github.com/ruby/ruby/blob/v2_1_0/NEWS#L19
