### PR TITLE
Mention that CVE-2014-6438 was assigned to this bug.

### DIFF
--- a/de/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/de/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -12,7 +12,8 @@ Wir haben 1.9.2-p330 veröffentlicht, das abschließende Release der
 
 Kurz nach der Bekanntgabe des
 [Unterstützungsendes für 1.9.2 und 1.8.7](https://www.ruby-lang.org/de/news/2014/07/01/eol-for-1-8-7-and-1-9-2/)
-wurde eine kritische Sicherheitslücke in 1.9.2 entdeckt.
+wurde eine kritische Sicherheitslücke in 1.9.2 entdeckt. Dieser
+Sicherheitslücke wurde die CVE-Nummer [CVE-2014-6438] zugewiesen.
 
 Dieser Fehler tritt auf, wenn ein langer String mithilfe der
 URI-Methode `decode_www_form_component` verarbeitet wird und kann in
@@ -52,3 +53,5 @@ Sie können den ursprünglichen Fehlerbericht im Ticketsystem nachlesen:
 Wir ermutigen Sie dazu, auf eine stabile und unterstützte
 [Version von Ruby](https://www.ruby-lang.org/de/downloads/)
 zu aktualisieren.
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438)

--- a/en/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/en/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -11,7 +11,8 @@ We have released 1.9.2-p330, the final release of the 1.9.2 series.
 
 Soon after announcing the
 [End of Life for 1.9.2 (and 1.8.7)](https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/),
-a critical security regression was found in 1.9.2.
+a critical security regression was found in 1.9.2. This vulnerability has been
+assigned the CVE identifier [CVE-2014-6438].
 
 This bug occurs when parsing a long string is using the URI method
 `decode_www_form_component`. This can be reproduced by running the following
@@ -50,3 +51,5 @@ You can read the original report on the bug tracker:
 
 We encourage you to upgrade to a stable and maintained
 [version of Ruby](https://www.ruby-lang.org/en/downloads/).
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/es/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/es/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -11,7 +11,9 @@ Hemos liberado la versión 1.9.2-p330, la versión final de la serie 1.9.2.
 
 Luego de haber anunciado el
 [Fin de la Vida de 1.9.2 (y 1.8.7)](https://www.ruby-lang.org/es/news/2014/07/01/eol-for-1-8-7-and-1-9-2/),
-se encontró una regresión de seguridad crítica en 1.9.2.
+se encontró una regresión de seguridad crítica en 1.9.2. A esta vulnerabilidad
+se le ha asignado el identificador [CVE-2014-6438].
+
 
 Este problema ocurre cuando se interpreta una cadena larga utilizando el método
 de URI `decode_www_form_component` y puede ser reproducido utilizando el código
@@ -50,3 +52,5 @@ Puedes leer el reporte original de el problema en el tracker:
 
 Te recomendamos que actualices a una versión
 [estable y mantendida de Ruby](https://www.ruby-lang.org/es/downloads/).
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/it/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/it/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -11,7 +11,8 @@ Abbiamo rilasciato Ruby 1.9.2-p330, la release finale della serie 1.9.2.
 
 Poco dopo l'annuncio di
 [EOL per 1.8.7 e 1.9.2](https://www.ruby-lang.org/it/news/2014/07/01/eol-for-1-8-7-and-1-9-2/)
-è stata trovata una regressione di sicurezza critica sulla 1.9.2.
+è stata trovata una regressione di sicurezza critica sulla 1.9.2. A questa
+vulnerabilità è stato assegnato l'identificativo [CVE-2014-6438].
 
 Il bug avviene quando il parsing di una lunga stringa usa il metodo URI
 `decode_www_form_component`. Questo può essere riprodotto eseguendo quanto segue
@@ -51,3 +52,5 @@ Potete leggere la segnalazione originale sul bug tracker:
 Vi incoraggiamo ad aggiornare ad una
 [versione di Ruby](https://www.ruby-lang.org/it/downloads/)
 stabile e mantenuta.
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/ja/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/ja/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -11,6 +11,7 @@ Ruby 1.9.2-p330 がリリースされました。これは 1.9.2 系列の最後
 
 ["Ruby 1.8.7 および 1.9.2 のサポート終了について"](https://www.ruby-lang.org/ja/news/2014/07/01/eol-for-1-8-7-and-1-9-2/)
 のアナウンス後、Ruby 1.9.2 にセキュリティ上致命的なリグレッションが発見されました。
+この脆弱性は [CVE-2014-6438] として CVE に登録されています。
 
 このバグは URI のメソッド `decode_www_form_component` を利用して、長い文字列をパースする時に発生します。この脆弱性を含む Ruby において、次のようにして再現する事が可能です:
 
@@ -44,3 +45,5 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
       SHA256: 7a04a028564de7f2ad09f26c8d57fd40fe2b0a6a0e1d9ff7205010ca6e70cea6
 
 われわれはより安定し、メンテナンスされている[バージョンの Ruby](https://www.ruby-lang.org/ja/downloads/) へのアップグレードを推奨します。
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/ko/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/ko/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -11,6 +11,7 @@ lang: ko
 
 [1.8.7과 1.9.2의 종료](https://www.ruby-lang.org/ko/news/2014/07/01/eol-for-1-8-7-and-1-9-2/)
 공지 직후에 치명적인 보안 회귀가 1.9.2에서 발견되었습니다.
+이 취약점은 CVE ID [CVE-2014-6438]에 할당 되었습니다.
 
 이 버그는 URI 메소드 `decode_www_form_component`를 이용해 긴 문자열을 파싱할 때
 발생합니다. 이 버그는 다음 코드를 취약점이 있는 루비 환경에서 실행해 보는 것으로
@@ -47,3 +48,5 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
       SHA256: 7a04a028564de7f2ad09f26c8d57fd40fe2b0a6a0e1d9ff7205010ca6e70cea6
 
 안정적이고 관리되고 있는 [루비 버전](https://www.ruby-lang.org/ko/downloads/)을 사용하시는 것을 권장합니다.
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/pl/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/pl/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -12,6 +12,7 @@ Właśnie wydaliśmy 1.9.2-p330, finalne wydanie serii 1.9.2.
 Wkrótce po ogłoszeniu
 [Końca życia dla 1.9.2 (i 1.8.7)](https://www.ruby-lang.org/pl/news/2014/07/01/eol-for-1-8-7-and-1-9-2/),
 została znaleziona krytyczna regresja bezpieczeństwa w 1.9.2.
+Tej podatności został przypisany identyfikator [CVE-2014-6438].
 
 Ten błąd występuje podczas parsowania długiego napisu podczas używania metody
 URI `decode_www_form_component`. Można to odtworzyć poprzez uruchomienie
@@ -50,3 +51,5 @@ Możesz przeczytać oryginalny raport o błędzie:
 
 Zalecamy zaktualizowanie do stabilnej i wspieranej
 [wersji Rubiego](https://www.ruby-lang.org/pl/downloads/).
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/vi/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/vi/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -13,6 +13,7 @@ Chúng tôi hân hạnh công bố ấn bản 1.9.2-p330,
 Ngay sau khi công bố
 [Ngưng hỗ trợ cho 1.9.2 (và 1.8.7)](https://www.ruby-lang.org/vi/news/2014/07/01/eol-for-1-8-7-and-1-9-2/),
 một lỗi regression bảo mật được phát hiện trong 1.9.2.
+Lỗ hổng này đã được đánh dấu lỗi trên CVE [CVE-2014-6438].
 
 Lỗi này xảy ra khi truyền vào một chuỗi với hàm URI `decode_www_form_component`.
 Lỗi có thể thực
@@ -51,3 +52,5 @@ Bạn có thể đọc bản báo cáo gốc trên bug tracker:
 
 Chúng tôi khuyến khích bạn nâng cấp lên
 [bản ổn định mới nhất của Ruby](https://www.ruby-lang.org/vi/downloads/).
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/zh_cn/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/zh_cn/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -10,6 +10,7 @@ lang: zh_cn
 1.9.2 版本最后一个版本 1.9.2-p330 已经发布。
 
 在宣布[终止 1.8.7 和 1.9.2](https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/) 版本不久后，1.9.2 版本发现一个严重的安全性问题。
+这个风险的 CVE 识別号已经被指派为 [CVE-2014-6438]。
 
 当使用 URI的 `decode_www_form_component` 方法去解析长字符串时会出现这个错误。
 
@@ -45,3 +46,5 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 我们建议你升级到一个稳定的并处于维护中的
 [Ruby 版本](https://www.ruby-lang.org/zh_cn/downloads/)。
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438

--- a/zh_tw/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/zh_tw/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -10,6 +10,7 @@ lang: zh_tw
 我們發佈了 1.9.2-p330，1.9.2 版本的最後一個發行版。
 
 在宣布[終止 1.8.7 和 1.9.2](https://www.ruby-lang.org/zh_tw/news/2014/07/01/eol-for-1-8-7-and-1-9-2/) 不久後，1.9.2 版本發現一個嚴重的安全性錯誤。
+這個風險的 CVE 識別號已經被指派為 [CVE-2014-6438]。
 
 這個錯誤發生在使用 URI 的 `decode_www_form_component` 方法來解析長字串的場景。可以透過使用存在風險的 Ruby 版本執行以下程式來重現這個錯誤：
 
@@ -43,3 +44,5 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 我們建議升級至穩定並仍在維護的
 [Ruby 版本](https://www.ruby-lang.org/zh_tw/downloads/)。
+
+[CVE-2014-6438]: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438


### PR DESCRIPTION
Add links to [CVE-2014-6438](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6438) to all "Ruby 1.9.2-p330 released" blog posts. I copied the translated text from the "REXML DoS CVE-2014-8090" blog posts.