### PR TITLE
Update _config.yml for Ruby 2.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,18 @@ license:
 
 downloads:
   stable:
+    version: 2.3.0
+    url:
+      bz2: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2
+      gz: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz
+      xz: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.xz
+      zip: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.zip
+    sha256:
+      bz2: ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e
+      gz: ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507
+      xz: 70125af0cfd7048e813a5eecab3676249582bfb65cfd57b868c3595f966e4097
+      zip: 8270bdcbc6b62a18fdf1b75bd28d5d6fc0fc26b9bd778d422393a1b98006020a
+  previous:
     version: 2.2.4
     url:
       bz2: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2
@@ -35,7 +47,7 @@ downloads:
       gz: b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761
       xz: d28bff4641e382681c58072ddc244d025ac47ff71dd9426a92fcfc3830d1773c
       zip: 9b7f9e96ef84eef97f44bd5ab1fa70ece1668a52585a88ba6a3487579f12e6f4
-  previous:
+  old:
     version: 2.1.8
     url:
       bz2: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2
@@ -47,7 +59,7 @@ downloads:
       gz: afd832b8d5ecb2e3e1477ec6a9408fdf9898ee73e4c5df17a2b2cb36bd1c355d
       xz: 94eeae3b3e3ac93cfd205e1aaef4c5325227b7656cbb2fc1ee217618145dd19d
       zip: 6e0491e029a6f4c40bc091033c5bc91f65438f3f9153f93f1b86889521e79cee
-  previous20:
+  tooold: # still supported
     version: 2.0.0-p648
     url:
       bz2: https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2
@@ -59,7 +71,6 @@ downloads:
       gz: 8690bd6b4949c333b3919755c4e48885dbfed6fd055fe9ef89930bde0d2376f8
       xz: 22fe97739110ba9171b13fc4dcd1a92e767f16769de3593ee41ef1283d218402
       zip: 6d1fb8b285c80bfc1838880626d04f128561a649161c80d1748423c731d548bd
