### PR TITLE
Add redirection rule: /foo to /foo/ (when /foo/index.html exists)

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -9,6 +9,10 @@ use Rack::Rewrite do
     r301 %r{.*}, "https://staging.ruby-lang.org$&", scheme: "http", host: "staging.ruby-lang.org"
   end
 
+  r302 %r{.*}, "$&/", if: ->(rack_env) {
+    rack_env["PATH_INFO"].match(%r{/$}).nil? && File.exist?("_site#{rack_env["PATH_INFO"]}/index.html")
+  }
+
   r302 %r{^/bugreport\.html$}, "http://bugs.ruby-lang.org/"
 
   r302 %r{^/ja/20030611\.html$}, "/ja/downloads"


### PR DESCRIPTION
This patch is to fix #579, redirections from `/foo` to `/foo/` does not work with rack-jekyll.
