### PR TITLE
Add a space

### DIFF
--- a/ja/news/_posts/2015-12-25-ruby-2-3-0-released.md
+++ b/ja/news/_posts/2015-12-25-ruby-2-3-0-released.md
@@ -17,7 +17,7 @@ Ruby 2.1 では既に、オブジェクトアロケーション削減のため�
 
 [safe navigation operator](https://bugs.ruby-lang.org/issues/11537) ([lonely operator](https://instagram.com/p/-M9l6mRPLR/) `&.` とも呼ばれています) が導入されました。これは `nil` の扱いをやりやすくするものです。既に C#, Groovy, Swift などでも同様の機能が存在します。
 また、`Array#dig`, `Hash#dig` も追加されました。
-safe navigation operator は、`nil` のみを取り扱う [ActiveSupport における try!](http://api.rubyonrails.org/v4.2.5/classes/Object.html#method-i-try-21) と同様の挙動をする事について注意してください。
+safe navigation operator は、`nil` のみを取り扱う [Active Support における try!](http://api.rubyonrails.org/v4.2.5/classes/Object.html#method-i-try-21) と同様の挙動をする事について注意してください。
 
 [did_you_mean gem がバンドル](https://bugs.ruby-lang.org/issues/11252) されました。
 この gem は `NameError` と `NoMethodError` の発生時、デバッグを容易にするため、正しい名前と思われる候補を合わせて表示します。


### PR DESCRIPTION
fix wording, "Active Support" has a space in between the words, not ActiveSupport.
see http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=52232&view=revision