### PR TITLE
Add post on 2014 Ruby Hero Awards.

### DIFF
--- a/en/news/_posts/2014-02-12-the-2014-ruby-hero-awards.md
+++ b/en/news/_posts/2014-02-12-the-2014-ruby-hero-awards.md
@@ -1,0 +1,20 @@
+---
+layout: news_post
+title: "2014 Ruby Hero Award Nominations"
+author: "Gregg Pollack"
+date: 2014-02-12 14:02:03 UTC
+lang: en
+---
+
+Has anyone helped you greatly in the Ruby community this year? Maybe they
+taught you something, wrote a gem, or gave you some tech support? If anyone
+comes to mind, then please take the time to
+[nominate them](http://rubyheroes.com/) for a Ruby Hero Award.  
+
+In the past 6 years we've given away 38 trophies to those in our community who
+don't get the recognition they deserve. In three weeks, the Ruby Heroes from
+all previous years will look at the nominations and decide who should receive
+the awards (this way there’s no popularity contest). However, your nominations
+do matter, so please take a moment and spread the gratitude.
+[Vote today!](http://rubyheroes.com/)
+


### PR DESCRIPTION
Blob post announcing the 2014 Ruby Hero Awards.
