### PR TITLE
Announce 1.9.3 end of life

### DIFF
--- a/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
+++ b/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
@@ -3,7 +3,7 @@ layout: news_post
 title: "Support for Ruby 1.9.3 has ended"
 author: "Olivier Lacan"
 translator:
-date: 2014-02-23 00:00:00 +0000
+date: 2015-02-23 00:00:00 +0000
 lang: en
 ---
 
@@ -12,4 +12,4 @@ from more recent Ruby versions will no longer be backported to 1.9.3.
 
 This end of life was [announced over a year ago](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
 
-We highly recommend that you upgrade to Ruby 2.0 or above as soon as possible.
+We highly recommend that you upgrade to Ruby 2.0.0 or above as soon as possible. Please contact us if you'd like to continue maintaining the 1.9.3 branch or if for some reason you can't upgrade.

--- a/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
+++ b/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
@@ -1,0 +1,15 @@
+---
+layout: news_post
+title: "Support for Ruby 1.9.3 has ended"
+author: "Olivier Lacan"
+translator:
+date: 2014-02-23 00:00:00 +0000
+lang: en
+---
+
+As of today, all support for Ruby 1.9.3 has ended. Bug and security fixes
+from more recent Ruby versions will no longer be backported to 1.9.3.
+
+This end of life was [announced over a year ago](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
+
+We highly recommend that you upgrade to Ruby 2.2 or 2.1 as soon as possible.

--- a/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
+++ b/en/news/_posts/2014-02-23-support-for-ruby-1-9-3-has-ended.md
@@ -12,4 +12,4 @@ from more recent Ruby versions will no longer be backported to 1.9.3.
 
 This end of life was [announced over a year ago](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
 
-We highly recommend that you upgrade to Ruby 2.2 or 2.1 as soon as possible.
+We highly recommend that you upgrade to Ruby 2.0 or above as soon as possible.


### PR DESCRIPTION
I would have missed the actual end of life of 1.9.3 if it weren't for @rafaelfranca's tweet today: https://twitter.com/rafaelfranca/status/569915266160840704

Is there any reason why we don't mirror the maintenance mode announcement with an end-of-life one today? https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/

If not, this PR addresses this.