### PR TITLE
Remove link to shut down website (all languages)

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -53,13 +53,10 @@ lang: bg
 * [Basecamp][9] е уеб базирана система за управлението на проекти,
   разработена от [37signals][10]
 
-* [43 Things][11] Ви позволява да направите, запазите и споделите списък
-  от цели.
-
-* [A List Apart][12] е списание за програмисти и дизайнери, като сайта
+* [A List Apart][11] е списание за програмисти и дизайнери, като сайта
   съществува от 1997 и е пренаписан на Ruby.
 
-* [Blue Sequence][13] е сложна апликация, част от процеса за
+* [Blue Sequence][12] е сложна апликация, част от процеса за
   производство на Toyota Motor, която наскоро беше избрана за финалист
   на тазгодишните награди на British Computer Information Management.
 
@@ -75,6 +72,5 @@ lang: bg
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/

--- a/de/documentation/success-stories/index.md
+++ b/de/documentation/success-stories/index.md
@@ -49,11 +49,7 @@ Projekten, die Ruby nutzen.
 * [Basecamp][7] ist eine webbasierte Projektmanagement Software von
   [37signals][8] und wurde komplett in Ruby geschrieben.
 
-* [43 Things][9] erlaubt Dir das Verwalten einer Liste mit Zielen, die
-  Du mit der ganzen Welt teilen kannst. Das System wurde komplett mit
-  Ruby entwickelt.
-
-* [A List Apart][10] ist seit 1997 ein Magazin für Leute, die Websites
+* [A List Apart][9] ist seit 1997 ein Magazin für Leute, die Websites
   erstellen. Die vor kurzem aktualisierte Site nutzt eine
   Individualsoftware, die mit Ruby on Rails entwickelt wurde.
 
@@ -67,5 +63,4 @@ Projekten, die Ruby nutzen.
 [6]: http://www.level3.com/
 [7]: http://www.basecamphq.com
 [8]: http://www.37signals.com
-[9]: http://www.43things.com
-[10]: http://www.alistapart.com
+[9]: http://www.alistapart.com

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -54,14 +54,11 @@ you’ll find a small sample of real world usage of Ruby.
 * [Basecamp][9], a web-based project management application developed by
   [37signals][10], is programmed entirely in Ruby.
 
-* [43 Things][11] allows you to keep a list of goals and share it with
-  the world. It was developed entirely in Ruby.
-
-* [A List Apart][12], a magazine for people who make websites that has
+* [A List Apart][11], a magazine for people who make websites that has
   been around since 1997, has recently been revamped and uses a custom
   application built with Ruby on Rails.
 
-* [Blue Sequence][13], a sophisticated mission-critical application
+* [Blue Sequence][12], a sophisticated mission-critical application
   which forms part of Toyota Motor Manufacturing’s own
   “sequence-in-time” production process, has recently been selected as
   finalist the British Computer (BCS) Information Management Awards.
@@ -69,11 +66,11 @@ you’ll find a small sample of real world usage of Ruby.
 #### Security
 
 * The [Metasploit Framework][14], a community open source project
-  managed by [Rapid7][15], is a free penetration testing platform that
+  managed by [Rapid7][14], is a free penetration testing platform that
   helps IT professionals assess the security of their networks and
   applications. The Metasploit Project consists of over 700,000 lines of
   code and has been downloaded over a million times in 2010. The
-  commercial editions [Metasploit Express][16] and [Metasploit Pro][17]
+  commercial editions [Metasploit Express][15] and [Metasploit Pro][16]
   developed by Rapid7 are also based on Ruby.
 
 
@@ -88,10 +85,9 @@ you’ll find a small sample of real world usage of Ruby.
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.metasploit.com
-[15]: http://www.rapid7.com
-[16]: http://www.rapid7.com/products/metasploit-express.jsp
-[17]: http://www.rapid7.com/products/metasploit-pro.jsp
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.metasploit.com
+[14]: http://www.rapid7.com
+[15]: http://www.rapid7.com/products/metasploit-express.jsp
+[16]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -56,13 +56,10 @@ témoignages du « monde réel. »
 * [Basecamp][10], un projet de gestion d’application écrit par
   [37signals][11], est entièrement programmé en Ruby.
 
