### PR TITLE
unlocked version of heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.1.2
+rvm: 2.1
 cache: bundler
 deploy:
   provider: heroku
@@ -8,6 +8,7 @@ deploy:
     secure: h0Z7JDyY3iqOhCgbamAif+D0P7QrznxMut6riZrpsWjJoBX46Z1GEOlZYrlxTnSufI8BisPY4/KoG/7hzrBD4gDnl3vxRBQ2YK9Iql04JMoCs1vhoZ1LWNAYB9L38K6OjkB/Fq7Xqjy54zgnU+an1jlK+a3i/mlVbJ7gNQRoepY=
   app: staging-ruby-lang
   on:
-    rvm: 2.1.2
+    rvm: 2.1
     repo: ruby/www.ruby-lang.org
     branch: master
+env: DEV=1


### PR DESCRIPTION
ruby version on Gemfile is only need for heroku environment, therefore I make disabled to this option on travis. and specifying to ruby version with rvm is needless tiny version after Ruby 2.1. I removed it.
