### PR TITLE
Replace dead railsapi.com with lively RubyDocs.org

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -69,7 +69,7 @@ lang: bg
 [rdoc.info][14]
 : Your source for open source Ruby documentation.
 
-[Rails Searchable API Doc][15]
+[Ruby & Rails Searchable API Docs][15]
 : Rails и Ruby документация с възможност за умно търсене.
 
 [RubyDox][16]
@@ -96,7 +96,7 @@ lang: bg
 [12]: http://www.ruby-doc.org/stdlib
 [13]: http://www.ruby-doc.org/doxygen/current/
 [14]: http://rdoc.info/
-[15]: http://railsapi.com/
+[15]: http://rubydocs.org/
 [16]: http://www.rubydox.net/
 [17]: http://ruby-doc.org
 [18]: http://www.ruby-doc.org/bookstore

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -89,7 +89,7 @@ will come in handy when you feel like coding in Ruby.
 : The one-stop web site for reference documentation about Ruby gems and
   GitHub-hosted Ruby projects.
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : Rails and Ruby documentation with smart searching.
 
 [APIdock][18]
@@ -152,7 +152,7 @@ list](/en/community/mailing-lists/) is a great place to start.
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -111,7 +111,7 @@ dominante en informatique. Bon courage !
 [rubydoc.info][20]
 : Documentation auto-générée pour un grand nombre de bibliothèques Ruby.
 
-[Rails Searchable API Doc][21]
+[Ruby & Rails Searchable API Docs][21]
 : Documentation sur les API Ruby et Ruby On Rails, proposant un système
   de recherche poussé.
 
@@ -150,7 +150,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [18]: http://www.ruby-doc.org/stdlib
 [19]: http://www.ruby-doc.org/doxygen/current/
 [20]: http://rubydoc.info/
-[21]: http://railsapi.com/
+[21]: http://rubydocs.org/
 [22]: http://www.rubydox.net/
 [23]: http://ruby-doc.org
 [24]: http://www.ruby-doc.org/bookstore

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -93,7 +93,7 @@ akan berguna ketika Anda merasa seperti coding di Ruby.
 : Situs web lengkap untuk dokumentasi referensi tentang gem Ruby dan
   proyek Ruby yang di-host di GitHub.
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : Dokumentasi Rails dan Ruby yang dilengkapi dengan pencarian cerdas.
 
 [APIdock][18]
@@ -154,7 +154,7 @@ adalah tempat yang baik untuk memulai.
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -96,7 +96,7 @@ ed arrivano fino alla programmazione OOP e lo sviluppo web.
 : La prima fermata per documentazione di riferimento su gemme
   e progetti Ruby su GitHub.
 
-[API Doc ricercabile per Rails e Ruby][17]
+[Ruby & Rails Searchable API Docs][17]
 : Documentazione ricercabile per Rails e Ruby.
 
 [APIdock][18]
@@ -159,7 +159,7 @@ iniziare.
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -93,7 +93,7 @@ lang: ko
 : 루비 젬과 GitHub에서 호스팅 되는 루비 프로젝트의 레퍼런스 문서들을
   모아놓은 사이트입니다.
 
-[Rails Searchable API Doc][17] (영문)
+[Ruby & Rails Searchable API Docs][17] (영문)
 : 스마트 검색이 가능한 루비, 레일즈 문서입니다.
 
 [APIdock][18] (영문)
@@ -153,7 +153,7 @@ lang: ko
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -99,7 +99,7 @@ Znajdziesz tutaj odnośniki do podręczników, tutoriali i materiałów
 : Strona internetowa z dokumentacją referencyjną gemów Rubiego i
   utrzymywanych na GitHubie projektów Rubiego.
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : Dokumentacja Railsów i Rubiego ze sprytnym wyszukiwaniem.
 
 [APIdock][18]
@@ -162,7 +162,7 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -89,7 +89,7 @@ lang: ru
 : Веб-сайт содержащий в себе документацию о гемах Ruby и Ruby проектах,
   расположенных на GitHub.
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : Rails и Ruby документация с умным поиском.
 
 [APIdock][18]
@@ -151,7 +151,7 @@ lang: ru
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -97,7 +97,7 @@ referanslar ve diğer belgeleri bulacaksınız.
 : Ruby gem’leri için dökümanlar ve GitHub Ruby projeleri için tek kaynak
   site.
 
-[Rails Searchable API Doc][20]
+[Ruby & Rails Searchable API Docs][20]
 : Akıllı arama özellikleri olan Rails ve Ruby dökümantasyonu.
 
 [RubyDox][21]
@@ -133,7 +133,7 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 [17]: http://www.ruby-doc.org/stdlib
 [18]: http://www.ruby-doc.org/doxygen/current/
 [19]: http://www.rubydoc.info/
-[20]: http://railsapi.com/
+[20]: http://rubydocs.org/
 [21]: http://www.rubydox.net/
 [22]: http://ruby-doc.org
 [23]: http://www.ruby-doc.org/bookstore

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -85,7 +85,7 @@ tại đây.
 : Các trang web một cửa cho tài liệu tham khảo về Ruby gems và GitHub chứa các
   dự án Ruby.
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : Tài liệu Rails và Ruby với tìm kiếm thông minh.
 
 [APIdock][18]
@@ -146,7 +146,7 @@ là một nơi tuyệt vời.
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -124,7 +124,7 @@ lang: zh_cn
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -68,7 +68,7 @@ lang: zh_tw
 [RubyDoc.info][16]
 : 一站式站點，擁有 RubyGems 與 GitHub 上托管的 Ruby 專案的文件。
 
-[Rails Searchable API Doc][17]
+[Ruby & Rails Searchable API Docs][17]
 : 可以聰明搜索 Ruby 與 Rails 的文件。
 
 [APIdock][18]
@@ -123,7 +123,7 @@ lang: zh_tw
 [14]: http://rdoc.sourceforge.net
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://railsapi.com/
+[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/


### PR DESCRIPTION
The railsapi.com site has been dead for many months and [the project is moribund](https://github.com/voloko/railsapi.com). It makes sense to replace a dead link with a worthwhile replacement and that's exactly what RubyDocs.org is.

The only issue I have with RubyDoc.org for now is that it's not open source but I pinged @manuelmeurer (the maintainer) on Twitter to see if he could open source what runs [RubyDocs.org](http://rubydocs.org) and [he said he would soon](https://twitter.com/manume/status/464054555429195776).