-* [43 Things][12] vous permet de gérer et partager des *todo lists* en
-  ligne, le tout étant écrit en Ruby.
-
-* [A List Apart][13], un magazine en ligne destiné aux développeurs web
+* [A List Apart][12], un magazine en ligne destiné aux développeurs web
   depuis 1997, a réalisé une refonte totale en utilisant Ruby on Rails.
 
-* [Blue Sequence][14] est un des composants du système d’applications
+* [Blue Sequence][13] est un des composants du système d’applications
   critiques *sequence-in-time* du constructeur automobile Toyota. Il a
   été sélectionné parmi les finalistes des *British Computer Information
   Awards*.
@@ -80,6 +77,5 @@ témoignages du « monde réel. »
 [9]: http://www.level3.com/
 [10]: http://www.basecamphq.com
 [11]: http://www.37signals.com
-[12]: http://www.43things.com
-[13]: http://www.alistapart.com
-[14]: http://www.bluefountain.com/supply-chain-management/
+[12]: http://www.alistapart.com
+[13]: http://www.bluefountain.com/supply-chain-management/

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -15,68 +15,65 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
   dikembangkan oleh [37signals][2], menggunakan Ruby on Rails. 37signals
   merupakan pembuat framework Rails yang menggunakan bahasa Ruby.
 
-* [43 Things][3] menyimpan daftar tujuan hidup Anda dan membaginya
-  dengan teman-teman Anda. Ditulis menggunakan Ruby on Rails.
-
-* [A List Apart][4], majalah digital bagi para webmaster yang telah
+* [A List Apart][3], majalah digital bagi para webmaster yang telah
   berdiri sejak tahun 1997, telah direnovasi dan menggunakan aplikasi
   khusus yang dikembangkan menggunakan Ruby on Rails.
 
-* [Twitter][5], situs komunitas yang sangat ramai menggunakan Ruby on
+* [Twitter][4], situs komunitas yang sangat ramai menggunakan Ruby on
   Rails sebagai *framework*.
 
-* [BookJetty][6] merupakan situs bagi pecinta buku, dikembangkan oleh
-  [Herryanto Siatono][7] ([Pluit Solutions][8]).
+* [BookJetty][5] merupakan situs bagi pecinta buku, dikembangkan oleh
+  [Herryanto Siatono][6] ([Pluit Solutions][7]).
 
-* [Ruby on Rails Applications][9] berisi sebagian kecil daftar aplikasi
+* [Ruby on Rails Applications][8] berisi sebagian kecil daftar aplikasi
   yang dikembangkan menggunakan Ruby on Rails.
 
-* [Rails 100][10] berisi daftar 100 aplikasi Rails terpopuler
+* [Rails 100][9] berisi daftar 100 aplikasi Rails terpopuler
   berdasarkan statistik dari Alexa.
 
-* [Real World Usage di Rails Wiki][11] berisi daftar aplikasi berbasis
+* [Real World Usage di Rails Wiki][10] berisi daftar aplikasi berbasis
   Ruby on Rails.
 
-* [Blue Sequence][12], aplikasi canggih yang merupakan bagian dari
+* [Blue Sequence][11], aplikasi canggih yang merupakan bagian dari
   proses produksi *sequence-in-time* di Toyota Motor Manufacturing,
   telah dipilih sebagaif finalis di British Computer (BCS) Information
   Management Awards.
 
 #### Simulasi
 
-* [NASA Langley Research Center][13] menggunakan Ruby untuk melakukan
+* [NASA Langley Research Center][12] menggunakan Ruby untuk melakukan
   simulasi.
 
-* Kelompok riset di [Motorola][14] menggunakan Ruby untuk melakukan
+* Kelompok riset di [Motorola][13] menggunakan Ruby untuk melakukan
   simulasi, baik untuk meng-*generate* skenario maupun memproses data
   hasilnya.
 
 #### Bisnis
 
