### PR TITLE
Slightly trim Ruby 2.2.0 release post (en)

### DIFF
--- a/en/news/_posts/2014-12-25-ruby-2-2-0-released.md
+++ b/en/news/_posts/2014-12-25-ruby-2-2-0-released.md
@@ -17,12 +17,8 @@ This reduces memory usage of Symbols; because GC was previously unable
 to collect them before 2.2.
 Since Rails 5.0 will require Symbol GC, it will support only Ruby 2.2 or later.
 (See [Rails 4.2 release post](http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/) for details.)
-
 Also, a reduced pause time thanks to the new Incremental Garbage Collector will
-be helpful for running Rails applications. Recent developments mentioned on the
-[Rails blog](http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/)
-suggest that Rails 5.0 will take advantage of Incremental GC as well as
-Symbol GC.
+be helpful for running Rails applications.
 
 Another feature related to memory management is an additional option
 for `configure.in` to use jemalloc


### PR DESCRIPTION
@hsbt @nurse

The release post rather vaguely states that:

```
Recent developments mentioned on the Rails blog* suggest that Rails 5.0 will take
advantage of Incremental GC as well as Symbol GC.

* link to Rails 4.2 release post
```

I couldn't find mention of Incremental GC anywhere on the Rails blog, especially not in the linked Rails 4.2. release post. And Symbol GC is already mentioned in the previous paragraph. So please consider to

1. remove this sentence (see this PR)
2. or provide a better reference

PS. Also, having SHA1 checksums would be nice, see #921.