### PR TITLE
Set canonical URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/mobile.css">
     <link rel="stylesheet" type="text/css" href="/stylesheets/print.css">
     <link href='https://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic&amp;subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
+    <link rel="canonical" href="{{ site.url }}{{ page.url | replace: 'index.html', '' }}" />
 
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
     {% include rss_discovery.html %}


### PR DESCRIPTION
Set canonical URL for link rel.

For instance, `http://www.ruby-lang.org/en/`, `https://www.ruby-lang.org/en/` and `https://www.ruby-lang.org/en/index.html` are all set the following canonical URL tag.

``` html
<link rel="canonical" href="https://www.ruby-lang.org/en/" />
```
