### PR TITLE
Fix deadlinks about rubycentral

### DIFF
--- a/bg/community/conferences/index.md
+++ b/bg/community/conferences/index.md
@@ -58,11 +58,11 @@ Central и [Skills Matter][12], и през 2007 г. с помощта на Ruby
 
 
 [1]: http://www.rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://www.rubycentral.org/rcg2006.pdf
+[6]: http://rubycentral.org/community/grant
 [7]: http://www.sdforum.org
 [8]: http://rubynation.org/
 [9]: http://conferences.oreillynet.com/os2006/

--- a/bg/community/index.md
+++ b/bg/community/index.md
@@ -47,6 +47,6 @@ lang: bg
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/de/community/conferences/index.md
+++ b/de/community/conferences/index.md
@@ -23,5 +23,5 @@ lang: de
 
 [1]: http://euruko.org/
 [2]: http://www.rubyconf.org/
-[3]: http://www.rubycentral.org
+[3]: http://rubycentral.org
 [4]: http://rubykaigi.org/

--- a/de/community/index.md
+++ b/de/community/index.md
@@ -70,6 +70,6 @@ Allgemeine Information zu Ruby
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/de/news/_posts/2003-02-24-alles-gute-zum-geburtstag-ruby.md
+++ b/de/news/_posts/2003-02-24-alles-gute-zum-geburtstag-ruby.md
@@ -18,5 +18,5 @@ Weitere Informationen in der Mailingliste: [\[ruby-talk:65632\]][2].
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632

--- a/de/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
+++ b/de/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
@@ -15,4 +15,4 @@ Inc.][3]
 
 [1]: http://www.rubycentral.org/conference
 [2]: http://www.rubycentral.org/conference/register.html
-[3]: http://www.rubycentral.org
+[3]: http://rubycentral.org

--- a/de/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
+++ b/de/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
@@ -13,6 +13,6 @@ of your group.
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://www.rubycentral.org/grant/announce.html
 [3]: http://www.rubycentral.org/grant/application.html

--- a/de/news/_posts/2006-02-09-conference-season-is-here.md
+++ b/de/news/_posts/2006-02-09-conference-season-is-here.md
@@ -25,7 +25,7 @@ and/or registering to attend.
 [1]: http://www.canadaonrails.org
 [2]: http://www.sdforum.org/rubyconference
 [3]: http:/www.sdforum.org
-[4]: http://www.rubycentral.org
+[4]: http://rubycentral.org
 [5]: http://www.railsconf.org
 [6]: http://conferences.oreillynet.com/cs/os2006/create/e_sess/
 [7]: http://conferences.oreillynet.com/os2006/

--- a/de/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
+++ b/de/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
@@ -13,5 +13,5 @@ Central.
 
 
 [1]: http://code.google.com/soc/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://www.rubycentral.org/soc2006

--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -77,11 +77,11 @@ O’Reilly), and Canada on Rails.
 
 
 [1]: http://rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://www.rubycentral.org/rcg2006.pdf
+[6]: http://rubycentral.org/community/grant
 [7]: http://www.sdforum.org
 [8]: http://rubynation.org/
 [9]: http://windycityrails.org

--- a/en/community/index.md
+++ b/en/community/index.md
@@ -49,6 +49,6 @@ General Ruby Information
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/en/news/_posts/2003-02-24-happy-birthday-ruby.md
+++ b/en/news/_posts/2003-02-24-happy-birthday-ruby.md
@@ -16,5 +16,5 @@ Inc][1] and RubyConf 2003!. See [\[ruby-talk:65632\]][2].
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632

--- a/en/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
+++ b/en/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
@@ -15,4 +15,4 @@ Inc.][3]
 
 [1]: http://www.rubycentral.org/conference
 [2]: http://www.rubycentral.org/conference/register.html
-[3]: http://www.rubycentral.org
+[3]: http://rubycentral.org

--- a/en/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
+++ b/en/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
@@ -13,6 +13,6 @@ of your group.
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://www.rubycentral.org/grant/announce.html
 [3]: http://www.rubycentral.org/grant/application.html

--- a/en/news/_posts/2006-02-09-conference-season-is-here.md
+++ b/en/news/_posts/2006-02-09-conference-season-is-here.md
@@ -25,7 +25,7 @@ and/or registering to attend.
 [1]: http://www.canadaonrails.org
 [2]: http://www.sdforum.org/rubyconference
 [3]: http:/www.sdforum.org
-[4]: http://www.rubycentral.org
+[4]: http://rubycentral.org
 [5]: http://www.railsconf.org
 [6]: http://conferences.oreillynet.com/cs/os2006/create/e_sess/
 [7]: http://conferences.oreillynet.com/os2006/

--- a/en/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
+++ b/en/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
@@ -13,5 +13,5 @@ Central.
 
 
 [1]: http://code.google.com/soc/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://www.rubycentral.org/soc2006

