### PR TITLE
Fix download button padding.

### DIFF
--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -4,7 +4,7 @@
     background: #CC342D url(/images/download-ruby-arrow@2x.png) no-repeat 8px center;
     background-size: 30px 25px;
     color: white;
-    padding: 8px 20px 8px 45px;
+    padding: 8px 20px 8px 20px;
     font-size: 16px;
     line-height: 20px;
     text-decoration: none;


### PR DESCRIPTION
Is this by design or should we fix it?

![screenshot 2014-06-21 22 05 01](https://cloud.githubusercontent.com/assets/1000669/3348987/13a1e804-f94d-11e3-82ae-4a3361f05de8.png)

![screenshot 2014-06-21 22 04 52](https://cloud.githubusercontent.com/assets/1000669/3348988/13a4ad46-f94d-11e3-934f-ffcab18941d9.png)
