### PR TITLE
Use sha2 digest instead of md5 for tar package.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,10 +30,10 @@ downloads:
       xz: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.xz
       zip: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.zip
     sha2:
-      bz2: d03cd4690fec1fff81d096d1c1255fde
-      gz: cd03b28fd0b555970f5c4fd481700852
-      xz: 54b43c6c6c9dd4c4b08ceb03ad0ded7a
-      zip: f8e1d0cee4f2d9535a9529ed23ae3700
+      bz2: 1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955
+      gz: 7671e394abfb5d262fbcd3b27a71bf78737c7e9347fa21c39e58b0bb9c4840fc
+      xz: 848714e280fc5fb44dbac3b060b206e56c1947006324ee68a174d68b483ef8ca
+      zip: e06c1e2b1248cf881749833084b2bec93f7612676009190ff9bc89b8fd07c29f
   previous:
     version: 2.1.5
     url:
@@ -41,9 +41,9 @@ downloads:
       gz: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.zip
     sha2:
-      bz2: a7c3e5fec47eff23091b566e9e1dac1b
-      gz: df4c1b23f624a50513c7a78cb51a13dc
-      zip: 810cd05eb03c00f89b0b03b10e9a3606
+      bz2: 0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9
+      gz: 4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100
+      zip: 22ba1eb8d475c9ed7e0541418d86044c1ea4c093ab79c300c38fc0f721afe9a3
   previous20:
     version: 2.0.0-p598
     url:
@@ -51,9 +51,9 @@ downloads:
       gz: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.zip
     sha2:
-      bz2: a3f3908103a7d209d1d1cf4712e3953c
-      gz: e043a21ce0d138fd408518a80aa31bba
-      zip: aa6ac22747947e6562d5b0dc9767ecda
+      bz2: 67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f
+      gz: 4136bf7d764cbcc1c7da2824ed2826c3550f2b62af673c79ddbf9049b12095fd
+      zip: 9dccf4c30e1bb004b18cb1129d9daac3c0ec510a671f4f4f13a2747897ffab35
   previous19:
     version: 1.9.3-p551
     url:
@@ -61,9 +61,9 @@ downloads:
       gz: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip
     sha2:
-      bz2: 0d8b272b05c3449dc848bb7570f65bfe
-      gz: 0d8212f7bc89bab8ef521b04cd9df278
-      zip: 14a394b1d7b7031b34d4d1af64ee657e
+      bz2: b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e
+      gz: bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8
+      zip: 44228297861f4dfdf23a47372a3e3c4c5116fbf5b0e10883417f2379874b55c6
   stable_snapshot:
     url:
       bz2: https://ftp.ruby-lang.org/pub/ruby/stable-snapshot.tar.bz2

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ downloads:
       gz: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz
       xz: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.xz
       zip: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.zip
-    sha2:
+    sha256:
       bz2: 1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955
       gz: 7671e394abfb5d262fbcd3b27a71bf78737c7e9347fa21c39e58b0bb9c4840fc
       xz: 848714e280fc5fb44dbac3b060b206e56c1947006324ee68a174d68b483ef8ca
@@ -40,7 +40,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.zip
-    sha2:
+    sha256:
       bz2: 0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9
       gz: 4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100
       zip: 22ba1eb8d475c9ed7e0541418d86044c1ea4c093ab79c300c38fc0f721afe9a3
@@ -50,7 +50,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.zip
-    sha2:
+    sha256:
       bz2: 67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f
       gz: 4136bf7d764cbcc1c7da2824ed2826c3550f2b62af673c79ddbf9049b12095fd
       zip: 9dccf4c30e1bb004b18cb1129d9daac3c0ec510a671f4f4f13a2747897ffab35
@@ -60,7 +60,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip
-    sha2:
+    sha256:
       bz2: b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e
       gz: bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8
       zip: 44228297861f4dfdf23a47372a3e3c4c5116fbf5b0e10883417f2379874b55c6

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ downloads:
       gz: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz
       xz: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.xz
       zip: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.zip
