### PR TITLE
Replace Decimal litaral with Rational literal in past entries [ja]

### DIFF
--- a/ja/news/_posts/2013-09-23-ruby-2-1-0-preview1-is-released.md
+++ b/ja/news/_posts/2013-09-23-ruby-2-1-0-preview1-is-released.md
@@ -42,8 +42,8 @@ Fastly による
 * RGenGC (ささださんの [RubyKaigi での発表](http://rubykaigi.org/2013/talk/S73) や [EuRuKo での発表](http://www.atdot.net/~ko1/activities/Euruko2013-ko1.pdf) を参照してください)
 * refinements
 * syntax
-* 小数リテラル
-* freeze された文字列リテラル
+  * 有理数リテラル
+  * freeze された文字列リテラル
 * def の返り値
 * Bignum
 * 128ビット

--- a/ja/news/_posts/2013-11-22-ruby-2-1-0-preview2-is-released.md
+++ b/ja/news/_posts/2013-11-22-ruby-2-1-0-preview2-is-released.md
@@ -47,7 +47,7 @@ Ruby 2.1.0-preview2 をリリースしました。
 * RGenGC (ささださんの [RubyKaigi での発表](http://rubykaigi.org/2013/talk/S73) や [RubyConf 2013 での発表](http://www.atdot.net/~ko1/activities/rubyconf2013-ko1_pub.pdf) を参照してください)
 * refinements [#8481](https://bugs.ruby-lang.org/issues/8481) [#8571](https://bugs.ruby-lang.org/issues/8571)
 * 文法の変更
-  * 小数リテラルと複素数リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
+  * 有理数リテラルと複素数リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
   * def の返り値 [#3753](https://bugs.ruby-lang.org/issues/3753)
 * Bignum
   * 128ビット整数の使用 [#8509](https://bugs.ruby-lang.org/issues/8509)

--- a/ja/news/_posts/2013-12-20-ruby-2-1-0-rc1-is-released.md
+++ b/ja/news/_posts/2013-12-20-ruby-2-1-0-rc1-is-released.md
@@ -39,7 +39,7 @@ Ruby 2.0.0 からの注目すべき変更点は以下の通りです:
 * RGenGC (ささださんの [RubyKaigi での発表](http://rubykaigi.org/2013/talk/S73) や [RubyConf 2013 での発表](http://www.atdot.net/~ko1/activities/rubyconf2013-ko1_pub.pdf) を参照してください)
 * refinements [#8481](https://bugs.ruby-lang.org/issues/8481) [#8571](https://bugs.ruby-lang.org/issues/8571)
 * 文法の変更
-  * 小数リテラルと複素数リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
+  * 有理数リテラルと複素数リテラル [#8430](https://bugs.ruby-lang.org/issues/8430)
   * def の返り値 [#3753](https://bugs.ruby-lang.org/issues/3753)
 * Bignum
   * GMP の使用 [#8796](https://bugs.ruby-lang.org/issues/8796)


### PR DESCRIPTION
In some past entries about Ruby 2.1.0, one of new literals was described as `Decimal` (小数).
However it may mean `Rational` (有理数). (ref [https://bugs.ruby-lang.org/issues/8430](https://bugs.ruby-lang.org/issues/8430))

Note:
In some entries in English (and all other languages), there are descriptions about `Decimal` literal, but it may be also `Rational`.
So we should fix  other language versions about it.
