### PR TITLE
Fix wordings about mailing list members in the security page (en)

### DIFF
--- a/en/security/index.md
+++ b/en/security/index.md
@@ -13,9 +13,10 @@ Security vulnerabilities should be reported via an email to
 security@ruby-lang.org ([the PGP public key](/security.asc)), which is a
 private mailing list. Reported problems will be published after fixes.
 
-The members of the mailing list are people (human, not ML) who provide Ruby
+The members of the mailing list are people who provide Ruby
 (Ruby committers and authors of other Ruby implementations,
 distributors, PaaS platformers).
+The members must be individual people, mailing lists are not permitted.
 
 ## Known issues
 


### PR DESCRIPTION
rel to #702.
I don't know about the contexts well, but my understanding is that #702 may be intended as this patch.

@nurse how bout it?
