### PR TITLE
Installation instructions

### DIFF
--- a/en/installation/index.md
+++ b/en/installation/index.md
@@ -30,7 +30,7 @@ Choose the way that is the most comfortable for you.
   * [RubyInstaller](#rubyinstaller) (Windows)
   * [RailsInstaller and Ruby Stack](#railsinstaller)
 * [Managers](#managers):
-  * [chruby]
+  * [chruby](#chruby)
   * [rbenv](#rbenv)
   * [RVM](#rvm)
   * [pik][pik] (Windows)


### PR DESCRIPTION
- Recommend Debian/Ubuntu users install the [ruby-full](https://packages.debian.org/stable/ruby-full) meta-package.
- Organized the installation instructions by method (package manager, installer, manager, build from source) then by platform/tool.
- Added [ruby-build](https://github.com/sstephenson/ruby-build#readme) and [ruby-install](https://github.com/postmodern/ruby-install#readme) to the Installers list.
- Added [chruby](https://github.com/postmodern/chruby#readme) to the Managers section.
