### PR TITLE
Translated (es) CVE-2015-7551: Unsafe tainted string usage in Fiddle …

### DIFF
--- a/es/news/_posts/en/news/_posts/2015-12-16-unsafe-tainted-string-usage-in-fiddle-and-dl-cve-2015-7551.md
+++ b/es/news/_posts/en/news/_posts/2015-12-16-unsafe-tainted-string-usage-in-fiddle-and-dl-cve-2015-7551.md
@@ -1,0 +1,88 @@
+---
+layout: news_post
+title: "CVE-2015-7551: Unsafe tainted string usage in Fiddle and DL"
+author: "usa"
+translator:
+date: 2015-12-16 12:00:00 +0000
+tags: security
+lang: es
+---
+
+Existe una vulerabilidad del tipo "unsafe tainted string usage" en Fiddle y DL.
+Esta vulnerabilidad se la ha asignado el identificador CVE
+[CVE-2015-7551](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7551).
+
+Detalles
+-------
+
+Existe una vulerabilidad del tipo "unsafe tainted string usage" en Fiddle y DL.
+Esta vulnerabilidad fue reportada y corregida originalmente con
+[CVE-2009-5147](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-5147) en
+DL, pero reaparecio despues que DL fue reimplementado utilizando Fiddle y libffi.
+
+DL, [CVE-2009-5147](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-5147) fue corregido en Ruby 1.9.1,
+pero no corregido en otros branches, asi que los rubies que integran DL, menos
+Ruby 1.91.1, son vulnerables.
+
+Algunos ejemplos de codigo impactado:
+
+{% highlight ruby %}
+handle = Fiddle::Handle.new(dangerous_user_input)
+{% endhighlight %}
+
+O:
+
+{% highlight ruby %}
+handle = Fiddle::Handle.new(some_library)
+function_pointer = handle[dangerous_user_input]
+{% endhighlight %}
+
+Todos los usuarios que estan utilizando una version afectada deben actualizarla
+o utilizar una de las soluciones inmediatamente.
+
+Versiones Afectadas
+-----------------
+
+* Todos los releases patch de Ruby 1.9.2 y Ruby 1.9.3 (DL y Fiddle).
+* Todos los releases patch de Ruby 2.0.0 prior to Ruby 2.0.0 patchlevel 648 (DL and Fiddle).
+* Todas las versiones de Ruby 2.1 anterior a Ruby 2.1.8 (DL y Fiddle).
+* Todas las versiones de Ruby 2.2 anterior a Ruby 2.2.4 (Fiddle).
+* Ruby 2.3.0 preview 1 y preview 2 (Fiddle).
+* anterior a trunk revision 53153 (Fiddle).
+
+Soluciones
+-----------
+
+Si no puedes actualizar, el siguiente monkey patch puede ser aplicado
+como una solucion para Fiddle:
+
+{% highlight ruby %}
+class Fiddle::Handle
+  alias :old_initialize :initialize
+
+  def initialize file, *args
+    raise SecurityError if file.tainted? && $SAFE > 0
+    old_initialize file, *args
+  end
+
+  alias :sym :[]
+  alias :old_call :[]
+
+  def [] fun
+    raise SecurityError if fun.tainted? && $SAFE > 0
+    old_call fun
+  end
+end
+{% endhighlight %}
+
+Si estas utilizando DL, utiliza Fiddle mejor.
+
+Creditos
+-------
+
+Gracias a Christian Hofstaedtler <zeha@debian.org> por reportar esta vulnerabilidad
+
+Historial
+-------
+
+* Originalmente publicado at 2015-12-16 12:00:00 UTC


### PR DESCRIPTION
…and DL