### PR TITLE
Improve 2.1.1 regression and update 2.1.1 release news (fr)

### DIFF
--- a/fr/news/_posts/2014-02-24-ruby-2-1-1-is-released.md
+++ b/fr/news/_posts/2014-02-24-ruby-2-1-1-is-released.md
@@ -22,6 +22,9 @@ et le [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_1_1/ChangeLog) pou
 Par rapport à la précédente annonce sur le [passage au versionnage sémantique de Ruby 2.1](https://www.ruby-lang.org/fr/news/2013/12/21/semantic-versioning-after-2-1-0/),
 cette version s'appelle simplement "2.1.1".
 
+**Mise à jour :** Nous avons détecté une régression de la méthode `Hash#reject`.
+Pour plus d'informations, consultez : [Régression de la méthode Hash#reject dans Ruby 2.1.1](https://www.ruby-lang.org/fr/news/2014/03/10/regression-of-hash-reject-in-ruby-2-1-1/).
+
 ## Téléchargement
 
 * <http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2>

--- a/fr/news/_posts/2014-03-10-regression-of-hash-reject-in-ruby-2-1-1.md
+++ b/fr/news/_posts/2014-03-10-regression-of-hash-reject-in-ruby-2-1-1.md
@@ -8,7 +8,7 @@ lang: fr
 ---
 
 Dans les versions de Ruby 2.1.0 et inférieures, la méthode `reject` des classes
-héritantées de `Hash` retourne un objet de cette sous-classe. Mais en Ruby 2.1.1,
+héritées de `Hash` retourne un objet de cette sous-classe. Mais en Ruby 2.1.1,
 ce comportement a accidentellement changé pour retourner constamment un objet de
 la classe `Hash`.
 
@@ -25,13 +25,13 @@ p SubHash.new.reject { }.class
 (Pour être exact, les autres états comme les variables d'instance et autres ne
 sont pas copiés non plus.)
 
-Ruby 2.1.1 n'aurait pas du inclure ce changement de comportement car depuis la
+Ruby 2.1.1 n'aurait pas dû inclure ce changement de comportement car depuis la
 sortie de Ruby 2.1.0, nous avons changé la
 [politique de versionnage](https://www.ruby-lang.org/fr/news/2013/12/21/semantic-versioning-after-2-1-0/),
 par conséquent, Ruby 2.1.1 est une version patch et ne doit contenir ce type
 de changement de comportement.
 
-Cette régression peut affecter potentiellement plusieurs librairies, parmi
+Cette régression peut affecter potentiellement plusieurs bibliothèques, parmi
 lesquels `HashWithIndifferentAccess` ou encore `OrderedHash` de Rails.
 Exemple de
 [ticket Rails](https://github.com/rails/rails/issues/14188).


### PR DESCRIPTION
Hi,

Here is the improving of the French news about the Ruby 2.1.1 regression according to the suggestions of @nono and @chatgris. And the updating of the Ruby 2.1.1 release French news with the paragraph about the regression.

cc @stomar

Thanks.
