### PR TITLE
Add a description about ruby toolbox to libraries [ja]

### DIFF
--- a/ja/libraries/index.md
+++ b/ja/libraries/index.md
@@ -100,7 +100,6 @@ RubyGems.org に [いくつかのガイド][rubygems-guides] があります。
 [rubygems-guides]: http://guides.rubygems.org/
 [rubyforge]: http://rubyforge.org/
 [github]: https://github.com/
-[raa]: http://raa.ruby-lang.org/
 [rubygems-command-ref]: http://guides.rubygems.org/command-reference/
 [bundler]: http://bundler.io/
 [ruby-toolbox]: https://www.ruby-toolbox.com/


### PR DESCRIPTION
In this pull req, I add a description about The Ruby Toolbox to [/ja/libraries](https://www.ruby-lang.org/ja/libraries).
It is translated from [the English version](https://www.ruby-lang.org/en/libraries).

Additionally, I replace numeric references for links with named ones to make it easy to modify the entry in future.
(eg. `[1]: https://rubygems.org/` to `[rubygems]: https://rubygems.org`)
