### PR TITLE
Start installation page with short description of available options

### DIFF
--- a/en/installation/index.md
+++ b/en/installation/index.md
@@ -13,6 +13,17 @@ and how to build Ruby from source.
 
 ## Choose Your Installation Method
 
+There are several ways to install Ruby:
+
+* When you are on a UNIX-like operating system, using your system's
+  **package manager** is the easiest way of getting started.
+  However, the packaged Ruby version usually is not the newest one.
+* **Installers** can be used to install a specific or multiple
+  Ruby versions. There is also an installer for Windows.
+* **Managers** help you to switch between multiple Ruby installations
+  on your system.
+* And finally, you can also **build Ruby from source**.
+
 The following overview lists available installation methods
 for different needs and platforms.
 


### PR DESCRIPTION
Provide a very short description of each of the installation methods on the very top of the page.
Directly starting with the list of options might be too overwhelming especially for beginners.

@postmodern A short feedback would be highly welcome.
PS. Can I delete your `installation_instructions` branch? It has been merged.
