### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ it will be available instantly.
 In case a build is not possible on your local machine
 you can also create a preview on Heroku.
 
-* Signup [Heroku](http://www.heroku.com) if you don't have an account yet.
+* Sign up for [Heroku](http://www.heroku.com) if you don't have an account yet.
 * Install [Heroku Toolbelt](https://toolbelt.heroku.com).
 * Clone repository.
 


### PR DESCRIPTION
Changed "Signup Heroku" to "Sign up for Heroku." I separated the word "Signup" into two words and chose the preposition "for" (and not "at," "with," or "on") because I saw Heroku ads in Google search results using that format (e.g. "Sign Up For Heroku, Free").