### PR TITLE
Fix mirror site list of downloads in es. it, ko, pl, zh_cn and zh_tw

### DIFF
--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -58,42 +58,54 @@ del mundo. Intenta usar el mirror site más cerca de ti.
 
 #### Mirror sites via HTTP
 
-* [CDN][64] (fastly.com)
-* [Japón 1][63] (Master) - HTTPS
-* [Japón 2][50] and [mirror][32] (RingServer)
-* [Gran Bretaña][49] (The Mirror Service)
-* [Alemania][51] (AmbiWeb GmbH)
-* [Bélgica][52] (Easynet)
-* [Dinamarca][53] (sunsite.dk)
-* [Holanda][54] (XS4ALL) - only release packages
-* [EEUU 1][55] (ibiblio.org)
-* [EEUU 2][56] (lcs.mit.edu)
-* [EEUU 3][57] (binarycode.org)
-* [EEUU 4][58] (online-mirror.org)
-* [EEUU 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
-* [China 1][65] (ruby.taobao.org)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japón 1][mirror-http-jp1] (Master) - HTTPS
+* Japón 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Gran Bretaña][mirror-http-uk] (The Mirror Service)
+* [Alemania][mirror-http-de] (AmbiWeb GmbH)
+* [Bélgica][mirror-http-be] (Easynet)
+* [Dinamarca][mirror-http-dk] (sunsite.dk)
+* [Holanda][mirror-http-nl] (XS4ALL) - only release packages
+* [EEUU 1][mirror-http-us1] (ibiblio.org)
+* [EEUU 2][mirror-http-us2] (lcs.mit.edu)
+* [EEUU 3][mirror-http-us3] (binarycode.org)
+* [EEUU 4][mirror-http-us4] (online-mirror.org)
+* [EEUU 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China 1][mirror-http-cn] (ruby.taobao.org)
 
 #### Mirror sites via FTP
 
-* [Japón 1][35] (Master: ruby-lang.org)
-* [Japón 2][31] and [mirror][32] (RingServer)
-* [Japón 3][33] (IIJ)
-* [Corea del Sur][36] (Korea FreeBSD Users Group)
-* [Alemania][37] (FU Berlin)
-* [Gran Bretaña][38] (The Mirror Service)
-* [Bélgica][39] (Easynet)
-* [Rusia][40] (ChgNet)
-* [Grecia][41] (ntua.gr)
-* [Dinamarca][42] (sunsite.dk)
-* [EEUU 1][43] (ibiblio.org)
-* [EEUU 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canadá][48] (mirror.cs.mun.ca)
+* [Japón 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japón 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japón 3][mirror-ftp-jp3] (IIJ)
+* [Corea del Sur][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Alemania][mirror-ftp-de] (FU Berlin)
+* [Gran Bretaña][mirror-ftp-uk] (The Mirror Service)
+* [Bélgica][mirror-ftp-be] (Easynet)
+* [Rusia][mirror-ftp-ru] (ChgNet)
+* [Grecia][mirror-ftp-gr] (ntua.gr)
+* [Dinamarca][mirror-ftp-dk] (sunsite.dk)
+* [EEUU 1][mirror-ftp-us1] (ibiblio.org)
+* [EEUU 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canadá][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### Mirror sites via rsync
 
@@ -300,37 +312,46 @@ una "completa especificación ejecutable para el lenguaje de programación Ruby"
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
-[65]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -65,41 +65,53 @@ giro per il mondo. Cerca di utilizzare il sito mirror più vicino a te.
 #### Siti mirror via HTTP
 
 * [CDN][64] (fastly.com)
-* [Giappone 1][63] (Master) - HTTPS
-* [Giappone 2][50] e [mirror][32] (RingServer)
-* [Gran Bretagna][49] (The Mirror Service)
-* [Germania][51] (AmbiWeb GmbH)
-* [Belgio][52] (Easynet)
-* [Danimarca][53] (sunsite.dk)
-* [Olanda][54] (XS4ALL) - solo release
-* [USA 1][55] (ibiblio.org)
-* [USA 2][56] (lcs.mit.edu)
-* [USA 3][57] (binarycode.org)
-* [USA 4][58] (online-mirror.org)
-* [USA 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
-* [China 1][65] (ruby.taobao.org)
+* [Giappone 1][mirror-https-jp] (Master) - HTTPS
+* Giappone 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Gran Bretagna][mirror-http-uk] (The Mirror Service)
+* [Germania][mirror-http-de] (AmbiWeb GmbH)
+* [Belgio][mirror-http-be] (Easynet)
+* [Danimarca][mirror-http-dk] (sunsite.dk)
+* [Olanda][mirror-http-nl] (XS4ALL) - solo release
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China 1][mirror-http-cn] (ruby.taobao.org)
 
 #### Siti mirror via FTP
 
