### PR TITLE
Remove unmaintained notice from Bulgarian translation

### DIFF
--- a/bg/index.html
+++ b/bg/index.html
@@ -25,5 +25,3 @@ intro: |
   </div>
 
 ---
-
-{% include unmaintained.html %}


### PR DESCRIPTION
Hey guys,

I updated all pages in Bulgarian to match their English counterparts last december and also keep translating every new news article as quick as I can. The unmaintained notice is a misleading.

I know there is a rule to have at least two active maintainers for a translation to be considered active but I couldn't find anyone else to help me. Could I be the sole maintainer and also remove the notice? 

What do you think?
