### PR TITLE
Remove link to planetrubyonrails.org

### DIFF
--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -16,7 +16,6 @@ for years now. A few of them providing convenient content:
 
 * [Ruby Corner][4]
 * [Planet Ruby][5]
-* [PlanetRubyOnRails.org][6]
 * [PlanetRubyOnRails.com][7]
 
 ### Blogs of Note
@@ -51,7 +50,6 @@ some brilliant code out there, be sure to let them know!
 
 [4]: http://rubycorner.com
 [5]: http://planetruby.0x42.net/
-[6]: http://www.planetrubyonrails.org/
 [7]: http://www.planetrubyonrails.com/
 [8]: http://oreillynet.com/ruby/
 [9]: http://weblog.rubyonrails.org/


### PR DESCRIPTION
That website doesn't seem to be an aggregator any more, looks spamish now. It should not be linked to from the weblogs page.