-    md5:
+    sha2:
       bz2: d03cd4690fec1fff81d096d1c1255fde
       gz: cd03b28fd0b555970f5c4fd481700852
       xz: 54b43c6c6c9dd4c4b08ceb03ad0ded7a
@@ -40,7 +40,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.zip
-    md5:
+    sha2:
       bz2: a7c3e5fec47eff23091b566e9e1dac1b
       gz: df4c1b23f624a50513c7a78cb51a13dc
       zip: 810cd05eb03c00f89b0b03b10e9a3606
@@ -50,7 +50,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.zip
-    md5:
+    sha2:
       bz2: a3f3908103a7d209d1d1cf4712e3953c
       gz: e043a21ce0d138fd408518a80aa31bba
       zip: aa6ac22747947e6562d5b0dc9767ecda
@@ -60,7 +60,7 @@ downloads:
       bz2: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2
       gz: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
       zip: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip
-    md5:
+    sha2:
       bz2: 0d8b272b05c3449dc848bb7570f65bfe
       gz: 0d8212f7bc89bab8ef521b04cd9df278
       zip: 14a394b1d7b7031b34d4d1af64ee657e

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -39,19 +39,19 @@ Ruby може да бъде инсталиран и от изходен код �
 
 * **Текуща стабилна версия:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Предишна стабилна версия:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Стара стабилна версия (серия 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Стара стабилна версия (серия 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -39,19 +39,19 @@ Ruby може да бъде инсталиран и от изходен код �
 
 * **Текуща стабилна версия:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Предишна стабилна версия:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Стара стабилна версия (серия 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Стара стабилна версия (серия 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -38,19 +38,19 @@ vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
 
 * **Stabile Version:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Stabile Vorgängerversion:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Stabile Vorgängerversion (2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Stabile Vorgängerversion (1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -38,19 +38,19 @@ vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
 
 * **Stabile Version:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Stabile Vorgängerversion:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Stabile Vorgängerversion (2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Stabile Vorgängerversion (1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -36,19 +36,19 @@ one of the third party tools mentioned above. They may help you.
 
 * **Current stable:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Previous stable:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Old stable (2.0.0 series):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Old stable (1.9.3 series):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -36,19 +36,19 @@ one of the third party tools mentioned above. They may help you.
 
 * **Current stable:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Previous stable:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Old stable (2.0.0 series):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Old stable (1.9.3 series):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -40,11 +40,11 @@ Si tienes algún problema compilando Ruby, considera usar una de las herramienta
 de terceros en la sección siguiente. Pueden servirte de ayuda.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Versión Estable (*recomendada*)
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }}) Versión Estable (*recomendada*)
 * [Ruby {{ site.downloads.previous.version }}][previous-gz]
-  (sha2:&nbsp;{{ site.downloads.previous.sha2.gz }}) Versión Previa
+  (sha256:&nbsp;{{ site.downloads.previous.sha256.gz }}) Versión Previa
 * [Ruby {{ site.downloads.previous19.version }}][old-gz]
-  (sha2:&nbsp;{{ site.downloads.previous19.sha2.gz }}) Versión Previa 1.9
+  (sha256:&nbsp;{{ site.downloads.previous19.sha256.gz }}) Versión Previa 1.9
 * [Snapshot estable][stable-snapshot-gz] Ultima versión (*estable*)
   del repositorio (ruby\_2\_1).
 * [Snapshot diario][nightly-gz] Ultima versión de lo que exista en SVN,

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -40,11 +40,11 @@ Si tienes algún problema compilando Ruby, considera usar una de las herramienta
 de terceros en la sección siguiente. Pueden servirte de ayuda.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }}) Versión Estable (*recomendada*)
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Versión Estable (*recomendada*)
 * [Ruby {{ site.downloads.previous.version }}][previous-gz]
-  (md5:&nbsp;{{ site.downloads.previous.md5.gz }}) Versión Previa
+  (sha2:&nbsp;{{ site.downloads.previous.sha2.gz }}) Versión Previa
 * [Ruby {{ site.downloads.previous19.version }}][old-gz]
-  (md5:&nbsp;{{ site.downloads.previous19.md5.gz }}) Versión Previa 1.9
+  (sha2:&nbsp;{{ site.downloads.previous19.sha2.gz }}) Versión Previa 1.9
 * [Snapshot estable][stable-snapshot-gz] Ultima versión (*estable*)
   del repositorio (ruby\_2\_1).
 * [Snapshot diario][nightly-gz] Ultima versión de lo que exista en SVN,

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -43,9 +43,9 @@ leur environnement. C’est également la solution à adopter par défaut
 lorsqu’aucun paquetage « tout compris » n’existe pour votre plateforme.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }}) Version stable (*recommandée*)
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Version stable (*recommandée*)
 * [Ruby {{ site.downloads.previous.version }}][previous-gz]
