### PR TITLE
Add RubyConf Taiwan 2015 CFP post (en)

### DIFF
--- a/en/news/_posts/2015-06-25-rubyconftw-2015-call-for-proposals.md
+++ b/en/news/_posts/2015-06-25-rubyconftw-2015-call-for-proposals.md
@@ -1,0 +1,23 @@
+---
+layout: news_post
+title: "RubyConf Taiwan 2015 CFP is open"
+author: "Juanito Fatas"
+translator:
+date: 2015-07-14 15:30:00 +0000
+lang: en
+---
+
+[RubyConf Taiwan 2015](http://rubyconf.tw) will take place during September
+11–12nd at Taipei, Taiwan, a tropical island located in the heart of Asia.
+
+[Matz](https://twitter.com/yukihiro_matz),
+[Aaron Patterson](https://twitter.com/tenderlove),
+[Sarah Allen](https://twitter.com/ultrasaurus),
+and [Ruddy Lee](https://ruddyblog.wordpress.com) are confirmed keynote speakers.
+[CFP is open](http://rubytaiwan.kktix.cc/events/rubyconftw2015-cfp)
+untill July 20th (GMT +8) and
+[Lightening talk CFP](http://rubytaiwan.kktix.cc/events/rubyconftw2015-ltcfp)
+is open untill August 10th (GMT +8).
+
+If you want to give a talk, please submit your proposal. Any topics related to
+Ruby are welcome. We look forward to seeing you in Taiwan.


### PR DESCRIPTION
Add RubyConf Taiwan 2015 CFP news. Please review thanks!

/cc @ryudoawaru @kaochenlong