### PR TITLE
Translate all November 2014 news (id)

### DIFF
--- a/id/news/_posts/2014-11-03-tropicalrb-2015-cfp.md
+++ b/id/news/_posts/2014-11-03-tropicalrb-2015-cfp.md
@@ -1,0 +1,20 @@
+---
+layout: news_post
+title: "Tropical Ruby 2015 CFP Dibuka"
+author: "Guilherme Cavalcanti"
+translator: "meisyal"
+date: 2014-11-03 15:20:57 +0000
+lang: id
+---
+
+[Tropical Ruby 2015](http://tropicalrb.com), *the beach Ruby conference*,
+akan berlangsung tanggal 5-8 Maret di Porto de Galinhas,
+sebuah pantai indah yang berlokasi di Pesisir Timur Laut Brazil.
+
+[Avdi Grimm](https://twitter.com/avdi) dan
+[Nick Sutterer](https://twitter.com/apotonick) telah dikonfirmasi sebagai pengisi, tetapi
+[CFP masih dibuka](http://cfp.tropicalrb.com/events/tropicalrb-2015).
+Jika Anda berminat sebagai pengisi atau memberikan loka karya, kirim proposal Anda batas hingga 7 Desember.
+
+Nikmati percakapan luar biasa, pemandangan menakjubkan, dan alam yang luar biasa.
+Datang dan bicara dengan beberapa Rubyists terbaik di konferensi ini.

--- a/id/news/_posts/2014-11-13-rexml-dos-cve-2014-8090.md
+++ b/id/news/_posts/2014-11-13-rexml-dos-cve-2014-8090.md
@@ -1,0 +1,74 @@
+---
+layout: news_post
+title: "CVE-2014-8090: Denial of Service Lain Ekspansi pada XML"
+author: "usa"
+translator: "meisyal"
+date: 2014-11-13 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Ekspansi entitas yang tidak dilarang dapat menyebabkan sebuah celah *DoS* pada REXML, seperti
+["Kerentanan DoS Ekspansi Entity pada REXML (Bom XML, CVE-2013-1821)"](https://www.ruby-lang.org/id/news/2013/02/22/rexml-dos-2013-02-22/)
+dan ["CVE-2014-8080: Parameter Entity expansion DoS vulnerability in REXML"](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/).
+Celah ini telah ditetapkan dalam *CVE identifier*
+[CVE-2014-8090](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-8090).
+Kami sangat merekomendasikan untuk memperbarui Ruby.
+
+## Detil
+
+Ini adalah perbaikan tambahan untuk
+[CVE-2013-1821](https://www.ruby-lang.org/id/news/2013/02/22/rexml-dos-2013-02-22/)
+dan [CVE-2014-8080](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/).
+*patches* sebelumnya memperbaiki ekspansi rekursif di beberapa tempat dan
+jumlah dari ukuran *Strings* yang dibuat. Namun demikian, mereka tidak dapat mengambil akun resmi
+yang digunakan untuk ekspansi entitas. 100% utilitas CPU dapat terjadi sebagai hasil
+ekspansi rekursif dengan sebuah *string* kosong.
+Ketika membaca ujung teks dari sebuah dokumen *XML*, REXML *parser* dapat dipaksa
+mengalokasikan objek *string* yang sangat besar yang mana dapat mengonsumsi semua
+memori dalam sebuah mesin, menyebabkan sebuah *denial of service*.
+
+Imbas tersebut akan terlihat dari kode berikut:
+
+{% highlight ruby %}
+require 'rexml/document'
+
+xml = <<XML
+<!DOCTYPE root [
+  # ENTITY expansion vector
+]>
+<cd></cd>
+XML
+
+p REXML::Document.new(xml)
+{% endhighlight %}
+
+Semua pengguna yang terkena imbas rilis ini seharusnya memperbarui atau menggunakan salah satu
+solusi di bawah ini segera.
+
+## Versi yang Terkena Imbas
+
+* Semua Ruby versi 1.9 hingga 1.9.3 patchlevel 551
+* Semua Ruby versi 2.0 hingga 2.0.0 patchlevel 598
+* Semua Ruby versi 2.1 hingga 2.1.5
+* sebelum revisi *trunk* 48402
+
+## Solusi
+
+Jika Anda tidak dapat memperbarui Ruby, gunakan *monkey patch* di bawah ini sebagai solusi lain:
+
+{% highlight ruby %}
+class REXML::Document
+  def document
+    self
+  end
+end
+{% endhighlight %}
+
+## Credits
+
+Terima kasih Tomas Hoger telah melaporkan masalah ini.
+
+## Histori
+
+* Semula dipublikasikan pada 2014-11-13 12:00:00 UTC

--- a/id/news/_posts/2014-11-13-ruby-1-9-3-p551-is-released.md
+++ b/id/news/_posts/2014-11-13-ruby-1-9-3-p551-is-released.md
@@ -1,0 +1,63 @@
+---
+layout: news_post
+title: "Ruby 1.9.3-p551 Telah Rilis"
+author: "usa"
+translator: "meisyal"
+date: 2014-11-13 12:00:00 +0000
+lang: id
+---
+
+Kami dengan senang hati mengumumkan rilis Ruby 1.9.3-p551.
+
+Rilis ini mencakup perbaikan celah keamanan *DoS* REXML.
+Hal ini sama halnya dengan
+[perbaikan celah](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/)
+yang ada di [rilis sebelumnya](https://www.ruby-lang.org/en/news/2014/10/27/ruby-1-9-3-p550-is-released/),
+tetapi perbaikan ini menangani kasus lain dari ekspansi entitas.
+Mohon untuk melihat topik berikut untuk lebih detil.
+
+* [CVE-2014-8090: Another Denial of Service XML Expansion](https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090/)
+
+
+## Perhatian
+
+Ruby 1.9.3 dalam tahap perawatan keamanan saat ini.
+Ini berarti kamu tidak akan pernah memperbaiki *bugs* tanpa adanya permasalahan keamanan.
+Dan, saat ini, akhir perawatan 1.9.3 juga telah dijadwalkan hingga Februari tahun depan.
+Kami merekomendasikan pengguna Ruby 1.9.3 untuk migrasi ke versi yang lebih baru segera mungkin.
+
+
+## Unduh
+
+* [http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2](http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2)
+
+      SIZE:   10049332 bytes
+      MD5:    0d8b272b05c3449dc848bb7570f65bfe
+      SHA256: b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e
+      SHA512: 5ea40f8c40cf116030ffdedbe436c1fdbf9a50b7bb44bc890845c9c2a885c34da711bc1a9e9694788c2f4710f7e6e0adc4410aec1ab18a25a27168f25ac3d68c
+
+* [http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz](http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz)
+
+      SIZE:   12605119 bytes
+      MD5:    0d8212f7bc89bab8ef521b04cd9df278
+      SHA256: bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8
+      SHA512: be12adf581ee76af70db117b44c6647c1df3d28fffa1b3379c6067e4aa1fb523dae7c9b130a51dcdcff268a8ee21a3d74f6f946135fb3ac6b90664f0a9df4a08
+
+* [http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.xz](http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.xz)
+
+      SIZE:   7704072 bytes
+      MD5:    7367b1dfb2ba1d6abf6fd7db70e765f5
+      SHA256: 44228297861f4dfdf23a47372a3e3c4c5116fbf5b0e10883417f2379874b55c6
+      SHA512: 2dd4cd7494d0d9b1cc2a5c3710a2c771617a367d1ba6f5099adc2785e37efcb668c6508780562359a4a4c83733e349aa5cb4f8532e1f334f9f96543670d35729
+
+* [http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip](http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.zip)
+
+      SIZE:   13987275 bytes
+      MD5:    14a394b1d7b7031b34d4d1af64ee657e
+      SHA256: cf468ccabd5cdef5047b8f02f4f71052fd3a9c87c12aba314f04748a451a63ec
+      SHA512: 6ee550c7e435622114e3669393220a90946652eade0a83dab74970fff7088d5c2051bee9c272e2e6eccc36885b4f64928fc2d27c36584c1cc8dac91ce730d3ea
+
+## Komentar Rilis
+
+Maaf atas ketidaknyamanan terhadap rilis yang berkelanjutan.
+Terima kasih kepada semua yang telah membantu rilis ini.

--- a/id/news/_posts/2014-11-13-ruby-2-0-0-p598-is-released.md
+++ b/id/news/_posts/2014-11-13-ruby-2-0-0-p598-is-released.md
@@ -1,0 +1,59 @@
+---
+layout: news_post
+title: "Ruby 2.0.0-p598 Telah Rilis"
+author: "usa"
+translator: "meisyal"
+date: 2014-11-13 12:00:00 +0000
+lang: id
+---
+
+Kami dengan senang hati mengumumkan rilis Ruby 2.0.0-p598.
+
+Rilis ini mencakup perbaikan celah keamanan *DoS* pada REXML.
+Hal ini sama halnya dengan
+[perbaikan celah](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/)
+yang ada di [rilis sebelumnya](https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-0-0-p594-is-released/),
+tetapi rilis ini juga menangani kasus lain ekspansi entitas.
+Mohon melihat topik berikut untuk lebih detil.
+
+* [CVE-2014-8090: Another Denial of Service XML Expansion](https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090/)
+
+Dan, beberapa perbaikan terhadap *bugs* juga dimasukkan.
+Lihat [tiket](https://bugs.ruby-lang.org/projects/ruby-200/issues?set_filter=1&amp;status_id=5)
+dan [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_0_0_598/ChangeLog)
+untuk lebih detil.
+
+## Unduh
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2)
+
+      SIZE:   10758882 bytes
+      MD5:    a3f3908103a7d209d1d1cf4712e3953c
+      SHA256: 67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f
+      SHA512: 10026a04e01a8ad14ea9c99bbdf4f7d04029b73ee0c01bbf6c2eb2817332d49adacf127b646693b67b5dd7010eaf3b696b23b6335cc0f7ee5a6b56dbba0f6f82
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz)
+
+      SIZE:   13608640 bytes
+      MD5:    e043a21ce0d138fd408518a80aa31bba
+      SHA256: 4136bf7d764cbcc1c7da2824ed2826c3550f2b62af673c79ddbf9049b12095fd
+      SHA512: 0548aba9bf45e380e5f73e73168ea7fea341fc9739e108c7d530d11b677f6a78b2c4e29062d16a73b4286acaa2333ed20cb34e16b65b5b6898da66661f1717da
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.xz](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.xz)
+
+      SIZE:   8316092 bytes
+      MD5:    2ec36f7018eef05003bf8cf0e0f05def
+      SHA256: 9dccf4c30e1bb004b18cb1129d9daac3c0ec510a671f4f4f13a2747897ffab35
+      SHA512: bf7b93d9fbaab98a64d1f45c3f3bbcdfebd3e1d0584dfb27696b2716d93c2ba13881e1edaef6d3eccd769ac2e21d6157024c902f3d891951a20b972c1942ef99
+
+* [http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.zip](http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.zip)
+
+      SIZE:   15126384 bytes
+      MD5:    aa6ac22747947e6562d5b0dc9767ecda
+      SHA256: d5bdafd7b0fbd4254902ba10385c6e5812beac4ad221805aa4d92a37eff47f97
+      SHA512: 6cdaf7f2d27a5f0ead9b94325b9c9fe90cf04c64dedaea8e1d45a8855a73ad61c5c72f1fda835eab73693c25c15a74c7e4e639ed5c18a9433dd79e398600b3ea
+
+## Komentar Rilis Tersebut
+
+Maaf atas ketidaknyamanan dalam menyampaikan rilis terus-menerus.
+Terima kasih kepada semua yang telah membantu rilis ini.

--- a/id/news/_posts/2014-11-13-ruby-2-1-5-is-released.md
+++ b/id/news/_posts/2014-11-13-ruby-2-1-5-is-released.md
@@ -1,0 +1,58 @@
+---
+layout: news_post
+title: "Ruby 2.1.5 Telah Rilis"
+author: "nagachika"
+translator: "meisyal"
+date: 2014-11-13 12:00:00 +0000
+lang: id
+---
+
+Ruby 2.1.5 telah dirilis.
+
+Rilis ini mencakup perbaikan celah keamanan *DoS* pada REXML.
+Perbaikan tersebut sama dengan
+[perbaikan celah](https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/)
+yang disebut di [rilis sebelumnya](https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-1-4-released/),
+tetapi ini baru dan berbeda dengan sebelumnya.
+
+* [CVE-2014-8090: Another Denial of Service XML Expansion](https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090/)
+
+Dan, beberapa perbaikan *bug* juga ikut dimasukkan.
+Lihat [tiket](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)
+dan [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_1_5/ChangeLog)
+untuk lebih detil.
+
+## Unduh
+
+* [http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2)
+
+      SIZE:   11994454 bytes
+      MD5:    a7c3e5fec47eff23091b566e9e1dac1b
+      SHA256: 0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9
+      SHA512: d4b1e3c2b6a0dc79846cce056043c48a2a2a97599c76e9a07af21a77fd10e04c8a34f3a60b6975181bff17b2c452af874fa073ad029549f3203e59095ab70196
+
+* [http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz)
+
+      SIZE:   15127433 bytes
+      MD5:    df4c1b23f624a50513c7a78cb51a13dc
+      SHA256: 4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100
+      SHA512: a7da8dc755e5c013f42269d5e376906947239b41ece189294d4355494a0225590ca73b85261ddd60292934a8c432231c2308ecfa137ed9e347e68a2c1fc866c8
+
+* [http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.xz](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.xz)
+
+      SIZE:   9371780 bytes
+      MD5:    8a30ed4b022a24acbb461976c9c70789
+      SHA256: 22ba1eb8d475c9ed7e0541418d86044c1ea4c093ab79c300c38fc0f721afe9a3
+      SHA512: 8a257da64158d49bc2810695baf4b5849ef83e3dde452bf1e4823e52e8261225427d729fce2fb4e9b53d6d17ca9c96d491f242535c2f963738b74f90944e2a0b
+
+* [http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.zip](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.zip)
+
+      SIZE:   16657694 bytes
+      MD5:    810cd05eb03c00f89b0b03b10e9a3606
+      SHA256: 69c517a6d3ea65264455a9316719ffdec49cf6a613a24fd89b3f6da7146a8aa7
+      SHA512: a55cf5970203904e7bc8cef2b6fbf7b8d5067a160289a1a49d13c4dfef8c95002bcdf697f5d04d420ef663efad5ee80d5a9e4e7445c4db9a02f9cbc9e4b8444e
+
+## Komentar Rilis
+
+Maaf atas ketidaknyamanan akibar rilis yang beruntun.
+Terima kasih kepada semua yang telah bekerja sama terhadap rilis ini.

--- a/id/news/_posts/2014-11-28-ruby-2-2-0-preview2-released.md
+++ b/id/news/_posts/2014-11-28-ruby-2-2-0-preview2-released.md
@@ -1,0 +1,94 @@
+---
+layout: news_post
+title: "Ruby 2.2.0-preview2 Telah Rilis"
+author: "naruse"
+translator: "meisyal"
+date: 2014-11-28 09:00:00 +0000
+lang: id
+---
+
+Kami dengan senang hati mengumumkan rilis Ruby 2.2.0-preview2.
+
+Ruby 2.2.0-preview2 adalah *preview* kedua dari Ruby 2.2.0.
+Banyak fitur baru dan penyempurnaan dimasukkan seiring dengan meningkatnya
+tuntunan dan perkembangan Ruby.
+
+Sebagai contoh, *Symbol GC* membuat *Symbols garbage collectable*.
+Hal ini mengurangi penggunaan memori dari simbol; karena GC tidak dapat mengumpulkan simbol sebelum
+Ruby 2.2. Karena Rails 5.0 akan memerlukan *Symbol GC*, hal tersebut hanya didukung oleg Ruby 2.2
+atau terbaru. (Lihat [Rails' blog post](http://weblog.rubyonrails.org/2014/8/20/Rails-4-2-beta1/) untuk lebih detil.)
+
+Juga, *Incremental GC* baru mengurangi waktu jeda dari *garbage collection*, di mana sangat membantu untuk menjalankan aplikasi Rails.
+
+Fitur lain yang berkaitan dengan manajemen memori adalah penambahan sebuah opsi *configure.in* untuk menggunakan *jemalloc*
+[Fitur #9113](https://bugs.ruby-lang.org/issues/9113).
+Ini merupakan fitur percobaan, dan dimatikan secara *default*.
+Kami butuh untuk mengumpulkan studi kasus dan data performa.
+Ketika kami yakin mendapatkan keberhasilan, fitur ini akan diaktifkan secara *default*.
+
+Satu topik lagi [menggunakan vfork(2) di system() dan spawn() (Japanese)](http://www.a-k-r.org/d/2014-09.html#a2014_09_06).
+Hal tersebut di atas diharapkan dapat membawa kecepatan tinggi ketika sebuah proses yang sangat besar mengeksekusi perintah eksternal berulang kali.
+Tetapi *vfork(2)* adalah sebuah pemanggil sistem yang berisiko.
+Kami ingin tahu berapa keberhasilan yang akan didapatkan melalui pengumpulan studi kasus dan data performa.
+
+Coba dan nikmati memprogram dengan Ruby 2.2.0-preview2, dan laporkan sejauh mana Anda ke kami!
+
+##  Perubahan Penting sejak 2.1
+
+* [Incremental GC](https://bugs.ruby-lang.org/issues/10137) ([YARV Maniacs No.12](http://magazine.rubyist.net/?0048-YARVManiacs))
+* [Symbol GC](https://bugs.ruby-lang.org/issues/9634) ([*slide* presentasi di RubyKaigi 2014](http://www.slideshare.net/authorNari/symbol-gc))
+* configure --with-jemalloc [Fitur #9113](https://bugs.ruby-lang.org/issues/9113)
+* *core libraries*:
+  * Mendukung Unicode 7.0 [#9092](https://bugs.ruby-lang.org/issues/9092)
+  * *New methods*:
+    * Enumerable#slice_after [#9071](https://bugs.ruby-lang.org/issues/9071), Enumerable#slice_when [#9826](https://bugs.ruby-lang.org/issues/9826)
+    * Float#next_float, Float#prev_float [#9834](https://bugs.ruby-lang.org/issues/9834)
+    * File.birthtime, File#birthtime [#9647](https://bugs.ruby-lang.org/issues/9647)
+    * String#unicode_normalize [#10084](https://bugs.ruby-lang.org/issues/10084)
+* *bundled libraries*:
+  * Memperbarui Psych 2.0.6
+  * Memperbarui Rake 10.4.0
+  * Memperbarui RDoc 4.2.0.alpha (21b241a)
+  * Memperbarui RubyGems 2.4.4+ (2f6e42e)
+  * rubygems 2.4.4+ (2f6e42e)
+  * Memperbarui test-unit 3.0.7 (dihapus dari *repository* tetapi dibundel
+di dalam *tarball*)
+  * Memperbarui minitest 5.4.3 (dihapus dari *repository* tetapi dibundel di dalam *tarball*)
+  * *Deprecate* mathn
+* C API
+  * Menghapus *APIs* yang usang
+
+Lihat [NEWS di dalam *repository* Ruby (WIP)](https://github.com/ruby/ruby/blob/v2_2_0_preview2/NEWS) untuk lebih detil.
+
+Dengan perubahan tersebut, 1239 berkas berubah, 98343 Penambahan(+), 61858 penghapusan(-).
+
+## Unduh
+
+* <http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2>
+  * SIZE:   12505279 bytes
+  * MD5:    d7abace25a8ffe861cb2807bef1c58a6
+  * SHA256: 9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b
+  * SHA512: c654d4c047f9463a5fb81eaea0fa5ab7bf316962bc7fb0fb356861e6336ce8ce2162c7779d8b27f72d7bc0e9604b5e5af2910abcb0b0a1f197b3138eaddfd4a5
+* <http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.gz>
+  * SIZE:   15505521 bytes
+  * MD5:    bde388d6f10012a92d5dc36196fd6755
+  * SHA256: dfcef7b01bd3acb41da6689993ac8dd30e2ecd4fd14bc1a833f46188a9fe2614
+  * SHA512: e2d316a679c15c021e40b0f9b7810b319c6a5e771a9b869fda35b6745aecac881bbb05d62192893799816a8673e05c8f17713f10ccdec077f546483608ab85c1
+* <http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.xz>
+  * SIZE:   9649216 bytes
+  * MD5:    0d582e28b92ce9d1456e40fb8d821422
+  * SHA256: d14d1fa045263fa242a515d7b9e8c485bf8a9ee9d9d3012dc2b6add0f3a370c6
+  * SHA512: 4a8a75ab21b2bd43db4a22d9c63f189f3c7805d575d662b07a4ddc25aa5b156b0c23053d8c48eecf23d5e22f1ea7131467f1cdc48f9ae0a83214b4cd46b08491
+* <http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.zip>
+  * SIZE:   17239396 bytes
+  * MD5:    d94160c214016863932c25cc1ac6ff90
+  * SHA256: 88d6c73ee1a4f5fe1f8ad37fe1f56c1ca50622f1338c20b9d46bbb5c2cd94040
+  * SHA512: 0a021d31f54c47c5c3901ef6f2ab02a1bfb5cc698f971978c1e16b1aeda78fdadec0c1cdd48af1c8784b8f72ad00d35cf2433d78e20d4447fa0630e02b4e3917
+
+## Komentar Rilis
+
+* [Isu 2.2.0 yang diketahui](http://bugs.ruby-lang.org/projects/ruby-trunk/issues?query_id=115)
+
+Lihat juga jadwal rilis dan informasi lainnya:
+
+[ReleaseEngineering22](http://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering22)


### PR DESCRIPTION
New pull request from the [old one](https://github.com/ruby/www.ruby-lang.org/pull/1116).
I have made the link of post reference to translated post when they exist. The title of translated link is translated too. But, if the translated link post doesn't exist I used the default language or English post as the reference without any title link translation.

Please, review this PR @gozali and @stomar!

Thank you so much.