-* [Toronto Rehab][15] menggunakan aplikasi berbasis RubyWebDialogs dalam
+* [Toronto Rehab][14] menggunakan aplikasi berbasis RubyWebDialogs dalam
   manajemen dukungan *on-call* dan *on-site* untuk *help desk* Teknologi
   Informasi dan tim operasi Teknologi Informasi.
 
 #### Robotika
 
-* Proyek [MORPHA][16] menggunakan Ruby untuk mengimplementasikan bagian
+* Proyek [MORPHA][15] menggunakan Ruby untuk mengimplementasikan bagian
   pengendali reaktif dari robot Siemens yang digunakan.
 
 #### Jaringan Komputer
 
-* [Open Domain Server][17] menggunakan Ruby untuk memungkinkan pengguna
+* [Open Domain Server][16] menggunakan Ruby untuk memungkinkan pengguna
   Dynamic DNS meng-*update* konfigurasi IP mereka secara *real time*
   agar dapat dipetakan ke domain statis.
 
 #### Telekomunikasi
 
-* Ruby digunakan oleh [Lucent][18] pada produk wireless 3G yang mereka
+* Ruby digunakan oleh [Lucent][17] pada produk wireless 3G yang mereka
   kembangkan.
 
 #### Administrasi Sistem
 
 * Ruby digunakan untuk mengembangkan koleksi data sentral di [Level 3
-  Communications][19] pada sistem *Unix Capacity and Planning* yang
+  Communications][18] pada sistem *Unix Capacity and Planning* yang
   memproses statistik di lebih dari 1700 server Unix (Solaris dan Linux)
   yang tersebar di seluruh dunia.
 
@@ -84,20 +81,19 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 
 [1]: http://www.basecamphq.com
 [2]: http://www.37signals.com
-[3]: http://www.43things.com
-[4]: http://www.alistapart.com
-[5]: http://www.twitter.com
-[6]: http://www.bookjetty.com/
-[7]: http://www.workingwithrails.com/person/5050-herryanto-siatono
-[8]: http://www.pluitsolutions.com/
-[9]: http://www.rubyonrails.org/applications
-[10]: http://rails100.pbwiki.com/
-[11]: http://wiki.rubyonrails.com/rails/pages/RealWorldUsage
-[12]: http://www.bluefountain.com/supply-chain-management/
-[13]: http://www.larc.nasa.gov/
-[14]: http://www.motorola.com
-[15]: http://www.torontorehab.com
-[16]: http://www.morpha.de/php_e/index.php3
-[17]: http://ods.org/
-[18]: http://www.lucent.com/
-[19]: http://www.level3.com/
+[3]: http://www.alistapart.com
+[4]: http://www.twitter.com
+[5]: http://www.bookjetty.com/
+[6]: http://www.workingwithrails.com/person/5050-herryanto-siatono
+[7]: http://www.pluitsolutions.com/
+[8]: http://www.rubyonrails.org/applications
+[9]: http://rails100.pbwiki.com/
+[10]: http://wiki.rubyonrails.com/rails/pages/RealWorldUsage
+[11]: http://www.bluefountain.com/supply-chain-management/
+[12]: http://www.larc.nasa.gov/
+[13]: http://www.motorola.com
+[14]: http://www.torontorehab.com
+[15]: http://www.morpha.de/php_e/index.php3
+[16]: http://ods.org/
+[17]: http://www.lucent.com/
+[18]: http://www.level3.com/

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -55,25 +55,23 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 
 * [Basecamp][9], un manager di progetto prodotto dalla [37signals][10],
   interamente programmato in Ruby.
-* [43 Things][11] ti permette di creare una lista di obiettivi e di
-  condividerla col mondo intero. E’ stato creato interamente in Ruby.
-* [A List Apart][12], un magazine per webmaster on-line dal 1997 che è
+* [A List Apart][11], un magazine per webmaster on-line dal 1997 che è
   stato recentemente aggiornato e utilizza applicazioni scritte in Ruby
   on Rails.
-* [Blue Sequence][13], una sofisticata applicazione mission-critical che
+* [Blue Sequence][12], una sofisticata applicazione mission-critical che
   deriva dal processo di produzione Toyota Motor Manufacturing’s
   “sequence-in-time”. E’ stata recentemente selezionata come finalista
   quest’anno al British Computer (BCS) Information Management Awards.
 
 #### Security
 
