### PR TITLE
Add "Installing Ruby" to documentation page (en)

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -8,6 +8,21 @@ Here you will find pointers to manuals, tutorials and references that
 will come in handy when you feel like coding in Ruby.
 {: .summary}
 
+### Installing Ruby
+
+Unless you only want to try Ruby in the browser (see the links below)
+you need to have Ruby installed on your computer.
+You can check whether Ruby already is available by opening a terminal
+and typing
+
+{% highlight sh %}
+ruby -v
+{% endhighlight %}
+
+This should output some information on the installed Ruby version.
+If not, see the [installation page][installation] for various options
+of getting Ruby.
+
 ### Getting Started
 
 [Try Ruby!][1]
@@ -136,6 +151,7 @@ list](/en/community/mailing-lists/) is a great place to start.
 
 
 
+[installation]: /en/documentation/installation/
 [1]: http://tryruby.org/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/


### PR DESCRIPTION
Mention installation on `documentation` page and also link to the `installation` page.
