### PR TITLE
Add latest news posts (ja): Rubyist Magazine 0047

### DIFF
--- a/ja/news/_posts/2014-06-30-rubyist-magazine-0047-published.md
+++ b/ja/news/_posts/2014-06-30-rubyist-magazine-0047-published.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0047号 発行"
+author: "sunaot"
+date: 2014-06-30 19:30:00 UTC
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist
+Magazine][2]の[0047号][3]がリリースされました([\[ruby-list:49858\]][4])。 お楽しみください。
+
+
+[1]: http://ruby-no-kai.org
+[2]: http://jp.rubyist.net/magazine/
+[3]: http://jp.rubyist.net/magazine/?0047
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49858


### PR DESCRIPTION
A new post about the Rubyist Magazine 0047 release to people who read Japanese.
