### PR TITLE
Markup not found issues

### DIFF
--- a/id/news/_posts/2009-01-30-ruby-1-9-1-rilis.md
+++ b/id/news/_posts/2009-01-30-ruby-1-9-1-rilis.md
@@ -21,16 +21,14 @@ Perlu diketahui bahwa Ruby 1.8.8 masih akan dirilis tahun ini.
 
 Anda dapat membaca tentang perubahan besar sejak 1.8.7 [disini][1]
 
-7 [bug telah
-diperbaiki](:https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=11)
-sejak Ruby 1.9.1 RC2.
+7 [bug telah diperbaiki][2] sejak Ruby 1.9.1 RC2.
 
 Jika anda menemukan bug atau ada masalah, silakan laporkan dengan
-menggunakan [sistem pelacakan masalah][2] resmi.
+menggunakan [sistem pelacakan masalah][3] resmi.
 
 Download dari
 
-* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2][3]
+* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2][4]
   SIZE: 7190271 bytes
 
   MD5: 0278610ec3f895ece688de703d99143e
@@ -39,7 +37,7 @@ Download dari
   de7d33aeabdba123404c21230142299ac1de88c944c9f3215b816e824dd33321
 ^
 
-* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz][4]
+* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz][5]
   SIZE: 9025004 bytes
 
   MD5: 50e4f381ce68c6de72bace6d75f0135b
@@ -48,7 +46,7 @@ Download dari
   a5485951823c8c22ddf6100fc9e10c7bfc85fb5a4483844033cee0fad9e292cc
 ^
 
-* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip][5]
+* [ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip][6]
   SIZE: 10273609 bytes
 
   MD5: 3377d43b041877cda108e243c6b7f436
@@ -59,7 +57,8 @@ Download dari
 
 
 [1]: http://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS
-[2]: https://bugs.ruby-lang.org
-[3]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2
-[4]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz
-[5]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip
+[2]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=11
+[3]: https://bugs.ruby-lang.org
+[4]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2
+[5]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz
+[6]: ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip

--- a/id/news/_posts/2012-10-12-cve-2012-4464-cve-2012-4466.md
+++ b/id/news/_posts/2012-10-12-cve-2012-4464-cve-2012-4466.md
@@ -49,4 +49,4 @@ Kerentanan ini ditemukan oleh Tyler Hickes.
 
 
 
-[1]: {{ site.url }}/id/news/2011/02/18/exception-methods-can-bypass-safe/
+[1]: {{ site.url }}/en/news/2011/02/18/exception-methods-can-bypass-safe/


### PR DESCRIPTION
- Found one 404 on https://www.ruby-lang.org/id/news/2012/10/12/cve-2012-4464-cve-2012-4466/index.html ( masalah keamanan yang mirip ), use English version.
- Other commit is about link generated `:https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=11`, use same bottom link as other news. (https://www.ruby-lang.org/id/news/2009/01/30/ruby-1-9-1-rilis/)