### PR TITLE
link to redmine issue in Ruby 1.9.3p547 announce (en)

### DIFF
--- a/en/news/_posts/2014-05-16-ruby-1-9-3-p547-released.md
+++ b/en/news/_posts/2014-05-16-ruby-1-9-3-p547-released.md
@@ -19,6 +19,7 @@ such as Ubuntu 10.04 LTS.
 This is a regression introduced in Ruby 1.9.3-p545.
 (The same problem also occurred in Ruby 2.1.1 and Ruby 2.0.0-p451 and has
 already been fixed with Ruby 2.1.2 and Ruby 2.0.0-p481.)
+Please look at [Bug ##9592](https://bugs.ruby-lang.org/issues/9592) for more details.
 So, we decided to release this fix.
 You should only upgrade if you are affected by this problem.
 


### PR DESCRIPTION
I've gotten some comments about how the "problems" are vague. To clear this up, we should just link to the original redmine issue.
