### PR TITLE
A few more `pt` translation fixes

### DIFF
--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -9,6 +9,20 @@ referências que serão úteis quando você sentir que gosta de programar
 em Ruby.
 {: .summary}
 
+### Instalando o Ruby
+
+A menos que você queira testar o Ruby no seu navegador (veja os links abaixo),
+você precisará ter o Ruby instalado no seu computador. Você pode verificar se
+o Ruby já está instalado abrindo o terminal e digitando
+
+{% highlight sh %}
+ruby -v
+{% endhighlight %}
+
+Isso deve imprimir algumas informações sobre a versão do Ruby instalada. Se não
+imprimir, consulte a [página de instalação](installation/) para conhecer as
+diversas maneiras de obter o Ruby.
+
 ### Primeiros Passos
 
 [Try Ruby!][1]

--- a/pt/documentation/installation/index.md
+++ b/pt/documentation/installation/index.md
@@ -4,8 +4,6 @@ title: "Instalando o Ruby"
 lang: pt
 ---
 
-{% include out-of-date.html %}
-
 Você pode usar diversas ferramentas para instalar o Ruby.
 Esta página descreve como usar os principais sistemas de
 gerenciamento de pacotes ou ferramentas de terceiros para
@@ -16,85 +14,45 @@ partir do código fonte.
 
 ## Escolha o seu Método de Instalação
 
+Existem diveras maneiras de instalar o Ruby:
+
+* Quando você está em um sistema operacional baseado em UNIX, utilizar o
+  **sistema de gerenciamento de pacotes** do seu sistema é a maneira mais fácil
+  de começar. No entanto, geralmente a versão do empacotada do Ruby não é a mais
+  recente.
+* **Instaladores** podem ser utilizados para instalar uma versão específica do
+  Ruby ou até mesmo várias delas. Também existe um instalador para o Windows.
+* **Gerenciadores** te ajudam a alternar entre múltiplas instalações do Ruby em
+  seu sistema.
+* E, por fim, você também pode **compilar o Ruby a partir do código fonte**.
+
 O resumo a seguir lista os métodos de instalação disponíveis
-para cada uma das principais plataformas. Escolha o jeito
-que seja mais confortável para você.
+para diferentes necessidades e plataformas:
 
