### PR TITLE
Fix link to ChangeLog

### DIFF
--- a/ja/news/_posts/2014-09-19-ruby-2-1-3-is-released.md
+++ b/ja/news/_posts/2014-09-19-ruby-2-1-3-is-released.md
@@ -11,7 +11,7 @@ Ruby 2.1.3 がリリースされました。これは安定版 2.1 系のパッ�
 
 今回のリリースには、full GC タイミングの変更によるメモリ使用量抑制([Bug #9607](https://bugs.ruby-lang.org/issues/9607) 参照)や、その他多数の不具合修正が含まれます。
 
-詳しくは対応する[チケット](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)および[ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_1_2/ChangeLog)を確認してください。
+詳しくは対応する[チケット](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)および[ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_1_3/ChangeLog)を確認してください。
 
 ## ダウンロード
 


### PR DESCRIPTION
Ruby 2.1.3 release announce (ja) refers the ChangeLog of `v2_1_2`.