-  (md5:&nbsp;{{ site.downloads.previous.md5.gz }}) Version précédente
+  (sha2:&nbsp;{{ site.downloads.previous.sha2.gz }}) Version précédente
 * [Stable Snapshot][stable-snapshot-gz] Archive de la dernière version stable du SVN
   (ruby\_2\_0\_0). A priori plus à jour que la dernière version stable
   publique.

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -43,9 +43,9 @@ leur environnement. C’est également la solution à adopter par défaut
 lorsqu’aucun paquetage « tout compris » n’existe pour votre plateforme.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Version stable (*recommandée*)
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }}) Version stable (*recommandée*)
 * [Ruby {{ site.downloads.previous.version }}][previous-gz]
-  (sha2:&nbsp;{{ site.downloads.previous.sha2.gz }}) Version précédente
+  (sha256:&nbsp;{{ site.downloads.previous.sha256.gz }}) Version précédente
 * [Stable Snapshot][stable-snapshot-gz] Archive de la dernière version stable du SVN
   (ruby\_2\_0\_0). A priori plus à jour que la dernière version stable
   publique.

--- a/id/downloads/index.md
+++ b/id/downloads/index.md
@@ -150,7 +150,7 @@ konfigurasi yang spesifik. Apabila tidak ada paket distribusi siap pakai
 untuk sistem operasi Anda, alternatif ini juga solusi yang baik.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }}) Stable (*dianjurkan*)
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Stable (*dianjurkan*)
 * [Ruby 1.9.3 preview1][22] (md5:&nbsp;0f0220be4cc7c51a82c1bd8f6a0969f3)
 * [Stable Snapshot][stable-snapshot-gz]
 * [Nightly Snapshot][nightly-gz] Ini adalah versi paling mutakhir langsung dari