-* Il [Metasploit Framework][14], un progetto community open source
-  gestito da [Rapid7][15], è una piattaforma gratuita di penetration testing
+* Il [Metasploit Framework][13], un progetto community open source
+  gestito da [Rapid7][14], è una piattaforma gratuita di penetration testing
   che aiuta i professionisti IT a valutare la sicurezza dei loro network
   e applicazioni.
   Il progetto Metasploit consiste in più di 700,000 linee di codice ed ha
   raggiunto più di un milione di download nel 2010. Le edizioni commerciali
-  [Metasploit Express][16] e [Metasploit Pro][17] sviluppate da Rapid7
+  [Metasploit Express][15] e [Metasploit Pro][16] sviluppate da Rapid7
   sono anche esse basate su Ruby.
 
 
@@ -88,10 +86,9 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.metasploit.com
-[15]: http://www.rapid7.com
-[16]: http://www.rapid7.com/products/metasploit-express.jsp
-[17]: http://www.rapid7.com/products/metasploit-pro.jsp
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.metasploit.com
+[14]: http://www.rapid7.com
+[15]: http://www.rapid7.com/products/metasploit-express.jsp
+[16]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/ko/documentation/success-stories/index.md
+++ b/ko/documentation/success-stories/index.md
@@ -52,25 +52,22 @@ lang: ko
 * [Basecamp][9]는 [37signals][10]에서 개발한 웹기반 프로젝트 관리 툴입니다.
   코드는 전부 루비로 되어있습니다.
 
-* [43 Things][11]는 목표의 목록을 관리하고 공유할 수 있게 합니다.
-  코드는 전부 루비로 개발 되었습니다.
-
-* [A List Apart][12]는 1997년부터 발행된 웹 사이트를 만드는 사람들을 위한
+* [A List Apart][11]는 1997년부터 발행된 웹 사이트를 만드는 사람들을 위한
   메거진입니다. 최근에 루비 온 레일즈로 만들어진 독자적인 애플리케이션으로
   리뉴얼하였습니다.
 
-* [Blue Sequence][13]는 도요타 자동차 제조에서 사용하는 “sequence-in-time”
+* [Blue Sequence][12]는 도요타 자동차 제조에서 사용하는 “sequence-in-time”
   생산 공정의 일부를 담당하는 복잡한 mission-critical 애플리케이션입니다.
   Blue Sequence는 최근 영국 컴퓨터(BCS) 정보 경영 대상으로 선정되었습니다.
 
 #### 보안
 
-* [Metasploit Framework][14]는 [Rapid7][15]에서 관리하는 커뮤니티형
+* [Metasploit Framework][13]는 [Rapid7][14]에서 관리하는 커뮤니티형
   오픈 소스 프로젝트입니다. Metasploit 프레임워크는 IT 전문가가 자신의
   네트워크 및 응용 프로그램의 보안을 평가하는 데 사용되는 무료 침투
   테스트 플랫폼입니다. Metasploit 프로젝트의 코드 700,000 라인으로
   구성되어 있으며 2010년에만 백만 회 이상 다운로드 되었습니다.
-  상용 버전인 [Metasploit Express][16]와 [Metasploit Pro][17]도
+  상용 버전인 [Metasploit Express][15]와 [Metasploit Pro][16]도
   Rapid7에서 개발하였으며 루비를 사용합니다.
 
 
@@ -85,10 +82,9 @@ lang: ko
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.metasploit.com
-[15]: http://www.rapid7.com
-[16]: http://www.rapid7.com/products/metasploit-express.jsp
-[17]: http://www.rapid7.com/products/metasploit-pro.jsp
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.metasploit.com
+[14]: http://www.rapid7.com
+[15]: http://www.rapid7.com/products/metasploit-express.jsp
+[16]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -52,21 +52,17 @@ Rubiego w rzeczywistości.
   przez [37signals][10], została zaprogramowana w całości w Rubim (Ruby
   on Rails)
 