--- a/es/community/index.md
+++ b/es/community/index.md
@@ -51,6 +51,6 @@ Información general sobre Ruby
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/fr/community/conferences/index.md
+++ b/fr/community/conferences/index.md
@@ -70,11 +70,11 @@ O’Reilly) et enfin *Canada on Rails*.
 
 
 [1]: http://www.rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://www.rubycentral.org/rcg2006.pdf
+[6]: http://rubycentral.org/community/grant
 [7]: http://www.sdforum.org
 [8]: http://conferences.oreillynet.com/os2006/
 [9]: http://www.rubyonrails.org

--- a/fr/community/index.md
+++ b/fr/community/index.md
@@ -55,6 +55,6 @@ Informations générales
 
 
 [1]: http://rubyfrance.org
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/id/community/conferences/index.md
+++ b/id/community/conferences/index.md
@@ -73,10 +73,10 @@ on Rails.
 [2]: http://ariekusumaatmaja.wordpress.com/2007/06/27/catatan-tercecer-bandung-sejuk-bergairah/
 [3]: http://ariekusumaatmaja.wordpress.com/2007/08/20/gathering-id-ruby-ketiga-19-agustus-2007-1145-1700-wib/
 [4]: http://www.rubyconf.org/
-[5]: http://www.rubycentral.org
+[5]: http://rubycentral.org
 [6]: http://rubykaigi.org/
 [7]: http://euruko.org
-[8]: http://www.rubycentral.org/rcg2006.pdf
+[8]: http://rubycentral.org/community/grant
 [9]: http://www.sdforum.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/id/community/index.md
+++ b/id/community/index.md
@@ -66,6 +66,6 @@ Informasi Umum Tentang Ruby
 
 
 [2]: http://tech.groups.yahoo.com/group/id-ruby/
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/it/community/conferences/index.md
+++ b/it/community/conferences/index.md
@@ -55,10 +55,10 @@ e in 2007 da Ruby Central e O’Reilly), e infine Canada on Rails.
 
 
 [1]: http://www.rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[5]: http://www.rubycentral.org/rcg2006.pdf
+[5]: http://rubycentral.org/community/grant
 [6]: http://www.sdforum.org
 [7]: http://conferences.oreillynet.com/os2006/
 [8]: http://www.rubyonrails.org

--- a/it/community/index.md
+++ b/it/community/index.md
@@ -51,6 +51,6 @@ Informazioni generali su Ruby
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/ja/news/_posts/2003-02-25-20030225.md
+++ b/ja/news/_posts/2003-02-25-20030225.md
@@ -19,4 +19,4 @@ Inc.のページやRubyConf.orgで公開されるそうです。
 
 
 [1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632
-[2]: http://www.rubycentral.org/
+[2]: http://rubycentral.org/

--- a/ko/community/conferences/index.md
+++ b/ko/community/conferences/index.md
@@ -52,7 +52,7 @@ Canada on Rails 등등의 많은 컨퍼런스들은 [Ruby on Rails][11]의 헌�
 
 
 [1]: http://rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/

--- a/ko/community/index.md
+++ b/ko/community/index.md
@@ -48,6 +48,6 @@ lang: ko
   * [Ruby at Open Directory Project][4]
   * [Rails at Open Directory Project][5]
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/ko/news/_posts/2003-02-24-happy-birthday-ruby.md
+++ b/ko/news/_posts/2003-02-24-happy-birthday-ruby.md
@@ -16,5 +16,5 @@ Inc][1] and RubyConf 2003!. See [\[ruby-talk:65632\]][2].
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632

--- a/ko/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
+++ b/ko/news/_posts/2004-07-31-rubyconf-2004-registration-now-open.md
@@ -15,4 +15,4 @@ Inc.][3]
 
 [1]: http://www.rubycentral.org/conference
 [2]: http://www.rubycentral.org/conference/register.html
-[3]: http://www.rubycentral.org
+[3]: http://rubycentral.org

--- a/ko/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
+++ b/ko/news/_posts/2004-12-02-ruby-codefest-grant-program-announced-by-ruby-central-inc.md
@@ -13,6 +13,6 @@ of your group.
 
 
 
-[1]: http://www.rubycentral.org
+[1]: http://rubycentral.org
 [2]: http://www.rubycentral.org/grant/announce.html
 [3]: http://www.rubycentral.org/grant/application.html

--- a/ko/news/_posts/2006-02-09-conference-season-is-here.md
+++ b/ko/news/_posts/2006-02-09-conference-season-is-here.md
@@ -25,7 +25,7 @@ and/or registering to attend.
 [1]: http://www.canadaonrails.org
 [2]: http://www.sdforum.org/rubyconference
 [3]: http:/www.sdforum.org
-[4]: http://www.rubycentral.org
+[4]: http://rubycentral.org
 [5]: http://www.railsconf.org
 [6]: http://conferences.oreillynet.com/cs/os2006/create/e_sess/
 [7]: http://conferences.oreillynet.com/os2006/

--- a/ko/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
+++ b/ko/news/_posts/2006-04-19-ruby-in-google-summer-of-code.md
@@ -13,5 +13,5 @@ Central.
 
 
 [1]: http://code.google.com/soc/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://www.rubycentral.org/soc2006

