### PR TITLE
Reword mentions of MRI on about and security page (en)

### DIFF
--- a/en/about/index.md
+++ b/en/about/index.md
@@ -183,9 +183,10 @@ Ruby has a wealth of other features, among which are the following:
 
 ### Other Implementations of Ruby
 
-Ruby, as a language, has a few different implementations. This page has
-been discussing the reference implementation, **MRI** (“Matz's Ruby
-Interpreter”) or **CRuby**, but there are also others.
+Ruby, as a language, has a few different implementations.
+This page has been discussing the reference implementation, in the
+community often referred to as **MRI** (“Matz’s Ruby Interpreter”)
+or **CRuby** (since it is written in C), but there are also others.
 They are often useful in certain situations, provide extra
 integration to other languages or environments, or have special features
 that MRI doesn’t.

--- a/en/security/index.md
+++ b/en/security/index.md
@@ -14,7 +14,7 @@ security@ruby-lang.org ([the PGP public key](/security.asc)), which is a
 private mailing list. Reported problems will be published after fixes.
 
 The members of the mailing list are people who provide Ruby
-(MRI committers, authors of other Ruby implementations,
+(Ruby committers and authors of other Ruby implementations,
 distributors, PaaS platformers).
 
 ## Known issues


### PR DESCRIPTION
"MRI" and "CRuby" are not officially used by the ruby-core team.

See also discussion on 9c315c328549e09c9a61d79db047ca28b66895ed.
