### PR TITLE
Use Ruby 2.1.3 in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.1.3' unless ENV['DEV']
+ruby '2.1.3'
 
 gem 'rake',   '~> 10.0'
 gem 'jekyll', '~> 1.0'


### PR DESCRIPTION
@hsbt

The DEV environment apparently has been used for travis, but it was removed with 5eb22b5ca651e4e07869d7a5f5bd9262d5bd037d.
Is it still necessary to use other Ruby versions?