--- a/pl/community/index.md
+++ b/pl/community/index.md
@@ -53,7 +53,7 @@ Ogólne informacje o Rubim
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
 [6]: http://forum.rubyonrails.pl/

--- a/pt/community/conferences/index.md
+++ b/pt/community/conferences/index.md
@@ -56,10 +56,10 @@ finalizar a Canada on Rails.
 
 
 [1]: http://www.rubyconf.org/ "RubyConf"
-[2]: http://www.rubycentral.org "Ruby Central, Inc."
+[2]: http://rubycentral.org "Ruby Central, Inc."
 [3]: http://rubykaigi.org/ "RubyKaigi"
 [4]: http://euruko.org
-[5]: http://www.rubycentral.org/rcg2006.pdf "Programa de Apoio a Conferências Regionais"
+[5]: http://rubycentral.org/community/grant "Programa de Apoio a Conferências Regionais"
 [6]: http://www.sdforum.org "SDForum"
 [7]: http://conferences.oreillynet.com/os2006/ "O'Reilly Open Source Conference"
 [8]: http://www.rubyonrails.org

--- a/pt/community/index.md
+++ b/pt/community/index.md
@@ -51,6 +51,6 @@ Informação sobre o Ruby
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/ru/community/conferences/index.md
+++ b/ru/community/conferences/index.md
@@ -66,11 +66,11 @@ O’Reilly), и Canada on Rails.
 
 
 [1]: http://rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://www.rubycentral.org/rcg2006.pdf
+[6]: http://rubycentral.org/community/grant
 [7]: http://www.sdforum.org
 [8]: http://rubynation.org/
 [9]: http://windycityrails.org

--- a/ru/community/index.md
+++ b/ru/community/index.md
@@ -48,6 +48,6 @@ lang: ru
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/tr/community/index.md
+++ b/tr/community/index.md
@@ -49,6 +49,6 @@ Genel Ruby Kaynakları
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/vi/community/conferences/index.md
+++ b/vi/community/conferences/index.md
@@ -60,11 +60,11 @@ Ruby Central và O’Reilly năm 2007), và Canada on Rails.
 
 
 [1]: http://rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://www.rubycentral.org/rcg2006.pdf
+[6]: http://rubycentral.org/community/grant
 [7]: http://www.sdforum.org
 [8]: http://rubynation.org/
 [9]: http://windycityrails.org

--- a/vi/community/index.md
+++ b/vi/community/index.md
@@ -49,6 +49,6 @@ Thông tin chung về Ruby
 
 
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/zh_cn/community/conferences/index.md
+++ b/zh_cn/community/conferences/index.md
@@ -54,10 +54,10 @@ O’Reilly), and Canada on Rails.
 
 
 [1]: http://www.rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[5]: http://www.rubycentral.org/rcg2006.pdf
+[5]: http://rubycentral.org/community/grant
 [6]: http://www.sdforum.org
 [7]: http://conferences.oreillynet.com/os2006/
 [8]: http://www.rubyonrails.org

--- a/zh_cn/community/index.md
+++ b/zh_cn/community/index.md
@@ -40,6 +40,6 @@ Ruby 的一般信息
 
 
 [1]: http://ruby-china.org
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -52,7 +52,7 @@ Ruby 演講，並逐年增加中。也有許多研討會以 [Ruby on Rails][15] 
 
 
 [1]: http://rubyconf.org/
-[2]: http://www.rubycentral.org
+[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://jp.rubyist.net/
 [5]: http://euruko.org/
@@ -61,7 +61,7 @@ Ruby 演講，並逐年增加中。也有許多研討會以 [Ruby on Rails][15] 
 [8]: http://osdc.tw
 [9]: http://rubyconfchina.org
 [10]: http://groups.google.com/group/shanghaionrails
-[11]: http://www.rubycentral.org/rcg2006.pdf
+[11]: http://rubycentral.org/community/grant
 [12]: http://www.sdforum.org
 [13]: http://rubynation.org/
 [14]: http://conferences.oreillynet.com/os2006/

--- a/zh_tw/community/index.md
+++ b/zh_tw/community/index.md
@@ -43,6 +43,6 @@ Ruby 的一般消息
 [2]: http://ruby.tw/about
 [railsfun]: http://railsfun.tw/index.php
 
-[3]: http://www.rubycentral.org/
+[3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/


### PR DESCRIPTION
issue #587

replaced:
- http://www.rubycentral.org -> http://rubycentral.org
- http://www.rubycentral.org/rcg2006.pdf -> http://rubycentral.org/community/grant

remain deadlinks:
- http://www.rubycentral.org/conference
- http://www.rubycentral.org/conference/register.html
- http://www.rubycentral.org/grant/announce.html
- http://www.rubycentral.org/grant/application.html
- http://www.rubycentral.org/conference/prereg/
- http://www.rubycentral.org/conference/register
- http://www.rubycentral.org/soc2006
- http://www.rubycentral.org/conference/agenda.html
