### PR TITLE
Put post date and author at the top of news_post layouts

### DIFF
--- a/_layouts/news_post.html
+++ b/_layouts/news_post.html
@@ -12,10 +12,9 @@ layout: default
   {% include title.html %}
 
   <div id="content">
-    {{ content }}
-
     <p class="post-info">{{ page.date | posted_by:page.author }}{% if page.translator %}<br />
                          {{ translated_by }} {{ page.translator }}{% endif %}</p>
+    {{ content }}
   </div>
 </div>
 <hr class="hidden-modern" />


### PR DESCRIPTION
News are news because of their timeliness, it's crucial for especially
release news posts to have their date displayed in a location that is
immediately obvious for readers: below the title.

Here's how ruby-lang.org news post currently display dates:
![image](https://cloud.githubusercontent.com/assets/65950/5034587/1c49b06e-6b25-11e4-9653-c53dab576f1b.png)
![image](https://cloud.githubusercontent.com/assets/65950/5034602/3de528f2-6b25-11e4-96e6-2d01a266924d.png)

Here's how it will look if you merge this in:
![image](https://cloud.githubusercontent.com/assets/65950/5034616/49ebfd1a-6b25-11e4-8967-2e0c0903de70.png)
