### PR TITLE
Mirrors list missing for german page

### DIFF
--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -56,6 +56,9 @@ vielleicht zu einem Drittanbieter-Werkzeug greifen, siehe nächster Abschnitt.
 Weitergehende Informationen zum Subversion- und Git-Repository von Ruby
 sind unter [Ruby Core](/en/community/ruby-core/) zu finden.
 
+Der Ruby-Quellcode ist auch auf verschiedenen [Mirror-Seiten](/en/downloads/mirrors/) zu finden.
+Bitte nutze einen Mirror in deiner Nähe.
+
 ### Drittanbieter-Werkzeuge
 
 Viele Rubyisten benutzen Drittanbieter-Werkzeuge, um Ruby zu installieren.


### PR DESCRIPTION
The mirrors list introduced in https://github.com/ruby/www.ruby-lang.org/pull/584 is missing for the german page.