-* [Giappone 1][35] (Master: ruby-lang.org)
-* [Giappone 2][31] e [mirror][32] (RingServer)
-* [Giappone 3][33] (IIJ)
-* [Corea del Sud][36] (Korea FreeBSD Users Group)
-* [Germania][37] (FU Berlin)
-* [Gran Bretagna][38] (The Mirror Service)
-* [Belgio][39] (Easynet)
-* [Russia][40] (ChgNet)
-* [Grecia][41] (ntua.gr)
-* [Danimarca][42] (sunsite.dk)
-* [USA 1][43] (ibiblio.org)
-* [USA 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canada][48] (mirror.cs.mun.ca)
+* [Giappone 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Giappone 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Giappone 3][mirror-ftp-jp3] (IIJ)
+* [Corea del Sud][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Germania][mirror-ftp-dk] (FU Berlin)
+* [Gran Bretagna][mirror-ftp-uk] (The Mirror Service)
+* [Belgio][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Grecia][mirror-ftp-gr] (ntua.gr)
+* [Danimarca][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### Siti mirror via rsync
 
@@ -303,37 +315,46 @@ di programmazione Ruby”.
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
-[65]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -49,42 +49,54 @@ lang: ko
 
 #### HTTP 경유 미러 사이트
 
-* [CDN][64] (fastly.com)
-* [Japan 1][63] (Master) - HTTPS
-* [Japan 2][50] and [mirror][32] (RingServer)
-* [Britain][49] (The Mirror Service)
-* [Germany][51] (AmbiWeb GmbH)
-* [Belgium][52] (Easynet)
-* [Denmark][53] (sunsite.dk)
-* [Holland][54] (XS4ALL) - only release packages
-* [USA 1][55] (ibiblio.org)
-* [USA 2][56] (lcs.mit.edu)
-* [USA 3][57] (binarycode.org)
-* [USA 4][58] (online-mirror.org)
-* [USA 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
-* [China 1][65] (ruby.taobao.org)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japan 1][mirror-https-jp] (Master) - HTTPS
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Britain][mirror-http-uk] (The Mirror Service)
+* [Germany][mirror-http-de] (AmbiWeb GmbH)
+* [Belgium][mirror-http-be] (Easynet)
+* [Denmark][mirror-http-dk] (sunsite.dk)
+* [Holland][mirror-http-nl] (XS4ALL) - only release packages
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China][mirror-http-cn] (ruby.taobao.org)
 
 #### FTP 경유 미러 사이트
 
-* [Japan 1][35] (Master: ruby-lang.org)
-* [Japan 2][31] and [mirror][32] (RingServer)
-* [Japan 3][33] (IIJ)
-* [South Korea][36] (Korea FreeBSD Users Group)
-* [Germany][37] (FU Berlin)
-* [Britain][38] (The Mirror Service)
-* [Belgium][39] (Easynet)
-* [Russia][40] (ChgNet)
-* [Greece][41] (ntua.gr)
-* [Denmark][42] (sunsite.dk)
-* [USA 1][43] (ibiblio.org)
-* [USA 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canada][48] (mirror.cs.mun.ca)
+* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japan 3][mirror-ftp-jp3] (IIJ)
+* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Britain][mirror-ftp-uk] (The Mirror Service)
+* [Germany][mirror-ftp-de] (FU Berlin)
+* [Belgium][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Greece][mirror-ftp-gr] (ntua.gr)
+* [Denmark][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### rsync 경유 미러 사이트
 
@@ -250,37 +262,46 @@ MRI를 포함, 일부 구현체들은 “complete executable specification for t
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
-[65]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -61,41 +61,54 @@ użyć jakiegoś blisko ciebie.
 
 #### Strony lustrzane poprzez HTTP
 
-* [CDN][64] (fastly.com)
-* [Japan 1][63] (Master) - HTTPS
-* [Japan 2][50] and [mirror][32] (RingServer)
-* [Britain][49] (The Mirror Service)
-* [Germany][51] (AmbiWeb GmbH)
-* [Belgium][52] (Easynet)
-* [Denmark][53] (sunsite.dk)
-* [Holland][54] (XS4ALL) - only release packages
-* [USA 1][55] (ibiblio.org)
-* [USA 2][56] (lcs.mit.edu)
-* [USA 3][57] (binarycode.org)
-* [USA 4][58] (online-mirror.org)
-* [USA 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japan 1][mirror-https-jp] (Master) - HTTPS
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Britain][mirror-http-uk] (The Mirror Service)
+* [Germany][mirror-http-de] (AmbiWeb GmbH)
+* [Belgium][mirror-http-be] (Easynet)
+* [Denmark][mirror-http-dk] (sunsite.dk)
+* [Holland][mirror-http-nl] (XS4ALL) - only release packages
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China][mirror-http-cn] (ruby.taobao.org)
 
 #### Strony lustrzane poprzez FTP
 
