### PR TITLE
Translate about/logo and about/website [bg]

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -516,12 +516,12 @@ locales:
       other_news: Други новини
       more_news: Още новини...
       continue: Прочетете още...
-      back_to_year: "Back to %Y Archives"
+      back_to_year: "Обратно към архив %Y"
       recent_news: Последни новини
-      yearly_archive_title: "%Y Archives"
-      monthly_archive_title: "%B %Y Archives"
+      yearly_archive_title: "Архив %Y"
+      monthly_archive_title: "Архив %B %Y"
       yearly_archives: Архив по година
-      monthly_archives: Archives by Month
+      monthly_archives: Архив по месец
       yearly_archive_link: "%Y"
       monthly_archive_link: "%B %Y"
     de:
@@ -1653,14 +1653,14 @@ locales:
 
   subscription_form:
     bg:
-      list: Mailing List
-      first_name: First Name
-      last_name: Last Name
-      email: Email Address
-      action: Action
-      subscribe: Subscribe
-      unsubscribe: Unsubscribe
-      submit: Submit Form
+      list: Пощенски списък
+      first_name: Име
+      last_name: Фамилия
+      email: Email адрес
+      action: Действие
+      subscribe: Записване
+      unsubscribe: Отписване
+      submit: Изпрати
     de:
       list: Mailingliste
       first_name: Vorname
@@ -1798,6 +1798,7 @@ locales:
       submit: 送出表格
 
   languages_heading:
+    bg: "Този сайт на други езици:"
     de: "Diese Website in anderen Sprachen:"
     en: "This site in other languages:"
     fr: "Autres langues disponibles :"
@@ -1809,12 +1810,8 @@ locales:
 
   credits:
     bg: |
-      Този сайт е генериран с Ruby и излползва <a href="http://www.jekyllrb.com/">Jekyll</a>.
-      Поддържа се от членове на Ruby обществото.
-      Ако имате желание да допринесете за развитието му, моля посетете
-      <a href="https://github.com/ruby/www.ruby-lang.org/">GitHub</a> или се свържете с
-      <a href="mailto:webmaster@ruby-lang.org">webmaster-a</a>
-      за въпроси или коментари.
+      <a href="/bg/about/website/">Този сайт</a>
+      се поддържа от членове на Ruby обществото.
     de: |
       <a href="/de/about/website/">Diese Website</a>
       wird mit Stolz von Mitgliedern der Ruby-Community gepflegt.

--- a/bg/about/logo/index.md
+++ b/bg/about/logo/index.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: "Логото на Ruby"
+lang: bg
+---
+
+![Логото на Ruby][logo]
+
+Логото на Ruby е обект на авторско право &copy; 2006, Yukihiro Matsumoto.
+
+То е лицензирано под условията на [Creative Commons Attribution-ShareAlike 2.5 License][cc-by-sa]
+споразумението.
+
+
+## Сваляне
+
+[Лого-комплектът на Ruby][logo-kit] съдържа логото в няколко различни формата
+(PNG, JPG, PDF, AI, SWF, XAR).
+
+
+[logo]: /images/header-ruby-logo.png
+[logo-kit]: https://cache.ruby-lang.org/pub/misc/logo/ruby-logo-kit.zip
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/2.5/

--- a/bg/about/website/index.md
+++ b/bg/about/website/index.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Относно този уебсайт"
+lang: bg
+---
+
+Този уебсайт е генериран с Ruby и използва [Jekyll][jekyll],<br>
+а изходният код се хоства в [Github][github-repo].
+
+Визуалният дизайн e изготвен от [Jason Zimdars][jzimdars].<br>
+
+[Логото на Ruby][logo] е обект на Авторско право &copy; 2006, Yukihiro Matsumoto.
+
+
+## Докладване за проблеми ##
+
+За докладване на проблем, моля използвайте нашият [issue tracker][github-issues]
+или се свържете с нашият [webmaster][webmaster] (на английски).
+
+
+## Как да допринесете ##
+
+Този уебсайт се поддържа от членове на Ruby обществото.
+
+Ако желаете да допринесете за развитието му, моля прочетете
+[инструкции за допринасяне][github-wiki] и създайте ново Issue
+или Pull request.
+
+
+## Благодарности ##
+
+Благодарим на всички автори, преводачи и всички, допринесли за развитието
+на този сайт.
+
+Благодарим и на организациите, които ни подкрепят:
+
+ * [NaCl][nacl] (хостинг),
+ * [Heroku][heroku] (хостинг),
+ * [IIJ][iij] (хостинг),
+ * [GlobalSign][globalsign] (SSL сертифициране),
+ * [Fastly][fastly] (CDN).
+ * [Hatena][hatena] ([mackerel][mackerel], Сървърен мониторинг)
+ * [CloudCore][cloudcore] (build сървър)
+ * [Ruby no Kai][rubynokai] (build сървър)
+
+[logo]: /bg/about/logo/
+[webmaster]: mailto:webmaster@ruby-lang.org
+[jekyll]: http://www.jekyllrb.com/
+[jzimdars]: http://twitter.com/jz
+[github-repo]: https://github.com/ruby/www.ruby-lang.org/
+[github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
+[github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki
+[nacl]: http://www.netlab.jp
+[heroku]: https://www.heroku.com/
+[iij]: http://www.iij.ad.jp
+[globalsign]: https://www.globalsign.com
+[fastly]: http://www.fastly.com
+[hatena]: http://hatenacorp.jp/
+[mackerel]: https://mackerel.io/
+[cloudcore]: http://www.cloudcore.jp/
+[rubynokai]: http://ruby-no-kai.org/


### PR DESCRIPTION
The changes were suggested by @stomar in #912.

The about/logo and about/website pages have been translated, as well as all missing strings in _config.yml.

I also found a broken link in the about/website page - the link to the twitter account of Jason Zimdars seems to have changed to https://twitter.com/jasonzimdars, but I will fix it in another PR.