### PR TITLE
Remove 1.9 series from downloads

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,16 +54,6 @@ downloads:
       bz2: 1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0
       gz: 4bd267a4187e4bc25c1db08f9f9bdc0ce595a705569cac460d98c4f5b02e614e
       zip: 73f6d939beda8865e12069689ddabd2658b3f637a9adebeee5e374388715c432
-  previous19:
-    version: 1.9.3-p551
-    url:
-      bz2: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2
-      gz: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
-      zip: http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip
-    sha256:
-      bz2: b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e
-      gz: bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8
-      zip: 44228297861f4dfdf23a47372a3e3c4c5116fbf5b0e10883417f2379874b55c6
   stable_snapshot:
     url:
       bz2: https://ftp.ruby-lang.org/pub/ruby/stable-snapshot.tar.bz2

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -49,10 +49,6 @@ Ruby може да бъде инсталиран и от изходен код �
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Стара стабилна версия (серия 1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     Това е архвирано копие на последната стабилна версия в SVN хранилището.
@@ -74,7 +70,6 @@ Ruby може да бъде инсталиран и от изходен код �
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -48,10 +48,6 @@ vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Stabile Vorgängerversion (1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     Hierbei handelt es sich um den neuesten Snapshot des stabilen Zweiges.
@@ -74,7 +70,6 @@ Bitte nutze einen Mirror in deiner Nähe.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -46,10 +46,6 @@ one of the third party tools mentioned above. They may help you.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Old stable (1.9.3 series):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     This is a tarball of the latest snapshot of the current stable branch.
@@ -71,7 +67,6 @@ Please try to use a mirror that is near you.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -45,10 +45,6 @@ de ayuda.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Estable viejo (serie 1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     Este es el tarball del último snapshot del branch del estable actual.
@@ -70,7 +66,6 @@ Intenta usar el mirror site más cerca de ti.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -50,10 +50,6 @@ peut-être vous aider.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Anciennes versions stables (séries 1.9.3) :**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots :**
   * [Stable Snapshot][stable-snapshot-gz]:
     Archive de la dernière version publiée à partir de la branche stable courante.
@@ -74,7 +70,6 @@ Utilisez s'il-vous-plaît un miroir proche de vous.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -52,10 +52,6 @@ esserti di aiuto.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Stabile Vecchia (serie 1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     Questo è il tarball dell'ultimo snapshot del branch stabile corrente.
@@ -78,7 +74,6 @@ Cerca di utilizzare il sito mirror più vicino a te.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -40,10 +40,6 @@ lang: ja
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **古い安定版 (1.9 系):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **スナップショット:**
   * [安定版のスナップショット][stable-snapshot-gz]:
     最も新しい現在の安定版ブランチのスナップショットのtarballです。
@@ -74,7 +70,6 @@ Windows向けのバイナリが有志により配布されています。
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -47,10 +47,6 @@ lang: ko
   [루비 {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **낡은 버전 (1.9.3 시리즈):**
-  [루비 {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **스냅숏:**
   * [Stable Snapshot][stable-snapshot-gz]:
     안정 브랜치의 최신 스냅숏을 tarball로 압축한 것.
@@ -70,7 +66,6 @@ lang: ko
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -48,10 +48,6 @@ skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Stary stabilny (seria 1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Migawki:**
   * [Stabilna migawka][stable-snapshot-gz]:
     To jest tarball ostatniej migawki stabilnej obecnego stabilnego brancha.
@@ -73,7 +69,6 @@ Spróbuj użyć jakiegoś blisko ciebie.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -52,10 +52,6 @@ lang: ru
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Старая стабильная (Из 1.9.3 серии):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
  * **Слепки:**
    * [Стабильный слепок][stable-snapshot-gz]:
      Это архив свежайшего стабильного слепка текущей стабильной ветки.
@@ -245,7 +241,6 @@ Ruby как язык имеет несколько разных имплемен
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -46,10 +46,6 @@ dụng một trong những công cụ của bên thứ ba đã được đề c�
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **Bản ổn định cũ (chuỗi 1.9.3):**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
     Đây là một tarball của snapshot mới nhất của nhánh ổn định hiện hành.
@@ -70,7 +66,6 @@ Xin hãy sử dụng mirror gần bạn nhất.
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -38,10 +38,6 @@ lang: zh_tw
   [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
   sha256: {{ site.downloads.previous20.sha256.gz }}
 
-* **舊穩定版（1.9.3 系列）：**
-  [Ruby {{ site.downloads.previous19.version }}][previous19-gz]<br>
-  sha256: {{ site.downloads.previous19.sha256.gz }}
-
 * **快照：**
   * [Stable Snapshot][stable-snapshot-gz]:
     當前穩定版 tarball 的最新快照
@@ -60,7 +56,6 @@ Ruby 原始碼可從世界各地的[鏡像站][mirrors]獲得。請嘗試離您�
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
 [previous20-gz]: {{ site.downloads.previous20.url.gz }}
-[previous19-gz]: {{ site.downloads.previous19.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/


### PR DESCRIPTION
Supports for ruby 1.9 series are ended now.
So I remove 1.9 series from downloads page.

@ruby/www-ruby-lang-org please review it.