### PR TITLE
Upgrade to Ruby 2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.1
+rvm: 2.1.4
 cache: bundler
 deploy:
   provider: heroku
@@ -9,6 +9,6 @@ deploy:
     secure: h0Z7JDyY3iqOhCgbamAif+D0P7QrznxMut6riZrpsWjJoBX46Z1GEOlZYrlxTnSufI8BisPY4/KoG/7hzrBD4gDnl3vxRBQ2YK9Iql04JMoCs1vhoZ1LWNAYB9L38K6OjkB/Fq7Xqjy54zgnU+an1jlK+a3i/mlVbJ7gNQRoepY=
   app: staging-ruby-lang
   on:
-    rvm: 2.1
+    rvm: 2.1.4
     repo: ruby/www.ruby-lang.org
     branch: master

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.1.3'
+ruby '2.1.4'
 
 gem 'rake',   '~> 10.0'
 gem 'jekyll', '~> 1.0'


### PR DESCRIPTION
@hsbt

Change version in Gemfile **and** .travis.yml to "2.1.4".

Using the "fuzzy matcher" `2.1` in .travis.yml (see c807ef2c1e9f16f195b152f42f2bbc6cd7feddb6) does not work at the moment, see @hone's PR (issue #869). Travis will use rvm with 2.1.3, and the build fails due to mismatch of the version specified in Gemfile and the actual Ruby version.
