### PR TITLE
Corrected capitalization for <ru/index.html>.

### DIFF
--- a/ru/index.html
+++ b/ru/index.html
@@ -19,7 +19,7 @@ intro: |
 
       <a href="downloads/" class="download-link">Скачать Ruby</a>
       или
-      <a href="about/">Узнать больше...</a>
+      <a href="about/">yзнать больше...</a>
     </div>
     <div id="code"></div>
 


### PR DESCRIPTION
Capitalized letters without reason aren't good for style.
