### PR TITLE
SDForum moved to SVForum

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -49,8 +49,8 @@ event dates, location, CFP (Call For Proposals) and Registration information.
 to offset expenses for local and regional groups wanting to organize
 events.
 
-Ruby Central has also teamed up with [SDForum][7] to produce the Silicon
-Valley Ruby Conference, entering its second year in 2007.
+Ruby Central has also teamed up with [SVForum][7] (previously known as SDForum) 
+to produce the Silicon Valley Ruby Conference, entering its second year in 2007.
 
 [RubyNation][8] is an annual Ruby conference serving the Virginia, West
 Virginia, Maryland, and Washington, DC areas.
@@ -97,7 +97,7 @@ O’Reilly), and Canada on Rails.
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
-[7]: http://www.sdforum.org
+[7]: http://www.svforum.org
 [8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/


### PR DESCRIPTION
Twitter https://twitter.com/sdforum informs site has moved.  SDForum.org is a bad link.