### PR TITLE
translate 2014/09/19/ruby-2-0-0-p576-is-released into zh_cn

### DIFF
--- a/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
+++ b/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
@@ -7,7 +7,7 @@ date: 2014-09-19 12:00:00 +0000
 lang: zh_cn
 ---
 
-我们很高兴地宣布发布 Ruby 2.0.0-p576, 以庆祝正在日本召开的 [RubyKaigi2014](http://rubykaigi.org/2014) 。
+我们很高兴地宣布发布 Ruby 2.0.0-p576， 以庆祝正在日本召开的 [RubyKaigi2014](http://rubykaigi.org/2014) 。
 
 这次发布修正了许多 bug，例如：
 

--- a/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
+++ b/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
@@ -7,7 +7,7 @@ date: 2014-09-19 12:00:00 +0000
 lang: zh_cn
 ---
 
-我们很高兴地宣布发布 Ruby 2.0.0-p576， 以庆祝正在日本召开的 [RubyKaigi2014](http://rubykaigi.org/2014) 。
+我们很高兴地宣布发布 Ruby 2.0.0-p576，以庆祝正在日本召开的 [RubyKaigi2014](http://rubykaigi.org/2014)。
 
 这次发布修正了许多 bug，例如：
 
@@ -49,5 +49,5 @@ lang: zh_cn
 
 ## 发布评论
 
-我十分感谢所有支持 Ruby 的人， 谢谢你们。
+我十分感谢所有支持 Ruby 的人，谢谢你们。
 

--- a/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
+++ b/zh_cn/news/_posts/2014-09-19-ruby-2-0-0-p576-is-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.0.0-p576 今日发布"
+author: "usa"
+translator: "li-thy-um"
+date: 2014-09-19 12:00:00 +0000
+lang: zh_cn
+---
+
+我们很高兴地宣布发布 Ruby 2.0.0-p576, 以庆祝正在日本召开的 [RubyKaigi2014](http://rubykaigi.org/2014) 。
+
+这次发布修正了许多 bug，例如：
+
+* 修正了许多内存泄露以及使用额外内存的问题，
+* 修正了许多与具体平台相关的问题（尤其是在构建过程中的那些），
+* 修正了许多文档相关问题。
+
+详情请到对应的 [tickets](https://bugs.ruby-lang.org/projects/ruby-200/issues?set_filter=1&amp;status_id=5) 以及 [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_0_0_576/ChangeLog) 进行确认。
+
+## 下载
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2)
+
+      SIZE:   10753403 bytes
+      MD5:    eccd42d43620544a085c5e3834572f37
+      SHA256: 8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059
+      SHA512: e089cca4867cd9c715f4f37e40a1db9af6ba0c74b47e79568121bb980476f8877a87ccb848b973381edb4667c0c73165f5e1761f60db839e67f6326302dbd864
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.gz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.gz)
+
+      SIZE:   13610215 bytes
+      MD5:    2e1f4355981b754d92f7e2cc456f843d
+      SHA256: 9f5a593d81768c856155be6b2d2e357b961b5c43e04ba54c1ee511987fac2b66
+      SHA512: f5b7e7fba87ed21ee5a422ea978794adbd2f63669db7c361cec3698b3ebba2e95fc113791de2e22513bbe23c5fecc0605d1b76cadb0e714162a2c0e94cbd77b9
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.xz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.xz)
+
+      SIZE:   8318772 bytes
+      MD5:    d64d6a92d6101c83396ef4a2754d9d2a
+      SHA256: 4aeac1cbca1b5ead0ace5625ba5ea50bb11ee6f8c41ff7cd305f7ff760e09496
+      SHA512: e556435df9e6b4aae1ad27f986307a5aa6718b4b6a3365f6572b1eb3be72f1fa7cdda3cf5b9c142b878617770497ea2660595f505d1fe6924dcffacb5ccabecf
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.zip](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.zip)
+
+      SIZE:   15122735 bytes
+      MD5:    620e105c4f9a4274a8351516d0f6a53a
+      SHA256: cb0166d9afb0126612dff10d15848483984df4900c1b34cd053b1be6893ea38b
+      SHA512: adce5f044283e97fccbc80c770f999d20e366f7ee8e13782ca71490b5a16198ae0cdbc6df7419f085e2f7adea30552704141d37496cefcb9b147802b55d3ff82
+
+## 发布评论
+
+我十分感谢所有支持 Ruby 的人， 谢谢你们。
+


### PR DESCRIPTION
Related #1074.
![ruby-2-0-0-p576-is-released](https://cloud.githubusercontent.com/assets/4740349/7878865/7d8ed82a-061d-11e5-9057-709ae5062ddd.png)

