### PR TITLE
Add Ruby Conferences to site

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -9,6 +9,12 @@ conferences, where they get together to share reports on
 work-in-progress, discuss the future of Ruby, and welcome newcomers to
 the Ruby community.
 
+[RubyConferences.org][rc] is a simple list of Ruby-specific conferences,
+published collaboratively with the Ruby community. There you'll find event
+dates, location, CFP and Registration information.
+
+[rc]: http://rubyconferences.org/
+
 ### Major Ruby Conferences
 
 [RubyConf][1]


### PR DESCRIPTION
Updated this page with a link to RubyConferences.org, a more complete list of the Ruby-specific conferences.
