### PR TITLE
Add link directly to ruby-core list

### DIFF
--- a/en/community/mailing-lists/index.md
+++ b/en/community/mailing-lists/index.md
@@ -17,7 +17,7 @@ Ruby-Talk
 
 Ruby-Core
 : This list deals with core and implementation topics about Ruby, often
-  used to run patches for review. ([Archives][4])
+  used to run patches for review. ([Subscribe][6] and [Archives][4])
 
 Ruby-Doc
 : This list is for discussing documentation standards and tools for
@@ -45,3 +45,4 @@ subscribing the [manual way](manual-instructions/).
 [3]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
 [4]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
 [5]: http://dir.gmane.org/gmane.comp.lang.ruby.documentation
+[6]: http://lists.ruby-lang.org/cgi-bin/mailman/listinfo/ruby-core


### PR DESCRIPTION
It is difficult to find the "Welcome to the "ruby-core" mailing list" email to manage your ruby-core list subscription. We should add a link directly to the page for easy access. I made the link body of to this site "subscribe" to keep it short, but we can pick something else. I think "subscribe" is not very accessible to people using screen readers, instead maybe "manage ruby-core list subscription".
