### PR TITLE
translate Abril Pro Ruby 2014 news (it)

### DIFF
--- a/it/news/_posts/2014-01-20-abril-pro-ruby-2014.md
+++ b/it/news/_posts/2014-01-20-abril-pro-ruby-2014.md
@@ -1,0 +1,17 @@
+---
+layout: news_post
+title: "Abril Pro Ruby 2014, The Tropical Ruby Conference"
+author: lailsonbm
+translator: "mtylty"
+date: 2014-01-20 11:22:14 UTC
+lang: it
+---
+
+[Abril Pro Ruby 2014](http://abrilproruby.com/), la terza edizione della Tropical Ruby Conference avrà luogo il **26 Aprile 2014** a
+**Porto de Galinhas beach**, un paradiso a nordest del Brasile. Venite ad incontrare alcuni Rubysti di prim'ordine mentre vi godete questo
+posto stupendo. Le [attività ufficiali della conferenza](http://abrilproruby.com/en/conference/), che avranno luogo il giorno precedente
+ed il successivo, includono immersioni subacquee, escursioni con la barca a remi e sul catamarano.
+
+**Jim Weirich** (il creatore di Rake), **Rafael França** (del Core Team di Rails) e **Nell Shamrell** (il guru delle Espressioni Regolari)
+sono confermati come relatori ed è ancora possibile **proporsi per una presentazione**. Se vuoi tenere una presentazione puoi
+[inviare una proposta](http://cfp.abrilproruby.com/) fino alla fine del mese (**31 Gennaio**).


### PR DESCRIPTION
@ruby/www-ruby-lang-org-i18n-it