-* [43 Things][11] umożliwia przechowywanie listy celów, które
-  chcielibyśmy osiągnąć i dzielenie się nimi ze światem. Aplikacja
-  napisana w całości w Rubim.
-
-* [A List Apart][12], magazyn dla projektantów stron internetowych,
+* [A List Apart][11], magazyn dla projektantów stron internetowych,
   istniejący juz od 1997, ostatnio został odświeżony i oparty o
   aplikację napisaną w Ruby on Rails.
 
-* [Blue Sequence][13], wyrafinowana aplikacja do misji krytycznych,
+* [Blue Sequence][12], wyrafinowana aplikacja do misji krytycznych,
   która stanowi część procesu produkcyjnego silników Toyoty (Toyota
   Motor Manufacturing), została niedawno uznana za finalistę w kategorii
   najlepszych brytyjskich informacyjnych systemów zarządzania (British
   Computer (BCS) Information Management Awards).
 
-* [Wyszukiwarka mieszkaniowa Hogo.pl][14] – wyszukiwarka kontekstowa
+* [Wyszukiwarka mieszkaniowa Hogo.pl][13] – wyszukiwarka kontekstowa
   ogłoszeń mieszkaniowych. Umożliwia przeszukiwanie wszystkich większych
   serwisów z ogłoszeniami nieruchomości z poziomu jednego serwisu.
   Dynamika i rozszerzalność Rubiego umożliwiła stworzenie systemu, który
@@ -76,7 +72,7 @@ Rubiego w rzeczywistości.
   i klasyfikację danych napisana w całości w Rubim z wykorzystaniem
   popularnych bibliotek open-source.
 
-* [Aplikacja do fakturowania Infakt.pl][15] umożliwia wystawianie faktur
+* [Aplikacja do fakturowania Infakt.pl][14] umożliwia wystawianie faktur
   (drukowanie, wysyłanie), tworzenie bazy klientów, wysyłanie upomnień o
   zaległych płatnościach faktur, jak również podziękowania za ich
   opłacenie. Infakt.pl przede wszystkim oszczędza czas użytkowników
@@ -99,8 +95,7 @@ Rubiego w rzeczywistości.
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.hogo.pl
-[15]: http://www.infakt.pl
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.hogo.pl
+[14]: http://www.infakt.pl

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -55,15 +55,11 @@ diversos projectos.
   desenvolvida pela [37signals][10] está programada inteiramente em
   Ruby.
 
-* [43 Things][11] permite a qualquer pessoa criar e manter uma lista de
-  objectivos e partilha-la com o mundo. Foi desenvolvido inteiramente em
-  Ruby.
-
-* [A List Apart][12], uma revista para pessoas interessadas na criação
+* [A List Apart][11], uma revista para pessoas interessadas na criação
   de websites que existe desde 1997, foi recentemente renovada e usa uma
   aplicação própria criada em Ruby on Rails.
 
-* [Blue Sequence][13], uma sofisticada aplicação de importância crítica
+* [Blue Sequence][12], uma sofisticada aplicação de importância crítica
   que faz parte do processo de producção “sequence-in-time” da Toyota
   Motors, foi recentemente selecionada como finalista para o concurso da
   British Computer (BCS) Information Management Awards.
@@ -80,6 +76,5 @@ diversos projectos.
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/

--- a/ru/documentation/success-stories/index.md
+++ b/ru/documentation/success-stories/index.md
@@ -58,26 +58,23 @@ lang: ru
 * [Basecamp][9], веб-сервис для управления проектами, разработанный
   компанией [37signals][10], написан целиком на Ruby.
 
-* [43 Things][11] позволяет вам хранить список целей и делиться им со
-  всем миром. Написан целиком на Ruby.
-
-* [A List Apart][12], журнал для людей, которые создают веб-сайты,
+* [A List Apart][11], журнал для людей, которые создают веб-сайты,
   который работает с 1997 года. Недавно был обновлен и приложение было
   написано на Ruby on Rails.
 
-* [Blue Sequence][13], сложное критически-целевое приложение, которое
+* [Blue Sequence][12], сложное критически-целевое приложение, которое
   формирует часть собственного "последовательного-во-времени" процесса
   производства Toyota Motor Manufacturing, была недавно выбрана в
   качестве финалиста British Computer (BCS) Information Management Awards.
 
 #### Безопасность
 
