### PR TITLE
Link to the Ruby Bibliography from the sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -710,6 +710,8 @@ locales:
       url: http://tryruby.org/
     books: &books
       url: http://www.amazon.com/s/ref=sr_nr_n_5?ie=UTF8&amp;rs=1000&amp;keywords=Ruby&amp;rh=i%3Aaps%2Ck%3ARuby%2Ci%3Astripbooks%2Cn%3A1000%2Cn%3A5
+    rubybib: &rubybib
+      url: http://rubybib.org/
 
     bg:
       get_started:
@@ -847,6 +849,9 @@ locales:
         books:
           text: Books
           <<: *books
+        rubybib:
+          text: Academic Research
+          <<: *rubybib
         libraries:
           text: Libraries
           url: /en/libraries/


### PR DESCRIPTION
The Ruby Bibliography is a list of academic and industry research papers on the Ruby programming language.

I wasn't sure I was editing the config file properly - I copied the 'books' example so hopefully that's correct.