### PR TITLE
Translate 2014-10-27-ruby-2-0-0-p594-is-released (id)

### DIFF
--- a/id/news/_posts/2014-10-27-ruby-2-0-0-p594-is-released.md
+++ b/id/news/_posts/2014-10-27-ruby-2-0-0-p594-is-released.md
@@ -1,0 +1,58 @@
+---
+layout: news_post
+title: "Ruby 2.0.0-p594 Dirilis"
+author: "usa"
+translator: "meisyal"
+date: 2014-10-27 12:00:00 +0000
+lang: id
+---
+
+Kami dengan senang hati mengumumkan Ruby 2.0.0-p594 telah dirilis.
+
+Rilis ini mencakup perbaikan cleah keamanan *DoS* pada REXML.
+
+* [CVE-2014-8080: Denial of Service XML Expansion](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/)
+
+Rilis ini juga mencakup perubahan pengaturan *default* dari ext/openssl.
+Opsi SSL/TLS yang tidak aman dimatikan secara *default*.
+
+* [Perubahan pengaturan *default* dari ext/openssl](https://www.ruby-lang.org/id/news/2014/10/27/changing-default-settings-of-ext-openssl/)
+
+Dan, banyak *bugs* lain diperbaiki.
+Lihat [tiket](https://bugs.ruby-lang.org/projects/ruby-200/issues?set_filter=1&amp;status_id=5)
+dan [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_0_0_594/ChangeLog) untuk lebih detil.
+
+## Unduh
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2)
+
+      SIZE:   10756895 bytes
+      MD5:    58469c0daf5f3a892a70cc674ea59c7f
+      SHA256: e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4
+      SHA512: 8301a51c73fb63a8cfeb14af47d0c18b5bc3c45e3d62fc2ed56a673a1cd6b0015c41f275e70eb14a9e40036b1530977199321e05285e107a6adf58514bef1b3d
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz)
+
+      SIZE:   13606970 bytes
+      MD5:    a9caa406da5d72f190e28344e747ee74
+      SHA256: ee515dd7b17cdbc106396cd432f5662bb0b5afc05044469175914aab65f3c6e7
+      SHA512: a6544f68a87aa3d00a59cee8c090386cf1fa6d6bfe5730af909d614e90bff9ee64c2cf9f542f7a43f8352b86e3945693504ffed6cefc57f736c6e26670ddb9ca
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.xz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.xz)
+
+      SIZE:   8316772 bytes
+      MD5:    fc64932b4d4af0f91c03d7966fbbc9b2
+      SHA256: 561465447428a5bc52ed3cca98c6067948b2c81811e1445a196b1c24913b3e72
+      SHA512: d5ba88dd5eb3569203cbe91e75bf21bea6897338885479e34a839569de15ca2f09e4eff655636923892e9234a0f0b6a2c058442ebc1b13a3d2ddced25bd88fa8
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.zip](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.zip)
+
+      SIZE:   15125232 bytes
+      MD5:    d5801bbe794a07236c3bcf4a28ad3509
+      SHA256: 38a8db127d5b241ac2090ef75e9f7941a34851d4c6b61135b88019129f9c04a3
+      SHA512: 1f7d94029e5af480a0ae0ebd21129a01b0066fecd15278b272754e6e80b6a6fb1ded53fd1288e7375a17021d482a59b40414270923c2ecfb06999ea66a91fc54
+
+## Komentar
+
+Saya berterima kasih kepada semua orang yang mendukung Ruby.
+Terima kasih.


### PR DESCRIPTION
Bahasa Indonesia translation for Ruby 2.0.0-p594 is released (https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-0-0-p594-is-released/).
Please, review my translation @gozali!

Thanks.