-* [Metasploit Framework][14], проект с открытым исходным кодом,
-  поддерживаемый [Rapid7][15], это бесплатная платформа проникающего тестирования,
+* [Metasploit Framework][13], проект с открытым исходным кодом,
+  поддерживаемый [Rapid7][14], это бесплатная платформа проникающего тестирования,
   которая помогает IT профессионалам проверить безопасность их сети и
   приложений. Metasploit Project содержит более 700 000 строк кода и был
   скачан больше миллиона раз в 2010 году. Коммерческая версия [Metasploit
-  Express][16] и [Metasploit Pro][17] разработаны Rapid7 и так же написаны
+  Express][15] и [Metasploit Pro][16] разработаны Rapid7 и так же написаны
   на Ruby.
 
 
@@ -92,10 +89,9 @@ lang: ru
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.metasploit.com
-[15]: http://www.rapid7.com
-[16]: http://www.rapid7.com/products/metasploit-express.jsp
-[17]: http://www.rapid7.com/products/metasploit-pro.jsp
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.metasploit.com
+[14]: http://www.rapid7.com
+[15]: http://www.rapid7.com/products/metasploit-express.jsp
+[16]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -56,27 +56,24 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 * [Basecamp][8], [37signals][9] tarafından geliştirilen web tabanlı
   proje yönetim uygulamasıdır, tamamen Ruby ile yazılmıştır.
 
-* [43 Things][10] hedeflerinin bir listesini tutmanı ve dünya ile
-  paylaşmanı sağlar. Tamamen Ruby ile geliştirilmiştir.
-
-* [A List Apart][11], yaklaşık 1997 yılından bu yana web-sitelerini
+* [A List Apart][10], yaklaşık 1997 yılından bu yana web-sitelerini
   yapan insanlar için bir dergi. Son zamanlarda yeniden canlandı ve Ruby
   On Rails ile oluşturulan özel bir uygulama kullanır.
 
-* [Blue Sequence][12], Toyota Motor İmalatı’nın kendi “sequence-in-time”
+* [Blue Sequence][11], Toyota Motor İmalatı’nın kendi “sequence-in-time”
   üretim sürecinin bir parçası olan gelişmiş,kritik bir uygulama, son
   zamanlarda British Computer (BCS) Bilgi Yönetimi Ödülleri’nde finalist
   olarak seçildi.
 
 #### Güvenlik
 
-* [Metasploit Framework][13], [Rapid7][14] tarafından yönetilen topluluk
+* [Metasploit Framework][12], [Rapid7][13] tarafından yönetilen topluluk
   açık kaynak projesi, ağların ve uygulamarın güvenliğini
   değerlendirmede BT uzmanlarına yardımcı olan ücretsiz bir penetrasyon
   test platformudur. Metasploit Projesi 700,000 satırın üstünde koddan
   oluşur ve 2010 yılında 1 milyondan fazla indirilme sayısına
-  ulaşmıştır. Ticari sürüm olan [Metasploit Express][15] ve [Metasploit
-  Pro][16] Rapid7 tarafından geliştirilir ayrıca Ruby tabanlıdır.
+  ulaşmıştır. Ticari sürüm olan [Metasploit Express][14] ve [Metasploit
+  Pro][15] Rapid7 tarafından geliştirilir ayrıca Ruby tabanlıdır.
 
 
 
@@ -89,10 +86,9 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 [7]: http://www.level3.com/
 [8]: http://www.basecamphq.com
 [9]: http://www.37signals.com
-[10]: http://www.43things.com
-[11]: http://www.alistapart.com
-[12]: http://www.bluefountain.com/supply-chain-management/
-[13]: http://www.metasploit.com
-[14]: http://www.rapid7.com
-[15]: http://www.rapid7.com/products/metasploit-express.jsp
-[16]: http://www.rapid7.com/products/metasploit-pro.jsp
+[10]: http://www.alistapart.com
+[11]: http://www.bluefountain.com/supply-chain-management/
+[12]: http://www.metasploit.com
+[13]: http://www.rapid7.com
+[14]: http://www.rapid7.com/products/metasploit-express.jsp
+[15]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -52,23 +52,20 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 * [Basecamp][9], là trình quản lý dự án trên nền web được phát triển bởi
   [37signals][10], hoàn toàn với ngôn ngữ Ruby.
 