-* [Japan 1][35] (Master: ruby-lang.org)
-* [Japan 2][31] and [mirror][32] (RingServer)
-* [Japan 3][33] (IIJ)
-* [South Korea][36] (Korea FreeBSD Users Group)
-* [Germany][37] (FU Berlin)
-* [Britain][38] (The Mirror Service)
-* [Belgium][39] (Easynet)
-* [Russia][40] (ChgNet)
-* [Greece][41] (ntua.gr)
-* [Denmark][42] (sunsite.dk)
-* [USA 1][43] (ibiblio.org)
-* [USA 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canada][48] (mirror.cs.mun.ca)
+* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japan 3][mirror-ftp-jp3] (IIJ)
+* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Britain][mirror-ftp-uk] (The Mirror Service)
+* [Germany][mirror-ftp-de] (FU Berlin)
+* [Belgium][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Greece][mirror-ftp-gr] (ntua.gr)
+* [Denmark][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### Strony lustrzane poprzez rsync
 
@@ -290,36 +303,46 @@ Niektóre z tych implementacji, włączając w to MRI, podążają za wytycznymi
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -59,41 +59,53 @@ lang: ru
 
 #### Зеркальные сайты по HTTP протоколу
 
-* [CDN][64] (fastly.com)
-* [Япония 1][63] (главный) - HTTPS
-* [Япония 2][50] и [зеркало][32] (RingServer)
-* [Англия][49] (The Mirror Service)
-* [Германия][51] (AmbiWeb GmbH)
-* [Бельгия][52] (Easynet)
-* [Дания][53] (sunsite.dk)
-* [Нидерланды][54] (XS4ALL) - только пакеты релизов
-* [США 1][55] (ibiblio.org)
-* [США 2][56] (lcs.mit.edu)
-* [США 3][57] (binarycode.org)
-* [США 4][58] (online-mirror.org)
-* [США 5][59] (trexle.com)
-* [Австралия][60] (tuwien.ac.at)
-* [Тайвань 1][61] (cdpa.nsysu.edu.tw)
-* [Тайвань 2][62] (ftp.cs.pu.edu.tw)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Япония 1][mirror-https-jp] (главный) - HTTPS
+* Япония 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Англия][mirror-http-uk] (The Mirror Service)
+* [Германия][mirror-http-de] (AmbiWeb GmbH)
+* [Бельгия][mirror-http-be] (Easynet)
+* [Дания][mirror-http-dk] (sunsite.dk)
+* [Нидерланды][mirror-http-nl] (XS4ALL) - только пакеты релизов
+* [США 1][mirror-http-us1] (ibiblio.org)
+* [США 2][mirror-http-us2] (lcs.mit.edu)
+* [США 3][mirror-http-us3] (binarycode.org)
+* [США 4][mirror-http-us4] (online-mirror.org)
+* [США 5][mirror-http-us5] (trexle.com)
+* [Австралия][mirror-http-at] (tuwien.ac.at)
+* [Тайвань 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Тайвань 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
 
 #### Зеркальные сайты по FTP протоколу
 
-* [Япония 1][35] (главный: ruby-lang.org)
-* [Япония 2][31] and [mirror][32] (RingServer)
-* [Япония 3][33] (IIJ)
-* [Южная корея][36] (Korea FreeBSD Users Group)
-* [Германия][37] (FU Berlin)
-* [Англия][38] (The Mirror Service)
-* [Бельгия][39] (Easynet)
-* [Россия][40] (ChgNet)
-* [Греция][41] (ntua.gr)
-* [Дания][42] (sunsite.dk)
-* [США 1][43] (ibiblio.org)
-* [США 2][44] (lcs.mit.edu)
-* [Австралия][45] (tuwien.ac.at)
-* [Тайвань 1][46] (cdpa.nsysu.edu.tw)
-* [Тайвань 2][47] (ftp.cs.pu.edu.tw)
-* [Канада][48] (mirror.cs.mun.ca)
+* [Япония 1][mirror-ftp-jp1] (главный: ruby-lang.org)
+* Япония 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Япония 3][mirror-ftp-jp3] (IIJ)
+* [Южная корея][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Германия][mirror-ftp-de] (FU Berlin)
+* [Англия][mirror-ftp-uk] (The Mirror Service)
+* [Бельгия][mirror-ftp-be] (Easynet)
+* [Россия][mirror-ftp-ru] (ChgNet)
+* [Греция][mirror-ftp-gr] (ntua.gr)
+* [Дания][mirror-ftp-dk] (sunsite.dk)
+* [США 1][mirror-ftp-us1] (ibiblio.org)
+* [США 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Австралия][mirror-ftp-at] (tuwien.ac.at)
+* [Тайвань 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Тайвань 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Канада][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### Зеркальные сайты по rsync
 
@@ -301,36 +313,46 @@ Ruby как язык имеет несколько разных имплемен
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -25,42 +25,54 @@ lang: zh_cn
 
 #### HTTP 镜像站
 
-* [CDN][64] (fastly.com)
-* [Japan 1][63] (Master) - HTTPS
-* [Japan 2][50] and [mirror][32] (RingServer)
-* [Britain][49] (The Mirror Service)
-* [Germany][51] (AmbiWeb GmbH)
-* [Belgium][52] (Easynet)
-* [Denmark][53] (sunsite.dk)
-* [Holland][54] (XS4ALL) - only release packages
-* [USA 1][55] (ibiblio.org)
-* [USA 2][56] (lcs.mit.edu)
-* [USA 3][57] (binarycode.org)
-* [USA 4][58] (online-mirror.org)
-* [USA 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
-* [China 1][65] (ruby.taobao.org)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japan 1][mirror-https-jp] (Master) - HTTPS
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Britain][mirror-http-uk] (The Mirror Service)
+* [Germany][mirror-http-de] (AmbiWeb GmbH)
+* [Belgium][mirror-http-be] (Easynet)
+* [Denmark][mirror-http-dk] (sunsite.dk)
+* [Holland][mirror-http-nl] (XS4ALL) - only release packages
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China][mirror-http-cn] (ruby.taobao.org)
 
 #### FTP 镜像站
 
