### PR TITLE
[es] Translate en/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md

### DIFF
--- a/es/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
+++ b/es/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
@@ -1,0 +1,20 @@
+---
+layout: news_post
+title: "Soporte para Ruby 1.9.3 finaliza el 23 de febrero de 2015."
+author: "hsbt"
+translator: "soveran"
+date: 2014-01-10 0:00:0 UTC
+lang: es
+---
+
+Anunciamos los planes para el futuro de la versión 1.9.3 de Ruby.
+
+Actualmente se encuentra en modo mantenimiento, y permanecerá así
+hasta el 23 de febrero de 2014.
+
+Desde entonces y hasta el 23 de febrero del 2015, sólo proveeremos
+parches de seguridad para 1.9.3. Después de esta fecha, no habrá
+soporte de ningún tipo para esta versión.
+
+Recomendamos actualizar Ruby a la versión 2.1 o 2.0.0 tan pronto
+como sea posible.


### PR DESCRIPTION
Add the translation to Spanish of the Ruby 1.9.3 end of life announcement.
