### PR TITLE
Extract a page about mirror sites

### DIFF
--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -51,69 +51,8 @@ party tools in [Installation](/en/installation) page. They may help you.
 For information about the Ruby Subversion and Git repositories, see our
 [Ruby Core](/en/community/ruby-core/) page.
 
-### Mirror sites
-
-The Ruby source is available from a worldwide set of mirror sites.
+The Ruby source is available from a worldwide set of [Mirror Sites](/en/downloads/mirrors/).
 Please try to use a mirror that is near you.
-
-#### Mirror sites via HTTP
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japan 1][mirror-https-jp] (Master) - HTTPS
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Britain][mirror-http-uk] (The Mirror Service)
-* [Germany][mirror-http-de] (AmbiWeb GmbH)
-* [Belgium][mirror-http-be] (Easynet)
-* [Denmark][mirror-http-dk] (sunsite.dk)
-* [Holland][mirror-http-nl] (XS4ALL) - only release packages
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China][mirror-http-cn] (ruby.taobao.org)
-
-#### Mirror sites via FTP
-
-* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japan 3][mirror-ftp-jp3] (IIJ)
-* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Britain][mirror-ftp-uk] (The Mirror Service)
-* [Germany][mirror-ftp-de] (FU Berlin)
-* [Belgium][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Greece][mirror-ftp-gr] (ntua.gr)
-* [Denmark][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### Mirror sites via rsync
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
 
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
@@ -129,46 +68,3 @@ Please try to use a mirror that is near you.
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org
 [rubyspec]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/en/downloads/mirrors/index.md
+++ b/en/downloads/mirrors/index.md
@@ -1,0 +1,113 @@
+---
+layout: page
+title: "Mirror Sites"
+lang: en
+---
+
+The Ruby source is available from a worldwide set of mirror sites.
+Please try to use a mirror that is near you.
+
+{: .summary}
+
+### Mirror sites via HTTP
+
+* [CDN][mirror-http-cdn] (fastly.com)
+* [Japan 1][mirror-https-jp] (Master) - HTTPS
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
+* [Britain][mirror-http-uk] (The Mirror Service)
+* [Germany][mirror-http-de] (AmbiWeb GmbH)
+* [Belgium][mirror-http-be] (Easynet)
+* [Denmark][mirror-http-dk] (sunsite.dk)
+* [Holland][mirror-http-nl] (XS4ALL) - only release packages
+* [USA 1][mirror-http-us1] (ibiblio.org)
+* [USA 2][mirror-http-us2] (lcs.mit.edu)
+* [USA 3][mirror-http-us3] (binarycode.org)
+* [USA 4][mirror-http-us4] (online-mirror.org)
+* [USA 5][mirror-http-us5] (trexle.com)
+* [Austria][mirror-http-at] (tuwien.ac.at)
+* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
+* [China][mirror-http-cn] (ruby.taobao.org)
+
+### Mirror sites via FTP
+
+* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
+* Japan 2 (RingServer)
+  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
+  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
+  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
+  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
+  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
+  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
+* [Japan 3][mirror-ftp-jp3] (IIJ)
+* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
+* [Britain][mirror-ftp-uk] (The Mirror Service)
+* [Germany][mirror-ftp-de] (FU Berlin)
+* [Belgium][mirror-ftp-be] (Easynet)
+* [Russia][mirror-ftp-ru] (ChgNet)
+* [Greece][mirror-ftp-gr] (ntua.gr)
+* [Denmark][mirror-ftp-dk] (sunsite.dk)
+* [USA 1][mirror-ftp-us1] (ibiblio.org)
+* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
+* [Austria][mirror-ftp-at] (tuwien.ac.at)
+* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
+* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
+* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
+
+### Mirror sites via rsync
+
+* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
+* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
+* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
+* rsync://mirror.cs.mun.ca/ruby/ (Canada)
+* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
+
+[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
+[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
+[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
+[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
+[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
+[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
+[mirror-http-be]: http://ruby.mirror.easynet.be/
+[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
+[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
+[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
+[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
+[mirror-http-us3]: http://www.binarycode.org/ruby/
+[mirror-http-us4]: http://www.online-mirror.org/ruby/
+[mirror-http-us5]: http://ruby.trexle.com/
+[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
+[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
+[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
+[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
+[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
+[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
+[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
+[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
+[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
+[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
+[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
+[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
+[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
+[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
+[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
+[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
+[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
+[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
+[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -51,69 +51,8 @@ de terceros en la sección siguiente. Pueden servirte de ayuda.
 Para información sobre los repositorios de Subversion y Git, consulta nuestra página
 [Ruby core](/es/community/ruby-core/).
 
-### Mirror sites
-
-El código fuente de Ruby está disponible desde un conjunto de mirror sites a lo largo
+El código fuente de Ruby está disponible desde un conjunto de [mirror sites](/en/downloads/mirrors/) a lo largo
 del mundo. Intenta usar el mirror site más cerca de ti.
-
-#### Mirror sites via HTTP
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japón 1][mirror-http-jp1] (Master) - HTTPS
-* Japón 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Gran Bretaña][mirror-http-uk] (The Mirror Service)
-* [Alemania][mirror-http-de] (AmbiWeb GmbH)
-* [Bélgica][mirror-http-be] (Easynet)
-* [Dinamarca][mirror-http-dk] (sunsite.dk)
-* [Holanda][mirror-http-nl] (XS4ALL) - only release packages
-* [EEUU 1][mirror-http-us1] (ibiblio.org)
-* [EEUU 2][mirror-http-us2] (lcs.mit.edu)
-* [EEUU 3][mirror-http-us3] (binarycode.org)
-* [EEUU 4][mirror-http-us4] (online-mirror.org)
-* [EEUU 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China 1][mirror-http-cn] (ruby.taobao.org)
-
-#### Mirror sites via FTP
-
-* [Japón 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japón 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japón 3][mirror-ftp-jp3] (IIJ)
-* [Corea del Sur][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Alemania][mirror-ftp-de] (FU Berlin)
-* [Gran Bretaña][mirror-ftp-uk] (The Mirror Service)
-* [Bélgica][mirror-ftp-be] (Easynet)
-* [Rusia][mirror-ftp-ru] (ChgNet)
-* [Grecia][mirror-ftp-gr] (ntua.gr)
-* [Dinamarca][mirror-ftp-dk] (sunsite.dk)
-* [EEUU 1][mirror-ftp-us1] (ibiblio.org)
-* [EEUU 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canadá][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### Mirror sites via rsync
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Gran Bretaña)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Dinamarca)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canadá)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
 
 ### Herramientas de terceros
 
@@ -310,46 +249,3 @@ una "completa especificación ejecutable para el lenguaje de programación Ruby"
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -57,69 +57,8 @@ esserti di aiuto.
 Puoi trovare maggiori informazioni sui repository Subversion e Git di Ruby
 nella pagina [Ruby Core](/it/community/ruby-core/).
 
-### Siti mirror
-
-Il codice sorgente di Ruby è disponibile tramite alcuni siti mirror in
+Il codice sorgente di Ruby è disponibile tramite alcuni [siti mirror](/en/downloads/mirrors/) in
 giro per il mondo. Cerca di utilizzare il sito mirror più vicino a te.
-
-#### Siti mirror via HTTP
-
-* [CDN][64] (fastly.com)
-* [Giappone 1][mirror-https-jp] (Master) - HTTPS
-* Giappone 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Gran Bretagna][mirror-http-uk] (The Mirror Service)
-* [Germania][mirror-http-de] (AmbiWeb GmbH)
-* [Belgio][mirror-http-be] (Easynet)
-* [Danimarca][mirror-http-dk] (sunsite.dk)
-* [Olanda][mirror-http-nl] (XS4ALL) - solo release
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China 1][mirror-http-cn] (ruby.taobao.org)
-
-#### Siti mirror via FTP
-
-* [Giappone 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Giappone 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Giappone 3][mirror-ftp-jp3] (IIJ)
-* [Corea del Sud][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Germania][mirror-ftp-dk] (FU Berlin)
-* [Gran Bretagna][mirror-ftp-uk] (The Mirror Service)
-* [Belgio][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Grecia][mirror-ftp-gr] (ntua.gr)
-* [Danimarca][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### Siti mirror via rsync
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Gran Bretagna)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Danimarca)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
 
 ### Strumenti di Terze Parti
 
@@ -315,46 +254,3 @@ di programmazione Ruby”.
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -29,68 +29,8 @@ Windows向けのバイナリが有志により配布されています。
 * [RailsInstaller][railsinstaller] (英語)
   RubyInstaller に Rails の開発に必要なものを加えたもの。
 
-## ミラーサイト
-
 Rubyのソースコードや、それを含めた当サイトの内容が、有志によりミラーされています。
-
-### HTTPミラーサイト
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [日本 1][mirror-https-jp] (マスターサイト) - HTTPS
-* 日本 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [イギリス][mirror-http-uk] (The Mirror Service)
-* [ドイツ][mirror-http-de] (AmbiWeb GmbH)
-* [ベルギー][mirror-http-be] (Easynet)
-* [デンマーク][mirror-http-dk] (sunsite.dk)
-* [オランダ][mirror-http-nl] (XS4ALL) - リリース版のみ
-* [アメリカ 1][mirror-http-us1] (ibiblio.org)
-* [アメリカ 2][mirror-http-us2] (lcs.mit.edu)
-* [アメリカ 3][mirror-http-us3] (binarycode.org)
-* [アメリカ 4][mirror-http-us4] (online-mirror.org)
-* [アメリカ 5][mirror-http-us5] (trexle.com)
-* [オーストリア][mirror-http-at] (tuwien.ac.at)
-* [台湾 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [台湾 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [中国][mirror-http-cn] (ruby.taobao.org)
-
-### FTPミラーサイト
-
-* [日本 1][mirror-ftp-jp1] (マスターサイト)
-* 日本 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [日本 3][mirror-ftp-jp3] (IIJ)
-* [韓国][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [ドイツ][mirror-ftp-de] (FU Berlin)
-* [イギリス][mirror-ftp-uk] (The Mirror Service)
-* [ベルギー][mirror-ftp-be] (Easynet)
-* [ロシア][mirror-ftp-ru] (ChgNet)
-* [ギリシャ][mirror-ftp-gr] (アテネ工科大)
-* [デンマーク][mirror-ftp-dk] (sunsite.dk)
-* [アメリカ 1][mirror-ftp-us1] (ibiblio.org)
-* [アメリカ 2][mirror-ftp-us2] (lcs.mit.edu)
-* [オーストリア][mirror-ftp-at] (tuwien.ac.at)
-* [台湾 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [台湾 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [カナダ][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-### Rsyncミラーサイト
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (イギリス)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (デンマーク)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (オーストリア)
-* rsync://mirror.cs.mun.ca/ruby/ (カナダ)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (台湾)
+[ミラーサイト一覧](/en/downloads/mirrors/)を参照してください。
 
 Posted by Shugo Maeda on 26 May 2006
 {: .post-info}
@@ -113,46 +53,3 @@ Posted by Shugo Maeda on 26 May 2006
 [active-script-ruby]: http://www.artonx.org/data/asr/
 [rubyinstaller]: http://rubyinstaller.org/
 [railsinstaller]: http://railsinstaller.org/
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -44,69 +44,8 @@ lang: ko
 
 루비 서브버전과 Git 저장소에 대한 정보는, [Ruby Core](/en/community/ruby-core/) 페이지를 읽어 보십시오.
 
-### 미러 사이트
-
-루비 소스는 전세계의 미러 사이트에서 사용하실 수 있습니다.
+루비 소스는 전세계의 [미러 사이트](/en/downloads/mirrors/)에서 사용하실 수 있습니다.
 자신과 가까운 곳의 미러를 이용해 주십시오.
-
-#### HTTP 경유 미러 사이트
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japan 1][mirror-https-jp] (Master) - HTTPS
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Britain][mirror-http-uk] (The Mirror Service)
-* [Germany][mirror-http-de] (AmbiWeb GmbH)
-* [Belgium][mirror-http-be] (Easynet)
-* [Denmark][mirror-http-dk] (sunsite.dk)
-* [Holland][mirror-http-nl] (XS4ALL) - only release packages
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China][mirror-http-cn] (ruby.taobao.org)
-
-#### FTP 경유 미러 사이트
-
-* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japan 3][mirror-ftp-jp3] (IIJ)
-* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Britain][mirror-ftp-uk] (The Mirror Service)
-* [Germany][mirror-ftp-de] (FU Berlin)
-* [Belgium][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Greece][mirror-ftp-gr] (ntua.gr)
-* [Denmark][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### rsync 경유 미러 사이트
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
 
 ### 서드파티 도구
 
@@ -283,46 +222,3 @@ MRI를 포함, 일부 구현체들은 “complete executable specification for t
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org
 [rubyspec]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -54,69 +54,10 @@ trzecich z następnej sekcji. Mogą ci pomóc.
 Aby uzyskać informacje na temat repozytorium Rubiego w Subversion i Git,
 zobacz stronę [Ruby Core](/en/community/ruby-core/).
 
-### Strony lustrzane
-
 Źródła Rubiego są dostępne na światowych stronach lustrzanych. Spróbuj
 użyć jakiegoś blisko ciebie.
 
-#### Strony lustrzane poprzez HTTP
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japan 1][mirror-https-jp] (Master) - HTTPS
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Britain][mirror-http-uk] (The Mirror Service)
-* [Germany][mirror-http-de] (AmbiWeb GmbH)
-* [Belgium][mirror-http-be] (Easynet)
-* [Denmark][mirror-http-dk] (sunsite.dk)
-* [Holland][mirror-http-nl] (XS4ALL) - only release packages
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China][mirror-http-cn] (ruby.taobao.org)
-
-#### Strony lustrzane poprzez FTP
-
-* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japan 3][mirror-ftp-jp3] (IIJ)
-* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Britain][mirror-ftp-uk] (The Mirror Service)
-* [Germany][mirror-ftp-de] (FU Berlin)
-* [Belgium][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Greece][mirror-ftp-gr] (ntua.gr)
-* [Denmark][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### Strony lustrzane poprzez rsync
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
+[Strony lustrzane](/en/downloads/mirrors/)
 
 ### Narzędzia osób trzecich
 
@@ -303,46 +244,3 @@ Niektóre z tych implementacji, włączając w to MRI, podążają za wytycznymi
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -51,69 +51,11 @@ lang: ru
 За информацией о Ruby Subversion и Git репозиториях пожалуйста,
 посмотрите страницу о [ядре Ruby](/ru/community/ruby-core/).
 
-### Зеркала
-
 Исходный код Ruby доступен по всему миру на нескольких зеркальных
 сайтах. Пожалуйста, попробуйте использовать зеркало, которое находится
 недалеко от вас.
 
-#### Зеркальные сайты по HTTP протоколу
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Япония 1][mirror-https-jp] (главный) - HTTPS
-* Япония 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Англия][mirror-http-uk] (The Mirror Service)
-* [Германия][mirror-http-de] (AmbiWeb GmbH)
-* [Бельгия][mirror-http-be] (Easynet)
-* [Дания][mirror-http-dk] (sunsite.dk)
-* [Нидерланды][mirror-http-nl] (XS4ALL) - только пакеты релизов
-* [США 1][mirror-http-us1] (ibiblio.org)
-* [США 2][mirror-http-us2] (lcs.mit.edu)
-* [США 3][mirror-http-us3] (binarycode.org)
-* [США 4][mirror-http-us4] (online-mirror.org)
-* [США 5][mirror-http-us5] (trexle.com)
-* [Австралия][mirror-http-at] (tuwien.ac.at)
-* [Тайвань 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Тайвань 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-
-#### Зеркальные сайты по FTP протоколу
-
-* [Япония 1][mirror-ftp-jp1] (главный: ruby-lang.org)
-* Япония 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Япония 3][mirror-ftp-jp3] (IIJ)
-* [Южная корея][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Германия][mirror-ftp-de] (FU Berlin)
-* [Англия][mirror-ftp-uk] (The Mirror Service)
-* [Бельгия][mirror-ftp-be] (Easynet)
-* [Россия][mirror-ftp-ru] (ChgNet)
-* [Греция][mirror-ftp-gr] (ntua.gr)
-* [Дания][mirror-ftp-dk] (sunsite.dk)
-* [США 1][mirror-ftp-us1] (ibiblio.org)
-* [США 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Австралия][mirror-ftp-at] (tuwien.ac.at)
-* [Тайвань 1][mirror-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Тайвань 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Канада][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### Зеркальные сайты по rsync
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Англия)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Дания)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Австрия)
-* rsync://mirror.cs.mun.ca/ruby/ (Канада)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Тайвань)
+[Зеркала](/en/downloads/mirrors/)
 
 ### Сторонние инструменты
 

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -21,66 +21,7 @@ lang: zh_cn
 
 ### 镜像站
 
-在世界各地的镜像站上面已经有 Ruby 的源代码了，你可以选择就近的地方下载。
-
-#### HTTP 镜像站
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japan 1][mirror-https-jp] (Master) - HTTPS
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Britain][mirror-http-uk] (The Mirror Service)
-* [Germany][mirror-http-de] (AmbiWeb GmbH)
-* [Belgium][mirror-http-be] (Easynet)
-* [Denmark][mirror-http-dk] (sunsite.dk)
-* [Holland][mirror-http-nl] (XS4ALL) - only release packages
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China][mirror-http-cn] (ruby.taobao.org)
-
-#### FTP 镜像站
-
-* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japan 3][mirror-ftp-jp3] (IIJ)
-* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Britain][mirror-ftp-uk] (The Mirror Service)
-* [Germany][mirror-ftp-de] (FU Berlin)
-* [Belgium][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Greece][mirror-ftp-gr] (ntua.gr)
-* [Denmark][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### rsync 镜像
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
+在世界各地的[镜像站](/en/downloads/mirrors/)上面已经有 Ruby 的源代码了，你可以选择就近的地方下载。
 
 ### Windows 系统
 
@@ -165,46 +106,3 @@ LightTPD, and MySQL on Tiger*][15] 将快速的教您启动和运行。
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -37,68 +37,7 @@ lang: zh_tw
 
 關於 Ruby Subversion 與 Git Repositories 的資訊，參見 [Ruby Core](/en/community/ruby-core/) 頁面。
 
-### 鏡像站
-
-Ruby 原始碼可從世界各地的鏡像站獲得。請嘗試離您最近的鏡像站。
-
-#### 透過 HTTP 的鏡像站
-
-* [CDN][mirror-http-cdn] (fastly.com)
-* [Japan 1][mirror-https-jp] (Master) - HTTPS
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-http-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-http-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-http-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-http-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-http-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-http-jp-ring-maffin]
-* [Britain][mirror-http-uk] (The Mirror Service)
-* [Germany][mirror-http-de] (AmbiWeb GmbH)
-* [Belgium][mirror-http-be] (Easynet)
-* [Denmark][mirror-http-dk] (sunsite.dk)
-* [Holland][mirror-http-nl] (XS4ALL) - only release packages
-* [USA 1][mirror-http-us1] (ibiblio.org)
-* [USA 2][mirror-http-us2] (lcs.mit.edu)
-* [USA 3][mirror-http-us3] (binarycode.org)
-* [USA 4][mirror-http-us4] (online-mirror.org)
-* [USA 5][mirror-http-us5] (trexle.com)
-* [Austria][mirror-http-at] (tuwien.ac.at)
-* [Taiwan 1][mirror-http-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-http-tw2] (ftp.cs.pu.edu.tw)
-* [China][mirror-http-cn] (ruby.taobao.org)
-
-#### 透過 FTP 的鏡像站
-
-* [Japan 1][mirror-ftp-jp1] (Master: ruby-lang.org)
-* Japan 2 (RingServer)
-  * [shibaura-it.ac.jp][mirror-ftp-jp-ring-shibaura-it]
-  * [tohoku.ac.jp][mirror-ftp-jp-ring-tohoku]
-  * [u-toyama.ac.jp][mirror-ftp-jp-ring-u-toyama]
-  * [yamanashi.ac.jp][mirror-ftp-jp-ring-yamanashi]
-  * [airnet.ne.jp][mirror-ftp-jp-ring-airnet]
-  * [maffin.ad.jp][mirror-ftp-jp-ring-maffin]
-* [Japan 3][mirror-ftp-jp3] (IIJ)
-* [South Korea][mirror-ftp-kr] (Korea FreeBSD Users Group)
-* [Britain][mirror-ftp-uk] (The Mirror Service)
-* [Germany][mirror-ftp-de] (FU Berlin)
-* [Belgium][mirror-ftp-be] (Easynet)
-* [Russia][mirror-ftp-ru] (ChgNet)
-* [Greece][mirror-ftp-gr] (ntua.gr)
-* [Denmark][mirror-ftp-dk] (sunsite.dk)
-* [USA 1][mirror-ftp-us1] (ibiblio.org)
-* [USA 2][mirror-ftp-us2] (lcs.mit.edu)
-* [Austria][mirror-ftp-at] (tuwien.ac.at)
-* [Taiwan 1][mirro-ftp-tw1] (cdpa.nsysu.edu.tw)
-* [Taiwan 2][mirror-ftp-tw2] (ftp.cs.pu.edu.tw)
-* [Canada][mirror-ftp-ca] (mirror.cs.mun.ca)
-
-#### 透過 rsync 的鏡像站
-
-* rsync://rsync.mirrorservice.org/ftp.ruby-lang.org/pub/ruby/ (Britain)
-* rsync://sunsite.dk/ftp/mirrors/ruby/ (Denmark)
-* rsync://gd.tuwien.ac.at/languages/ruby/ (Austria)
-* rsync://mirror.cs.mun.ca/ruby/ (Canada)
-* rsync://ftp.cs.pu.edu.tw/Ruby/ (Taiwan)
+Ruby 原始碼可從世界各地的[鏡像站](/en/downloads/mirrors/)獲得。請嘗試離您最近的鏡像站。
 
 ### 第三方工具
 {: #third-party-tools}
@@ -226,49 +165,6 @@ MRI 與某些實作遵循 [RubySpec][28]，Ruby 程式語言的完整規格文�
 [26]: http://www.ironruby.net
 [27]: http://ruby.gemstone.com
 [28]: http://rubyspec.org
-[mirror-http-cdn]: http://cache.ruby-lang.org/pub/ruby/
-[mirror-http-jp-ring-shibaura-it]: http://ring.shibaura-it.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-tohoku]: http://ring.tains.tohoku.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-u-toyama]: http://ring.u-toyama.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-yamanashi]: http://ring.yamanashi.ac.jp/archives/lang/ruby/
-[mirror-http-jp-ring-airnet]: http://ring.airnet.ne.jp/archives/lang/ruby/
-[mirror-http-jp-ring-maffin]: http://ring.maffin.ad.jp/archives/lang/ruby/
-[mirror-https-jp]: https://ftp.ruby-lang.org/pub/ruby/
-[mirror-http-uk]: http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-http-de]: http://dl.ambiweb.de/mirrors/ftp.ruby-lang.org/
-[mirror-http-be]: http://ruby.mirror.easynet.be/
-[mirror-http-dk]: http://mirrors.sunsite.dk/ruby/
-[mirror-http-nl]: http://www.xs4all.nl/~hipster/lib/mirror/ruby/
-[mirror-http-us1]: http://www.ibiblio.org/pub/languages/ruby/
-[mirror-http-us2]: http://xyz.lcs.mit.edu/ruby/
-[mirror-http-us3]: http://www.binarycode.org/ruby/
-[mirror-http-us4]: http://www.online-mirror.org/ruby/
-[mirror-http-us5]: http://ruby.trexle.com/
-[mirror-http-at]: http://gd.tuwien.ac.at/languages/ruby/
-[mirror-http-tw1]: http://pluto.cdpa.nsysu.edu.tw/ruby/
-[mirror-http-tw2]: http://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-http-cn]: http://ruby.taobao.org/mirrors/ruby/
-[mirror-ftp-jp1]: ftp://ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-jp-ring-shibaura-it]: ftp://ring.shibaura-it.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-tohoku]: ftp://ring.tains.tohoku.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-u-toyama]: ftp://ring.u-toyama.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-yamanashi]: ftp://ring.yamanashi.ac.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-airnet]: ftp://ring.airnet.ne.jp/pub/lang/ruby/
-[mirror-ftp-jp-ring-maffin]: ftp://ring.maffin.ad.jp/pub/lang/ruby/
-[mirror-ftp-jp3]: ftp://ftp.iij.ad.jp/pub/lang/ruby/
-[mirror-ftp-kr]: ftp://ftp.kr.freebsd.org/pub/ruby/
-[mirror-ftp-de]: ftp://ftp.fu-berlin.de/unix/languages/ruby/
-[mirror-ftp-uk]: ftp://ftp.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/
-[mirror-ftp-be]: ftp://ftp.easynet.be/ruby/ruby/
-[mirror-ftp-ru]: ftp://ftp.chg.ru/pub/lang/ruby/
-[mirror-ftp-gr]: ftp://ftp.ntua.gr/pub/lang/ruby/
-[mirror-ftp-dk]: ftp://sunsite.dk/mirrors/ruby/
-[mirror-ftp-us1]: ftp://www.ibiblio.org/pub/languages/ruby/
-[mirror-ftp-us2]: ftp://xyz.lcs.mit.edu/pub/ruby/
-[mirror-ftp-at]: ftp://gd.tuwien.ac.at/languages/ruby/
-[mirror-ftp-tw1]: ftp://ruby.cdpa.nsysu.edu.tw/ruby/
-[mirror-ftp-tw2]: ftp://ftp.cs.pu.edu.tw/Unix/lang/Ruby/
-[mirror-ftp-ca]: ftp://mirror.cs.mun.ca/pub/mirror/ruby/
 
 [rbenv]: https://github.com/sstephenson/rbenv
 [ruby-install]: https://github.com/postmodern/ruby-install


### PR DESCRIPTION
Fix #560.

I create a page about mirror sites in `/en/downloads/mirrors/` and replace a list of mirror sites in downloads page of some languages with links to the mirror page.
