### PR TITLE
Add Matsue RubyKaigi 07 registration open news

### DIFF
--- a/ja/news/_posts/2015-09-03-matsue-rubykaigi-registration-is-open.md
+++ b/ja/news/_posts/2015-09-03-matsue-rubykaigi-registration-is-open.md
@@ -1,0 +1,27 @@
+---
+layout: news_post
+title: "松江Ruby会議07の参加登録が開始されました"
+author: "Sho Hashimoto（@sho_hashimoto）"
+translator:
+date: 2015-09-03 14:50:12 +0000
+lang: ja
+---
+
+日本Rubyの会が後援する、[地域Ruby会議(RegionalRubyKaigi)][1]の1つである[松江Ruby会議07](http://matsue.rubyist.net/matrk07/)の参加登録が開始されました。
+
+* 開催日: 2015年9月26日(土) 11:00 〜 17:10 (懇親会) 18:00 〜 20:00
+* 会場: [松江テルサ４F](https://www.google.com/maps/search/松江テルサ/@35.463976,133.062015,14z?hl=ja)
+* 主　 催: Matsue.rb(まつえるびー)
+* 参加費: 無料
+* 中継: [動画による中継(YouTube)](https://www.youtube.com/watch?v=JhNlQra5VKg)
+* 公式タグ: [#matrk07](https://twitter.com/search?q=matrk07&src=typd&f=realtime)
+
+## 参加登録
+
+Doorkeeper にて申し込みを受け付けています。
+
+* [参加受付](https://matsue-rb.doorkeeper.jp/events/27629)
+* [懇親会(一般)](http://matsue-rb.doorkeeper.jp/events/27632)
+* [懇親会(学生)](http://matsue-rb.doorkeeper.jp/events/27631)
+
+[1]: http://regional.rubykaigi.org/


### PR DESCRIPTION
Add Matsue RubyKaigi 07 registration open news according to the instructions in [Regionalrubykaigi's wiki](https://github.com/ruby-no-kai/official/wiki/Regionalrubykaigi#参加申し込みを開始したら).