### PR TITLE
Improve SSL configuration

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -78,7 +78,10 @@ use Rack::Rewrite do
   r302 %r{^/pt/bibliotecas(.*)$}, "/pt/libraries$1"
 end
 
-use Rack::SSL
+if ENV["RACK_ENV"] == "production"
+  use Rack::SSL
+end
+
 use Rack::Protection::HttpOrigin
 use Rack::Protection::FrameOptions
 

--- a/config.ru
+++ b/config.ru
@@ -7,11 +7,6 @@ require 'yaml'
 use Rack::CommonLogger
 
 use Rack::Rewrite do
-  if ENV["RACK_ENV"] == "production"
-    r301 %r{.*}, "https://www.ruby-lang.org$&", scheme: "http", host: "www.ruby-lang.org"
-    r301 %r{.*}, "https://staging.ruby-lang.org$&", scheme: "http", host: "staging.ruby-lang.org"
-  end
-
   # enforce trailing slash (/foo -> /foo/) when index.html exists
   r302 %r{.*}, "$&/", if: ->(rack_env) {
     rack_env["PATH_INFO"].match(%r{/$}).nil? && File.exist?("_site#{rack_env["PATH_INFO"]}/index.html")


### PR DESCRIPTION
@hsbt Any objections?

Activating rack-ssl only in production makes serving locally using `rackup` easier. (I couldn't manage to do that with SSL on.) Compared to serving the site using e.g. `jekyll --serve`, local testing could then be done in a more production-like environment, including rewrite rules, rack/jekyll, ...