-* [Japan 1][35] (Master: ruby-lang.org)
-* [Japan 2][31] and [mirror][32] (RingServer)
-* [Japan 3][33] (IIJ)
-* [South Korea][36] (Korea FreeBSD Users Group)
-* [Germany][37] (FU Berlin)
-* [Britain][38] (The Mirror Service)
-* [Belgium][39] (Easynet)
-* [Russia][40] (ChgNet)
-* [Greece][41] (ntua.gr)
-* [Denmark][42] (sunsite.dk)
-* [USA 1][43] (ibiblio.org)
-* [USA 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canada][48] (mirror.cs.mun.ca)
+* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japan 3][mirror-ftp-jp3] (IIJ)
+* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Britain][mirror-ftp-uk] (The Mirror Service)
+* [Germany][mirror-ftp-de] (FU Berlin)
+* [Belgium][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Greece][mirror-ftp-gr] (ntua.gr)
+* [Denmark][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### rsync 镜像
 
@@ -153,37 +165,46 @@ LightTPD, and MySQL on Tiger*][15] 将快速的教您启动和运行。
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
-[65]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -43,42 +43,54 @@ Ruby 原始碼可從世界各地的鏡像站獲得。請嘗試離您最近的鏡
 
 #### 透過 HTTP 的鏡像站
 
