### PR TITLE
Add post: RubyConf Taiwan 2014 registration now open.

### DIFF
--- a/en/news/_posts/2014-03-14-rubyconf-taiwan-2014.md
+++ b/en/news/_posts/2014-03-14-rubyconf-taiwan-2014.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "RubyConf Taiwan 2014 Registration Now Open"
+author: "Juanito Fatas"
+translator:
+date: 2014-03-14 05:58:31 +0000
+lang: en
+---
+
+RubyConf Taiwan 2014 will be held in Taipei, Taiwan on 25-26 April, 2014.
+
+For details about speakers and schedule please visit the [conference site](http://rubyconf.tw/2014/) and the [RubyConf Taiwan press release](http://rubytaiwan.tumblr.com/post/79134654151/rubyconftaiwan2014-press-release-en).
+
+Tickets are open till March 31st, 2014.
+
+[Reserve Your Ticket!](http://rubytaiwan.kktix.cc/events/rubyconftw2014?locale=en)


### PR DESCRIPTION
Post announcing the RubyConf Taiwan 2014 registration is now open.