-* OS X
-
+* [Sistemas de Gerenciamento de Pacotes](#package-management-systems)
+  * [Debian, Ubuntu](#apt)
+  * [CentOS, Fedora, RHEL](#yum)
+  * [Gentoo](#portage)
+  * [Arch Linux](#pacman)
+  * [OS X](#homebrew)
+  * [Solaris, OpenIndiana](#solaris)
+  * [Outras Distribuições](#other-systems)
+* [Instaladores](#installers)
+  * [ruby-build](#ruby-build)
+  * [ruby-install](#ruby-install)
+  * [RubyInstaller](#rubyinstaller) (Windows)
+  * [RailsInstaller e Ruby Stack](#railsinstaller)
+* [Gerenciadores](#managers)
+  * [chruby](#chruby)
   * [rbenv](#rbenv)
   * [RVM](#rvm)
-  * [Homebrew](#homebrew)
-  * [Compilando do código fonte](#building-from-source)
-
-* Linux/UNIX
-
-  * [rbenv](#rbenv)
-  * [RVM](#rvm)
-  * [Sistemas de gerenciamento de pacotes](#package-management-systems)
-  * [Compilando do código fonte](#building-from-source)
-
-* Windows
-
-  * [RubyInstaller](#rubyinstaller)
-  * [pik][pik]
-
-
-## Ferramentas de Terceiros
-
-Muitos programadores usam ferramentas de terceiros para
-instalar o Ruby. Elas conferem várias vantagens, mas não são
-suportadas oficialmente. No entanto, suas respectivas
-comunidades são muito prestativas.
-
-
-### rbenv
-{: #rbenv}
-
-O [rbenv][rbenv] permite que vocÊ gerencie múltiplas instalações
-do Ruby. Ele não suporta a instalação do Ruby, mas existe um
-plugin popular chamado ruby-build para isso. Ambas estas
-ferramentas estão disponíveis para OS X, Linux ou outros
-sistemas operacionais do tipo UNIX.
-
-
-### RVM ("Ruby Version Manager")
-{: #rvm}
-
-O [RVM][rvm] permite que você instale e gerencie múltiplas
-instalações do Ruby em seu sistema. Ele também permite
-gerenciar diferentes gemsets. Também está disponível para
-OS X, Linux ou outros sistemas operacionais do tipo UNIX.
-
-
-### RubyInstaller
-{: #rubyinstaller}
-
-Se você está no Windows, existe um ótimo projeto para ajudá-lo
-a instalar o Ruby: [RubyInstaller][rubyinstaller]. Ele te dá
-tudo o que você precisa para configurar um ambiente de
-desenvolvimento em Ruby completo no Windows.
-
-Apenas baixe, rode e está pronto!
-
-
-### RailsInstaller e Ruby Stack
-
-Se você está instalando o Ruby para usar o Ruby on Rails,
-você pode usar os seguintes instaladores:
-
-* [RailsInstaller][railsinstaller],
-  que usa o RubyInstaller, mas te dá ferramentas adicionais
-  que ajudam no desenvolvimento com Rails. Suporta o OS X e o Windows.
-* [Bitnami Ruby Stack][rubystack],
-  que fornece um ambiente de desenvolviment completoo para Rails.
-  Suporta OS X, Linux, Windows, máquinas virtuais e imagens na nuvem.
-
+  * [uru](#uru)
+* [Compilando a partir do código fonte](#building-from-source)
 
 ## Sistemas de Gerenciamento de Pacotes
 {: #package-management-systems}
 
-Se você não pode compilar o seu próprio Ruby e vocÊ não quer usar uma
+Se você não pode compilar o seu próprio Ruby e você não quer usar uma
 ferramenta de terceiros, você pode usar o gerenciador de pacotes do
 seu sistema para instalar o Ruby.
 
@@ -107,16 +65,6 @@ do Ruby em seus repositórios oficiais. Se você gostaria de usar
 um Ruby mais recente, assegure-se de usar o nome do pacote correto,
 ou de usar as ferramentas descritas acima ao invés disso.
 
-Os seguintes gerenciadores de pacotes são descritos abaixo:
-
-* [apt (Debian ou Ubuntu)](#apt)
-* [yum (CentOS, Fedora ou RHEL)](#yum)
-* [portage (Gentoo)](#gentoo)
-* [pacman (Arch Linux)](#pacman)
-* [Homebrew (OS X)](#homebrew)
-* [Solaris, OpenIndiana](#solaris)
-
-
 ### apt (Debian ou Ubuntu)
 {: #apt}
 
@@ -124,10 +72,10 @@ O Debian GNU/Linux e o Ubuntu usam o gerenciador de pacotes apt.
 Você pode utilizá-lo da seguinte forma:
 
 {% highlight sh %}
-$ sudo apt-get install ruby
+$ sudo apt-get install ruby-full
 {% endhighlight %}
 
-No momento em que foi escrita esta página, o pacote `ruby` fornecia
+No momento em que foi escrita esta página, o pacote `ruby-full` fornecia
 a versão 1.9.3 do Ruby, que é uma versão estável antiga, tanto no
 Debian quanto no Ubuntu.
 
@@ -155,8 +103,8 @@ O Gentoo usa o gerenciador de pacotes portage.
 $ sudo emerge dev-lang/ruby
 {% endhighlight %}
 
-Por padrão, ele tentará instalar todas as versões disponíveis (1.8, 1.9
-e 2.0). Para instalar uma versão específica, configure `RUBY_TARGETS`
+Por padrão, ele tentará instalar as versões 1.9 e 2.0, mas mais versões estão
+disponíveis. Para instalar uma versão específica, configure `RUBY_TARGETS`
 em seu `make.conf`. Consulte o [website do projeto Ruby do Gentoo][gentoo-ruby]
 para mais detalhes.
 
@@ -164,7 +112,7 @@ para mais detalhes.
 ### pacman (Arch Linux)
 {: #pacman}
 
-O Arch Linux usa um gerenciador de pacotes chamado pacman.
+O Arch Linux utiliza um gerenciador de pacotes chamado pacman.
 Para obter o Ruby, apenas faça isso:
 
 {% highlight sh %}
@@ -175,26 +123,17 @@ $ sudo pacman -S ruby
 ### Homebrew (OS X)
 {: #homebrew}
 
-No OS X Mavericks, o Ruby 2.0 já está incluso. O OS X Mountain Lion,
+No OS X Yosemite e Mavericks, o Ruby 2.0 já está incluso. O OS X Mountain Lion,
 Lion e Snow Leopard vêm com o Ruby 1.8.7.
 
-Existem diversas opções para instalar versões mais novas do Ruby.
-A maioria dos usuários de OS X na comunidade Ruby usam ferramentas
-de terceiros para instalar o Ruby, mas existem alguns gerenciadores
-de pacotes que o suportam.
-
-Muitas pessoas no OS X usam o [Homebrew][homebrew] como um
-gerenciador de pacotes. É muito fácil de obter o Ruby:
+Muitas pessoas no OS X usam o [Homebrew][homebrew] como gerenciador de pacotes.
+É muito fácil de obter uma versão mais nova do Ruby usando o Homebrew:
 
 {% highlight sh %}
 $ brew install ruby
 {% endhighlight %}
 
-Além disso, já que o OS X é baseado em Unix, baixar e instalar a partir
-do código fonte é tão fácil e eficiente quanto as demais soluções.
-Provavelmente é uma boa ideia usar ferramentas de terceiros para
-ajudá-lo a instalar novas versões do Ruby no OS X.
-
+Este comando deve instalar a versão mais recente do Ruby.
 
 ### Ruby no Solaris e OpenIndiana
 {: #solaris}
@@ -202,9 +141,7 @@ ajudá-lo a instalar novas versões do Ruby no OS X.
 O Ruby 1.8.7 está disponível do Solaris 8 até o Solaris 10 no
 [Sunfreeware][sunfreeware] e o Ruby 1.8.7 está disponível no
 [Blastwave][blastwave]. O Ruby 1.9.2p0 também está disponível no
-[Sunfreeware][sunfreeware], mas está desatualizado. Usar
-ferramentas de terceiros te ajudará a obter as versões mais
-recentes do Ruby.
+[Sunfreeware][sunfreeware], mas está desatualizado.
 
 Para instalar o Ruby no [OpenIndiana][openindiana], por favor use o
 client do [Image Packaging System (IPS)][opensolaris-pkg]. Ele
@@ -220,10 +157,107 @@ de obter as versões mais recentes do Ruby.
 
 
 ### Outras Distribuições
+{: #other-systems}
 
 Em outros sistemas, você pode pesquisar por Ruby no repositório de
 pacotes do gerenciador da sua distribuição de Linux, ou as
 ferramentas de terceiros podem ser a sua escolha certa.
+
+
+## Instaladores
+{: #installers}
+
+Se a versão do Ruby fornecida com o seu sistema ou gerenciador de pacotes estiver
+desatualizada, você pode instalar uma mais recentes através de um instalador de
+terceiros. Alguns deles também permitem que você instale múltiplas versões no
+mesmo sistema; os gerenciadores associados podem te ajudar a alternar entre
+diferentes Rubies. Se você planeja utilizar o [RVM](#rvm) como um gerenciador de
+versão, você não precisa de um instalador separado, ele vem com o seu próprio.
+
+
+### ruby-build
+{: #ruby-build}
+
+O [ruby-build][ruby-build] é um plugin para o [rbenv](#rbenv) que permite que
+você compile e instale diferentes versões do Ruby em diretórios arbitrários. O
+ruby-build também pode ser usado como um programa por si só, sem o rbenv. Ele
+está disponível para OS X, Linux e outros sistemas operacionais baseados em UNIX.
+
+
+### ruby-install
+{: #ruby-install}
+
+O [ruby-install][ruby-install] permite que você compile e instale diferentes
+versões do Ruby em diretórios arbitrários. Também tem um colega, que gerencia
+a alternância entre versões do Ruby. Ele está disponível para OS X, Linux e
+outros sistemas operacionais baseados em UNIX.
+
+
+### RubyInstaller
+{: #rubyinstaller}
+
+Se você está no Windows, existe um ótimo projeto para ajudá-lo
+a instalar o Ruby: [RubyInstaller][rubyinstaller]. Ele te dá
+tudo o que você precisa para configurar um ambiente de
+desenvolvimento em Ruby completo no Windows.
+
+Apenas baixe, rode e está pronto!
+
+
+### RailsInstaller e Ruby Stack
+{: #railsinstaller}
+
+Se você está instalando o Ruby para usar o Ruby on Rails,
+você pode usar os seguintes instaladores:
+
+* [RailsInstaller][railsinstaller],
+  que usa o RubyInstaller, mas te dá ferramentas adicionais
+  que ajudam no desenvolvimento com Rails. Suporta o OS X e o Windows.
+* [Bitnami Ruby Stack][rubystack],
+  que fornece um ambiente de desenvolvimento completo para Rails.
+  Suporta OS X, Linux, Windows, máquinas virtuais e imagens na nuvem.
+
+
+## Gerenciadores
+{: #managers}
+
+Muitos programadores Ruby utilizam gerenciadores para organizar múltiplas versões
+do Ruby. Eles conferem várias vantagens, mas não são suportados oficialmente. No
+entanto, suas comunidades são muito prestativas.
+
+
+### chruby
+{: #chruby}
+
+O [chruby][chruby] permite que você alterne entre múltiplos Rubies. O chruby
+pode gerenciar os Rubies instalados através do [ruby-install](#ruby-install) ou
+até mesmo compilados a partir do código fonte.
+
+
+### rbenv
+{: #rbenv}
+
+O [rbenv][rbenv] permite que você gerencie múltiplas instalações
+do Ruby. Ele não suporta a instalação do Ruby, mas existe um
+plugin popular chamado [ruby-build](#ruby-build) para isso. Ambas estas
+ferramentas estão disponíveis para OS X, Linux ou outros
+sistemas operacionais do tipo UNIX.
+
+
+### RVM ("Ruby Version Manager")
+{: #rvm}
+
+O [RVM][rvm] permite que você instale e gerencie múltiplas
+instalações do Ruby em seu sistema. Ele também permite
+gerenciar diferentes gemsets. Também está disponível para
+OS X, Linux ou outros sistemas operacionais do tipo UNIX.
+
+
+## uru
+{: #uru}
+
+O [Uru][uru] é uma ferramenta de linha de comando leve e multi-plataforma, que
+te ajuda a usar múltiplas versões do Ruby em sistemas OS X, Linux e Windows.
 
 
 ## Compilando a Partir do Código Fonte
@@ -247,11 +281,14 @@ por nenhuma ferramenta.
 
 
 [rvm]: http://rvm.io/
-[rbenv]: https://github.com/sstephenson/rbenv
+[rbenv]: https://github.com/sstephenson/rbenv#readme
+[ruby-build]: https://github.com/sstephenson/ruby-build#readme
+[ruby-install]: https://github.com/postmodern/ruby-install#readme
+[chruby]: https://github.com/postmodern/chruby#readme
+[uru]: https://bitbucket.org/jonforums/uru
 [rubyinstaller]: http://rubyinstaller.org/
 [railsinstaller]: http://railsinstaller.org/
 [rubystack]: http://bitnami.com/stack/ruby/installer
-[pik]: https://github.com/vertiginous/pik
 [sunfreeware]: http://www.sunfreeware.com
 [blastwave]: http://www.blastwave.org
 [openindiana]: http://openindiana.org/


### PR DESCRIPTION
Fix two issues as pointed out by @stomar in #1199 

* on the `downloads` page, one complete paragraph is missing (Installing Ruby)
* the `installation` page translation was based on a very outdated en version