### PR TITLE
Fix Rails blog link in 2.2.0-rc1 release post.

### DIFF
--- a/en/news/_posts/2014-12-18-ruby-2-2-0-rc1-released.md
+++ b/en/news/_posts/2014-12-18-ruby-2-2-0-rc1-released.md
@@ -19,7 +19,7 @@ This reduces memory usage of Symbols; because GC was previously unable to collec
 Since Rails 5.0 will require Symbol GC, it will support only Ruby 2.2
 or later. (See [Rails' blog post](http://weblog.rubyonrails.org/2014/8/20/Rails-4-2-beta1/) for details.)
 
-Also, a reduced pause time thanks to the new Incremental Garbage Collector will be helpful for running Rails applications. Recent developments mentioned on the [Rails' blog post](weblog.rubyonrails.org) suggest that Rails 5.0 will take advantage of Incremental GC as well as Symbol GC.
+Also, a reduced pause time thanks to the new Incremental Garbage Collector will be helpful for running Rails applications. Recent developments mentioned on the [Rails 4.2 release post](http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/) suggest that Rails 5.0 will take advantage of Incremental GC as well as Symbol GC.
 
 Another feature related to memory management is an additional option for `configure.in` to use jemalloc
 [Feature #9113](https://bugs.ruby-lang.org/issues/9113).


### PR DESCRIPTION
[2.2.0-rc1 release post](https://www.ruby-lang.org/en/news/2014/12/18/ruby-2-2-0-rc1-released/) contains a dead link (see below photo):

![screenshot 2014-12-20 18 00 39](https://cloud.githubusercontent.com/assets/1000669/5514461/2207dbec-8872-11e4-921a-8e33fe820135.png)

> Rails 5.0 will target Ruby 2.2+ exclusively. There are a bunch of optimizations coming in Ruby 2.2 that are going to be very nice, but most importantly for Rails, symbols are going to be garbage collected. This means we can shed a lot of weight related to juggling strings when we accept input from the outside world. It also means that we can convert fully to keyword arguments and all the other good stuff from the latest Ruby.

Please :eyes: 

:balloon: 