-* [43 Things][11] cho phép bạn lưu giữ một danh sách các mục tiêu và chia sẻ
-  nó với cả thế giới. Nó được phát triển hoàn toàn với Ruby.
-
-* [A List Apart][12], tạp chí cho ai thích tạo website, ra đời năm 1997, mới
+* [A List Apart][11], tạp chí cho ai thích tạo website, ra đời năm 1997, mới
   cải tiến site của họ bằng một ứng dụng riêng xây dựng với Ruby on Rails.
 
-* [Blue Sequence][13], Một ứng dụng mission-critical rất tinh vi, và là
+* [Blue Sequence][12], Một ứng dụng mission-critical rất tinh vi, và là
   một phần của công đoạn sản xuất “sequence-in-time” của Toyota Motor Manufacturing,
   vừa được bình chọn vào chung kết giải British Computer (BCS) Information Management Awards.
 
 #### Bảo mật
 
-* [Metasploit Framework][14], một dự án mã nguồn mỡ quản lý bởi
-  [Rapid7][15], là một nền tảng thử nghiệm các tấn công bảo mật
+* [Metasploit Framework][13], một dự án mã nguồn mỡ quản lý bởi
+  [Rapid7][14], là một nền tảng thử nghiệm các tấn công bảo mật
   giúp các chuyên gia kiểm định bảo mật của mạng hay ứng dụng.
   Dự án Metasploit bao gồm trên 700,000 dòng mã và được download
-  trên một triệu lần trong năm 2010. Phiên bản thương mại [Metasploit Express][16] và [Metasploit Pro][17]
+  trên một triệu lần trong năm 2010. Phiên bản thương mại [Metasploit Express][15] và [Metasploit Pro][16]
   do Rapid7 phát triển cũng dựa trên Ruby.
 
 
@@ -83,10 +80,9 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
-[14]: http://www.metasploit.com
-[15]: http://www.rapid7.com
-[16]: http://www.rapid7.com/products/metasploit-express.jsp
-[17]: http://www.rapid7.com/products/metasploit-pro.jsp
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/
+[13]: http://www.metasploit.com
+[14]: http://www.rapid7.com
+[15]: http://www.rapid7.com/products/metasploit-express.jsp
+[16]: http://www.rapid7.com/products/metasploit-pro.jsp

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -43,12 +43,10 @@ lang: zh_tw
 
 * [Basecamp][9] ，由 [37signals][10] 公司完全以 Ruby 所撰寫的網頁專案管理系統。
 
-* [43 Things][11] 可讓你保存43個想要達成的目標清單並與世界分享。他也是完全以 Ruby 所撰寫而成。
-
-* [A List Apart][12], 從 1997 年就開始發行的一個針對網站製作者的雜誌，最近改版使用 Ruby on Rails
+* [A List Apart][11], 從 1997 年就開始發行的一個針對網站製作者的雜誌，最近改版使用 Ruby on Rails
   所客製化而成的程式。
 
-* [Blue Sequence][13] ，Toyota 汽車 “sequence-in-time” 生產流程中的一個先進的關鍵性任務應用
+* [Blue Sequence][12] ，Toyota 汽車 “sequence-in-time” 生產流程中的一個先進的關鍵性任務應用
   (mission-critical application)，最近被選入 BCS 資訊管理獎的決選名單。
 
 
@@ -63,6 +61,5 @@ lang: zh_tw
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com
 [10]: http://www.37signals.com
-[11]: http://www.43things.com
-[12]: http://www.alistapart.com
-[13]: http://www.bluefountain.com/supply-chain-management/
+[11]: http://www.alistapart.com
+[12]: http://www.bluefountain.com/supply-chain-management/


### PR DESCRIPTION
this patch for issue [#1104](https://github.com/ruby/www.ruby-lang.org/issues/1104) removes the mentioned link to 43things.com and corrects the reference link number of the following ones.