-
   stable_snapshot:
     url:
       bz2: https://ftp.ruby-lang.org/pub/ruby/stable-snapshot.tar.bz2

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -45,9 +45,9 @@ Ruby може да бъде инсталиран и от изходен код �
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Стара стабилна версия (серия 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Стара стабилна версия :**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -69,7 +69,7 @@ Ruby може да бъде инсталиран и от изходен код �
 [installation]: /bg/documentation/installation
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -44,9 +44,9 @@ vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Stabile Vorgängerversion (2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Stabile Vorgängerversion:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -69,7 +69,7 @@ Bitte nutze einen Mirror in deiner Nähe.
 [installation]: /de/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -42,9 +42,15 @@ one of the third party tools mentioned above. They may help you.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Old stable (2.0.0 series):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Old stable:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
+
+{% if site.downloads.tooold %}
+* **Too old stable (will EOL soon!):**
+  [Ruby {{site.downloads.tooold.version}}][tooold-gz]<br>
+  sha256: {{ site.downloads.tooold.sha256.gz }}
+{% endif %}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -66,7 +72,8 @@ Please try to use a mirror that is near you.
 [installation]: /en/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
+[tooold-gz]: {{ site.downloads.tooold.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -41,9 +41,9 @@ de ayuda.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Estable viejo (serie 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Estable viejo:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -65,7 +65,7 @@ Intenta usar el mirror site que te quede más cerca.
 [installation]: /es/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -46,9 +46,9 @@ peut-être vous aider.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Anciennes versions stables (séries 2.0.0) :**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Anciennes versions stables:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots :**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -69,7 +69,7 @@ Utilisez s'il-vous-plaît un miroir proche de vous.
 [installation]: /fr/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -48,9 +48,9 @@ esserti di aiuto.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Stabile Vecchia (serie 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Stabile Vecchia:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -73,7 +73,7 @@ Cerca di utilizzare il sito mirror più vicino a te.
 [installation]: /it/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -36,9 +36,15 @@ lang: ja
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **古い安定版 (2.0 系):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **古い安定版:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
+
+{% if site.downloads.tooold %}
+* **さらに古い安定版 (まもなく EOL):**
+  [Ruby {{site.downloads.tooold.version}}][tooold-gz]<br>
+  sha256: {{ site.downloads.tooold.sha256.gz }}
+{% endif %}
 
 * **スナップショット:**
   * [安定版のスナップショット][stable-snapshot-gz]:
@@ -69,7 +75,8 @@ Windows向けのバイナリが有志により配布されています。
 [installation]: /ja/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
+[tooold-gz]: {{ site.downloads.tooold.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -43,9 +43,9 @@ lang: ko
   [루비 {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **낡은 버전 (2.0.0 시리즈):**
-  [루비 {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **낡은 버전:**
+  [루비 {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **스냅숏:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -65,7 +65,7 @@ lang: ko
 [installation]: /ko/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -44,9 +44,9 @@ skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Stary stabilny (seria 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Stary stabilny:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Migawki:**
   * [Stabilna migawka][stable-snapshot-gz]:
@@ -68,7 +68,7 @@ Spróbuj użyć jakiegoś blisko ciebie.
 [installation]: /pl/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -44,9 +44,9 @@ mencionadas acima. Elas podem te ajudar.
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Versão estável antiga (série 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Versão estável antiga:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Snapshot Estável][stable-snapshot-gz]:
@@ -68,7 +68,7 @@ usar um _mirror_ que está próximo de você.
 [installation]: /pt/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -48,9 +48,9 @@ lang: ru
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Старая стабильная (Из 2.0.0 серии):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Старая стабильная:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
  * **Слепки:**
    * [Стабильный слепок][stable-snapshot-gz]:
@@ -240,7 +240,7 @@ Ruby как язык имеет несколько разных имплемен
 [license]: {{ site.license.url }}
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -42,9 +42,9 @@ dụng một trong những công cụ của bên thứ ba đã được đề c�
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **Bản ổn định cũ (chuỗi 2.0.0):**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **Bản ổn định c:**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **Snapshots:**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -65,7 +65,7 @@ Xin hãy sử dụng mirror gần bạn nhất.
 [installation]: /vi/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -34,9 +34,9 @@ lang: zh_cn
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **旧的稳定版（2.0.0 系列）：**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **旧的稳定版：**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **快照：**
   * [稳定版快照][stable-snapshot-gz]：当前稳定版 tarball 的最新快照
@@ -52,7 +52,7 @@ Ruby 源代码可从世界各地的[镜像站][mirrors]获得。请尝试离您�
 [installation]: /zh_cn/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -34,9 +34,9 @@ lang: zh_tw
   [Ruby {{ site.downloads.previous.version }}][previous-gz]<br>
   sha256: {{ site.downloads.previous.sha256.gz }}
 
-* **舊穩定版（2.0.0 系列）：**
-  [Ruby {{ site.downloads.previous20.version }}][previous20-gz]<br>
-  sha256: {{ site.downloads.previous20.sha256.gz }}
+* **舊穩定版：**
+  [Ruby {{ site.downloads.old.version }}][old-gz]<br>
+  sha256: {{ site.downloads.old.sha256.gz }}
 
 * **快照：**
   * [Stable Snapshot][stable-snapshot-gz]:
@@ -55,7 +55,7 @@ Ruby 原始碼可從世界各地的[鏡像站][mirrors]獲得。請嘗試離您�
 [installation]: /zh_tw/documentation/installation/
 [stable-gz]: {{ site.downloads.stable.url.gz }}
 [previous-gz]: {{ site.downloads.previous.url.gz }}
-[previous20-gz]: {{ site.downloads.previous20.url.gz }}
+[old-gz]: {{ site.downloads.old.url.gz }}
 [stable-snapshot-gz]: {{ site.downloads.stable_snapshot.url.gz }}
 [nightly-gz]: {{ site.downloads.nightly_snapshot.url.gz }}
 [mirrors]: /en/downloads/mirrors/


### PR DESCRIPTION
- Also moving 2.0.0 to new section called `tooold` instead of removing.
  I think leaving it for a while is better even if Ruby 2.0.0 EOL is soon, but
  it's still maintained.