### PR TITLE
Add the news about the end of Ruby 1.9.3 (fr)

### DIFF
--- a/fr/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
+++ b/fr/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "Le support de Ruby 1.9.3 s'achèvera le 23 février 2015"
+author: "hsbt"
+translator: "Geoffrey Roguelon"
+date: 2014-01-10 0:00:0 UTC
+lang: fr
+---
+
+Aujourd'hui, nous annonçons le planning de la fin du support de Ruby 1.9.3.
+
+Actuellement, cette branche est en mode maintenance et le restera jusqu'au 23 février 2014.
+
+Après le 23 février 2014, nous fournirons seulement des correctifs de sécurité jusqu'au 23 février 2015, après cette date. La version 1.9.3 de Ruby ne sera plus supportée.
+
+Nous recommandons fortement de mettre à jour vos applications en Ruby 2.1 ou 2.0.0, dès que possible.


### PR DESCRIPTION
Hi,

Please find a proposition of translation of the news about the end of Ruby 1.9.3.

I have a question, concerning the recent news about Ruby 2.1.0 semantic versions, we should not write "Ruby 2.1.0" instead of "Ruby 2.1" like written in the original news?

Thanks.