-* [CDN][64] (fastly.com)
-* [Japan 1][63] (Master) - HTTPS
-* [Japan 2][50] and [mirror][32] (RingServer)
-* [Britain][49] (The Mirror Service)
-* [Germany][51] (AmbiWeb GmbH)
-* [Belgium][52] (Easynet)
-* [Denmark][53] (sunsite.dk)
-* [Holland][54] (XS4ALL) - only release packages
-* [USA 1][55] (ibiblio.org)
-* [USA 2][56] (lcs.mit.edu)
-* [USA 3][57] (binarycode.org)
-* [USA 4][58] (online-mirror.org)
-* [USA 5][59] (trexle.com)
-* [Austria][60] (tuwien.ac.at)
-* [Taiwan 1][61] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][62] (ftp.cs.pu.edu.tw)
-* [China 1][65] (ruby.taobao.org)
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japan 1][mirror-https-jp] (Master) - HTTPS
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Britain][mirror-http-uk] (The Mirror Service)
+* [Germany][mirror-http-de] (AmbiWeb GmbH)
+* [Belgium][mirror-http-be] (Easynet)
+* [Denmark][mirror-http-dk] (sunsite.dk)
+* [Holland][mirror-http-nl] (XS4ALL) - only release packages
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China][mirror-http-cn] (ruby.taobao.org)
 
 #### 透過 FTP 的鏡像站
 
-* [Japan 1][35] (Master: ruby-lang.org)
-* [Japan 2][31] and [mirror][32] (RingServer)
-* [Japan 3][33] (IIJ)
-* [South Korea][36] (Korea FreeBSD Users Group)
-* [Germany][37] (FU Berlin)
-* [Britain][38] (The Mirror Service)
-* [Belgium][39] (Easynet)
-* [Russia][40] (ChgNet)
-* [Greece][41] (ntua.gr)
-* [Denmark][42] (sunsite.dk)
-* [USA 1][43] (ibiblio.org)
-* [USA 2][44] (lcs.mit.edu)
-* [Austria][45] (tuwien.ac.at)
-* [Taiwan 1][46] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][47] (ftp.cs.pu.edu.tw)
-* [Canada][48] (mirror.cs.mun.ca)
+* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japan 3][mirror-ftp-jp3] (IIJ)
+* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Britain][mirror-ftp-uk] (The Mirror Service)
+* [Germany][mirror-ftp-de] (FU Berlin)
+* [Belgium][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Greece][mirror-ftp-gr] (ntua.gr)
+* [Denmark][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
 
 #### 透過 rsync 的鏡像站
 
@@ -214,40 +226,49 @@ MRI 與某些實作遵循 [RubySpec][28]，Ruby 程式語言的完整規格文�
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[31]: ftp://core.ring.gr.jp/pub/lang/ruby/
-[32]: http://www.t.ring.gr.jp/
-[33]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[35]: ftp://ftp.ruby-lang.org/pub/ruby/
-[36]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[37]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[38]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[39]: ftp://ftp.easynet.be/ruby/ruby/
-[40]: ftp://ftp.chg.ru/pub/lang/ruby/
-[41]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[42]: ftp://sunsite.dk/mirrors/ruby/
-[43]: ftp://www.ibiblio.org/pub/languages/ruby/
-[44]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[45]: ftp://gd.tuwien.ac.at/languages/ruby/
-[46]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[47]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[48]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
-[49]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[50]: http://www.dnsbalance.ring.gr.jp/archives/lang/ruby/
-[51]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[52]: http://ruby.mirror.easynet.be/
-[53]: http://mirrors.sunsite.dk/ruby/
-[54]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[55]: http://www.ibiblio.org/pub/languages/ruby/
-[56]: http://xyz.lcs.mit.edu/ruby/
-[57]: http://www.binarycode.org/ruby/
-[58]: http://www.online-mirror.org/ruby/
-[59]: http://ruby.trexle.com/
-[60]: http://gd.tuwien.ac.at/languages/ruby/
-[61]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[62]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[63]: https://ftp.ruby-lang.org/pub/ruby/
-[64]: http://cache.ruby-lang.org/pub/ruby/
-[65]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
 
 [rbenv]: https://github.com/sstephenson/rbenv
 [ruby-install]: https://github.com/postmodern/ruby-install


### PR DESCRIPTION
I fix mirror site list in versions of es. it, ko, pl, zh_cn and zh_tw as #544.
