### PR TITLE
Update downloads page (en)

### DIFF
--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -42,8 +42,12 @@ one of the third party tools mentioned above. They may help you.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   md5: {{ site.downloads.previous.md5.gz }}
 
-* **Old stable:**
-  [Ruby {{ site.downloads.previous19.version }}][old-gz]<br>
+* **Old stable (2.0.0 series):**
+  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
+  md5: {{ site.downloads.previous20.md5.gz }}
+
+* **Old stable (1.9.3 series):**
+  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
   md5: {{ site.downloads.previous19.md5.gz }}
 
 * **Snapshots:**
@@ -66,7 +70,8 @@ Please try to use a mirror that is near you.
 [installation]: /en/documentation/installation/
 [stable-gz]:   {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[old-gz]:      {{ site.downloads.previous19.url.gz }}
+[previous20-gz]:      {{ site.downloads.previous20.url.gz }}
+[previous19-gz]:      {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/


### PR DESCRIPTION
With release of Ruby 2.2, list two "old" branches: 2.0.0 and 1.9.3.

Waiting for the preview... then I'll merge.
