### PR TITLE
Switched ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-rvm: 2.2.4
+rvm: 2.3.0
 cache:
   bundler: true
 # Notifications, used by our Gitter channel.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.2.4'
+ruby '2.3.0'
 
 gem 'rake',   '~> 10.0'
 gem 'jekyll', '~> 2.0'


### PR DESCRIPTION
We should use Ruby 2.3.0. I will merge this after travis-ci tests.