### PR TITLE
Add RubyBib to the sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -40,6 +40,10 @@
     <li><a href="{{ sidebar.explore.books.url }}">{{ sidebar.explore.books.text }}</a></li>
     {% endif %}
 
+    {% if sidebar.explore.rubybib != null %}
+    <li><a href="{{ sidebar.explore.rubybib.url }}">{{ sidebar.explore.rubybib.text }}</a></li>
+    {% endif %}
+
     {% if sidebar.explore.libraries != null %}
     <li><a href="{{ sidebar.explore.libraries.url }}">{{ sidebar.explore.libraries.text }}</a></li>
     {% endif %}


### PR DESCRIPTION
@hsbt reference 61eaf874269102dd7dedb638a55b7f722afb466f - I didn't realise I needed to change the sidebar template as well - I thought just changing the configuration was enough. This fixes that and should put it into the sidebar.