### PR TITLE
Translate Google Summer of Code 2015 news (zh_cn) 

### DIFF
--- a/zh_cn/news/_posts/2015-03-06-google-summer-of-code-2015.md
+++ b/zh_cn/news/_posts/2015-03-06-google-summer-of-code-2015.md
@@ -2,7 +2,7 @@
 layout: news_post
 title: "Google Summer of Code 2015"
 author: "Federico Builes"
-translator:
+translator: "Kevin Cheng"
 date: 2015-03-06 10:48:37 +0000
 lang: zh_cn
 ---

--- a/zh_cn/news/_posts/2015-03-06-google-summer-of-code-2015.md
+++ b/zh_cn/news/_posts/2015-03-06-google-summer-of-code-2015.md
@@ -1,0 +1,27 @@
+---
+layout: news_post
+title: "Google Summer of Code 2015"
+author: "Federico Builes"
+translator:
+date: 2015-03-06 10:48:37 +0000
+lang: zh_cn
+---
+
+Ruby 将以顶级组织身份参与[Google Summer of Code 2015][gsoc]。我们将为包括 [Ruby][ruby-ideas]、 [JRuby][jruby-ideas]、 [Celluloid][celluloid] 和
+[其他][ideas] 这样的 Ruby 相关项目提供保护伞。学生项目提交日期为 3 月 16 日至 3 月 27 日（这是[时间表][timeline]）。
+
+请有兴趣参加本次活动的学生或老师加入[邮件列表][ml]。在[RubyGSoC wiki][ideas]有一份相关项目的列表。
+
+[Ruby on Rails][ror] 和 [SciRuby][sciruby] 同样以顶级组织的身份参加本次活动。如果有更适合这些项目的想法，请查看相应的公告[Ruby on Rails][ror-announcement] [SciRuby][sciruby-ideas]。
+
+[gsoc]: http://www.google-melange.com/gsoc/document/show/gsoc_program/google/gsoc2015/about_page
+[timeline]: http://www.google-melange.com/gsoc/events/google/gsoc2015
+[jruby-ideas]: https://github.com/jruby/jruby/wiki/Google-Summer-of-Code-2015
+[celluloid]: https://github.com/rubygsoc/rubygsoc/wiki/Ideas-List#celluloid
+[ideas]: https://github.com/rubygsoc/rubygsoc/wiki/Ideas-List
+[ml]: https://groups.google.com/forum/?hl=en#!forum/rubygsoc
+[ror-announcement]: http://weblog.rubyonrails.org/2015/3/4/google-summer-of-code-2015/
+[sciruby-ideas]: https://github.com/SciRuby/sciruby/wiki/Google-Summer-of-Code-2015-Ideas
+[ruby-ideas]: https://github.com/rubygsoc/rubygsoc/wiki/Ideas-List#mri-matz-ruby-interpreter
+[ror]: http://rubyonrails.org/
+[sciruby]: http://sciruby.com/


### PR DESCRIPTION
translate google-summer-of-code-2015 news published at 2015-03-06

Related #1074 