--- a/id/downloads/index.md
+++ b/id/downloads/index.md
@@ -150,7 +150,7 @@ konfigurasi yang spesifik. Apabila tidak ada paket distribusi siap pakai
 untuk sistem operasi Anda, alternatif ini juga solusi yang baik.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Stable (*dianjurkan*)
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }}) Stable (*dianjurkan*)
 * [Ruby 1.9.3 preview1][22] (md5:&nbsp;0f0220be4cc7c51a82c1bd8f6a0969f3)
 * [Stable Snapshot][stable-snapshot-gz]
 * [Nightly Snapshot][nightly-gz] Ini adalah versi paling mutakhir langsung dari

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -42,15 +42,15 @@ esserti di aiuto.
 
 * **Stabile:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Stabile Precedente:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Vecchia Stabile:**
   [Ruby {{ site.downloads.previous19.version }}][old-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -42,15 +42,15 @@ esserti di aiuto.
 
 * **Stabile:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Stabile Precedente:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Vecchia Stabile:**
   [Ruby {{ site.downloads.previous19.version }}][old-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -30,19 +30,19 @@ lang: ja
 
 * **最新の安定版:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **前世代の安定版:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **古い安定版 (2.0 系):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **古い安定版 (1.9 系):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **スナップショット:**
   * [安定版のスナップショット][stable-snapshot-gz]:

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -30,19 +30,19 @@ lang: ja
 
 * **最新の安定版:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **前世代の安定版:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **古い安定版 (2.0 系):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **古い安定版 (1.9 系):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **スナップショット:**
   * [安定版のスナップショット][stable-snapshot-gz]:

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -37,19 +37,19 @@ lang: ko
 
 * **안정버전:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **이전버전:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **낡은버전 (2.0.0 시리즈):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **낡은버전 (1.9.3 시리즈):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **스냅샷:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -37,19 +37,19 @@ lang: ko
 
 * **안정버전:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **이전버전:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **낡은버전 (2.0.0 시리즈):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **낡은버전 (1.9.3 시리즈):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **스냅샷:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -38,19 +38,19 @@ skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
 
 * **Obecny stabilny:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Poprzedni stabilny:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Stary stabilny (seria 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Stary stabilny (seria 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Migawki:**
   * [Stabilna migawka][stable-snapshot-gz]:

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -38,19 +38,19 @@ skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
 
 * **Obecny stabilny:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Poprzedni stabilny:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Stary stabilny (seria 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Stary stabilny (seria 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Migawki:**
   * [Stabilna migawka][stable-snapshot-gz]:

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -18,7 +18,7 @@ eventualmente também uma boa solução porque pode não haver pacotes
 pré-construídos para a sua plataforma.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }}) Stable (*recommended*)
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Stable (*recommended*)
 * [Snapshot Estável][stable-snapshot-gz] Ficheiros compactados em tar e gzip do último
   CVS estável. Deverá ser melhor que o última distribuição estável.
 * [Snapshot Nocturno][nightly-gz] Ficheiros compactados em tar e gzip do último

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -18,7 +18,7 @@ eventualmente também uma boa solução porque pode não haver pacotes
 pré-construídos para a sua plataforma.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) Stable (*recommended*)
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }}) Stable (*recommended*)
 * [Snapshot Estável][stable-snapshot-gz] Ficheiros compactados em tar e gzip do último
   CVS estável. Deverá ser melhor que o última distribuição estável.
 * [Snapshot Nocturno][nightly-gz] Ficheiros compactados em tar e gzip do último

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -42,19 +42,19 @@ lang: ru
 
 * **Текущая стабильная:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Предыдущая стабильная:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Старая стабильная (Из 2.0.0 серии):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Старая стабильная (Из 1.9.3 серии):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
  * **Слепки:**
    * [Стабильный слепок][stable-snapshot-gz]:

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -42,19 +42,19 @@ lang: ru
 
 * **Текущая стабильная:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Предыдущая стабильная:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Старая стабильная (Из 2.0.0 серии):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Старая стабильная (Из 1.9.3 серии):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
  * **Слепки:**
    * [Стабильный слепок][stable-snapshot-gz]:

--- a/tr/downloads/index.md
+++ b/tr/downloads/index.md
@@ -16,7 +16,7 @@ ortamınızda özel ayarlar gerekiyorsa uygun çözümdür. Eğer platformunuza
 hazır paket bulunmazsa da uygun olacaktır.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }})
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }})
   Kararlı Versiyon (*tavsiye edilir*)
 * [Stable Snapshot][stable-snapshot-gz] Bu son kararlı SVN’nin tar gzip hali. Son kararlı
   sürümden daha iyi olması beklenir.

