### PR TITLE
Use Lanyon instead of rack-jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake',   '~> 10.0'
 gem 'jekyll', '~> 2.0'
 
 gem 'unicorn'
-gem 'rack-jekyll', '~> 0.4.2'
+gem 'lanyon', '~> 0.2.0'
 gem 'rack-rewrite'
 gem 'rack-ssl'
 gem 'rack-protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
       listen (~> 3.0)
     kgio (2.10.0)
     kramdown (1.9.0)
+    lanyon (0.2.0)
+      jekyll (~> 2.0)
+      rack (~> 1.6)
     liquid (2.6.3)
     listen (3.0.4)
       rb-fsevent (>= 0.9.3)
@@ -54,10 +57,6 @@ GEM
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
     rack (1.6.4)
-    rack-jekyll (0.4.5)
-      jekyll (>= 1.3)
-      listen (>= 1.3)
-      rack (~> 1.5)
     rack-protection (1.5.3)
       rack
     rack-rewrite (1.5.1)
@@ -90,7 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 2.0)
-  rack-jekyll (~> 0.4.2)
+  lanyon (~> 0.2.0)
   rack-protection
   rack-rewrite
   rack-ssl

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-require 'rack/jekyll'
+require 'lanyon'
 require 'rack/rewrite'
 require 'rack/ssl'
 require 'rack/protection'
@@ -81,4 +81,4 @@ end
 use Rack::Protection::HttpOrigin
 use Rack::Protection::FrameOptions
 
-run Rack::Jekyll.new
+run Lanyon.application(:skip_build => true)

--- a/config.ru
+++ b/config.ru
@@ -7,10 +7,6 @@ require 'yaml'
 use Rack::CommonLogger
 
 use Rack::Rewrite do
-  # enforce trailing slash (/foo -> /foo/) when index.html exists
-  r302 %r{.*}, "$&/", if: ->(rack_env) {
-    rack_env["PATH_INFO"].match(%r{/$}).nil? && File.exist?("_site#{rack_env["PATH_INFO"]}/index.html")
-  }
 
   # bugreport.html (linked to from Ruby source code)
   r302 %r{^/bugreport\.html$}, "http://bugs.ruby-lang.org/"


### PR DESCRIPTION
@hsbt 

I switched from rack-jekyll to the (new) lanyon gem.

rack-jekyll is essentially unmaintained and until a couple of weeks ago was a real mess: buggy, no tests at all, unused garbage code... After providing lots of tests and essentially nearly rewriting the whole thing, I decided to start fresh with a new gem, "Lanyon". It should work work just as good, and drops some functionality that we do not need (namely: no auto regeneration).

Note: lanyon 0.2.0 is the first gem release; versions 0.1.x belong to an unrelated yanked gem.