### PR TITLE
Introduce new about/website page (en)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1805,12 +1805,8 @@ locales:
       Verbesserung dieser Seite mitwirken oder sich bei Fragen oder Kommentaren an
       unseren <a href="mailto:webmaster@ruby-lang.org">Webmaster</a> wenden (in Englisch).
     en: |
-      This website was generated with Ruby using <a href="http://www.jekyllrb.com/">Jekyll</a>.
-      It is proudly maintained by members of the Ruby community.
-      Design by <a href="http://twitter.com/jz">Jason Zimdars</a>.
-      Please contribute on <a href="https://github.com/ruby/www.ruby-lang.org/">GitHub</a>
-      or contact our <a href="mailto:webmaster@ruby-lang.org">webmaster</a>
-      for questions or comments concerning this website.
+      <a href="/en/about/website/">This website</a> is proudly maintained
+      by members of the Ruby community.
     es: |
       Este sitio web está desarrollado con Ruby y <a href="http://www.jekyllrb.com/">Jekyll</a>
       y es orgullosamente mantenido por miembros de la comunidad.
@@ -1875,8 +1871,6 @@ locales:
       請聯絡<a href="mailto:webmaster@ruby-lang.org">網站管理員</a>。
 
   logo_credit:
-    en: |
-      <a href="/en/about/logo/">The Ruby Logo</a> is Copyright &copy; 2006, Yukihiro Matsumoto; licensed under the terms of the <a href="http://creativecommons.org/licenses/by-sa/2.5/">CC BY-SA 2.5</a>.
     pl: |
       <a href="/pl/about/logo/">Logo Rubiego</a> jest Zastrzeżone &copy; 2006, Yukihiro Matsumoto; licencjonowane na warunkach <a href="http://creativecommons.org/licenses/by-sa/2.5/">CC BY-SA 2.5</a>.
     ru: |

--- a/en/about/website/index.md
+++ b/en/about/website/index.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: "About the Ruby Website"
+lang: en
+---
+
+This website was generated with Ruby using [Jekyll][jekyll],<br>
+its source is hosted on [GitHub][github-repo].
+
+Visual design by [Jason Zimdars][jzimdars].<br>
+Based on an earlier design by the Ruby Visual Identity Team.
+
+[The Ruby logo][logo] is Copyright &copy; 2006, Yukihiro Matsumoto.
+
+
+## Reporting Problems ##
+
+To report a problem use the [issue tracker][github-issues]
+or contact our [webmaster][webmaster] (in English).
+
+
+## How to Contribute ##
+
+This website is proudly maintained by members of the Ruby community.
+
+If you wish to contribute, read the [contribution instructions][github-wiki]
+and just start opening issues or pull requests!
+
+
+## Acknowledgments ##
+
+We thank all committers, authors, translators, and other contributors
+to this website.
+
+Also many thanks to the organizations that support us:
+
+ * [NaCl][nacl] (hosting),
+ * [Heroku][heroku] (hosting),
+ * [IIJ][iij] (hosting),
+ * [GlobalSign][globalsign] (SSL certification),
+ * [Fastly][fastly] (CDN).
+
+
+[logo]: /en/about/logo/
+[webmaster]: mailto:webmaster@ruby-lang.org
+[jekyll]: http://www.jekyllrb.com/
+[jzimdars]: http://twitter.com/jz
+[github-repo]: https://github.com/ruby/www.ruby-lang.org/
+[github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
+[github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki
+[nacl]: http://www.netlab.jp
+[heroku]: https://www.heroku.com/
+[iij]: http://www.iij.ad.jp
+[globalsign]: https://www.globalsign.com
+[fastly]: http://www.fastly.com


### PR DESCRIPTION
@hsbt, @chikamichi, @postmodern, @makimoto, @sorah, @zzak

This commit moves most of the contents of the credits footer to a dedicated page, `en/about/website`.
IMO the footer got too crowded by now, and a separate page could contain additional information.

Please comment on:
- what must stay in the footer
- what content is still missing on about/website
- do we need to add more legal information (license), and where?

Currently proposed, highly stripped-down footer:

> `<a href="/en/about/website/">This website</a> is proudly maintained
>       by members of the Ruby community.`

I don't want to merge before we agreed on a in some degree "final" version.