--- a/tr/downloads/index.md
+++ b/tr/downloads/index.md
@@ -16,7 +16,7 @@ ortamınızda özel ayarlar gerekiyorsa uygun çözümdür. Eğer platformunuza
 hazır paket bulunmazsa da uygun olacaktır.
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }})
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }})
   Kararlı Versiyon (*tavsiye edilir*)
 * [Stable Snapshot][stable-snapshot-gz] Bu son kararlı SVN’nin tar gzip hali. Son kararlı
   sürümden daha iyi olması beklenir.

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -36,19 +36,19 @@ dụng một trong những công cụ của bên thứ ba đã được đề c�
 
 * **Bản ổn định hiện hành:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **Bản ổn định trước đó:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **Bản ổn định cũ (chuỗi 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **Bản ổn định cũ (chuỗi 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -36,19 +36,19 @@ dụng một trong những công cụ của bên thứ ba đã được đề c�
 
 * **Bản ổn định hiện hành:**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **Bản ổn định trước đó:**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **Bản ổn định cũ (chuỗi 2.0.0):**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **Bản ổn định cũ (chuỗi 1.9.3):**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -13,7 +13,7 @@ lang: zh_cn
 需要安装到您的平台上，这也是一个好的方法。
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (md5:&nbsp;{{ site.downloads.stable.md5.gz }}) 稳定版 (*推荐*)
+  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) 稳定版 (*推荐*)
 * [稳定版快照][stable-snapshot-gz] 这里的 tar’ed 和 gzip’ed 文件是最新稳定的 CVS。它应该比上次发布的版本更稳定。
 * [开发版快照][nightly-gz] 这里的 tar’ed 和 gzip’ed 文件是最新的 CVS。它可能包含一些没有解决的问题。
 

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -13,7 +13,7 @@ lang: zh_cn
 需要安装到您的平台上，这也是一个好的方法。
 
 * [Ruby {{ site.downloads.stable.version }}][stable-gz]
-  (sha2:&nbsp;{{ site.downloads.stable.sha2.gz }}) 稳定版 (*推荐*)
+  (sha256:&nbsp;{{ site.downloads.stable.sha256.gz }}) 稳定版 (*推荐*)
 * [稳定版快照][stable-snapshot-gz] 这里的 tar’ed 和 gzip’ed 文件是最新稳定的 CVS。它应该比上次发布的版本更稳定。
 * [开发版快照][nightly-gz] 这里的 tar’ed 和 gzip’ed 文件是最新的 CVS。它可能包含一些没有解决的问题。
 

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -28,19 +28,19 @@ lang: zh_tw
 
 * **當前穩定版：**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  sha2: {{ site.downloads.stable.sha2.gz }}
+  sha256: {{ site.downloads.stable.sha256.gz }}
 
 * **穩定上一版：**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  sha2: {{ site.downloads.previous.sha2.gz }}
+  sha256: {{ site.downloads.previous.sha256.gz }}
 
 * **舊穩定版（2.0.0 系列）：**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha2: {{ site.downloads.previous20.sha2.gz }}
+  sha256: {{ site.downloads.previous20.sha256.gz }}
 
 * **舊穩定版（1.9.3 系列）：**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha2: {{ site.downloads.previous19.sha2.gz }}
+  sha256: {{ site.downloads.previous19.sha256.gz }}
 
 * **快照：**
   * [Stable Snapshot][stable-snapshot-gz]:

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -28,19 +28,19 @@ lang: zh_tw
 
 * **當前穩定版：**
   [Ruby {{ site.downloads.stable.version }}][stable-gz]<br>
-  md5: {{ site.downloads.stable.md5.gz }}
+  sha2: {{ site.downloads.stable.sha2.gz }}
 
 * **穩定上一版：**
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
-  md5: {{ site.downloads.previous.md5.gz }}
+  sha2: {{ site.downloads.previous.sha2.gz }}
 
 * **舊穩定版（2.0.0 系列）：**
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  md5: {{ site.downloads.previous20.md5.gz }}
+  sha2: {{ site.downloads.previous20.sha2.gz }}
 
 * **舊穩定版（1.9.3 系列）：**
   [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  md5: {{ site.downloads.previous19.md5.gz }}
+  sha2: {{ site.downloads.previous19.sha2.gz }}
 
 * **快照：**
   * [Stable Snapshot][stable-snapshot-gz]:


### PR DESCRIPTION
I got offering to use secure digest without MD5. see https://bugs.ruby-lang.org/issues/10793

I replace md5 to sha2 for download page.