### PR TITLE
Simplify release list on downloads page (en)

### DIFF
--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -34,22 +34,14 @@ See the [Installation][installation] page for details on building
 Ruby from source. If you have an issue compiling Ruby, consider using
 one of the third party tools mentioned above. They may help you.
 
-* **Current stable:**
-  [Ruby {{ site.downloads.stable[0].version }}]({{ site.downloads.stable[0].url.gz }})<br>
-  sha256: {{ site.downloads.stable[0].sha256.gz }}
-
-* **Previous stable:**
-  [Ruby {{ site.downloads.stable[1].version }}]({{ site.downloads.stable[1].url.gz }})<br>
-  sha256: {{ site.downloads.stable[1].sha256.gz }}
-
-* **Old stable:**
-  [Ruby {{ site.downloads.stable[2].version }}]({{ site.downloads.stable[2].url.gz }})<br>
-  sha256: {{ site.downloads.stable[2].sha256.gz }}
+* **Stable releases:**{% for release in site.downloads.stable %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.downloads.security_maintenance %}
-* **In security maintenance phase (will EOL soon!):**
-  [Ruby {{ site.downloads.security_maintenance[0].version }}]({{ site.downloads.security_maintenance[0].url.gz }})<br>
-  sha256: {{ site.downloads.security_maintenance[0].sha256.gz }}
+* **In security maintenance phase (will EOL soon!):**{% for release in site.downloads.security_maintenance %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 * **Snapshots:**


### PR DESCRIPTION
@hsbt

Stop distinguishing between "current", "previous", ... releases,
simply list all of them under "stable releases".
-> No need to come up with names; and easier to change in case there are
4 or only 2 stable branches at a certain time period, because we can simply
iterate over an array of releases defined in _config.yml.

Preview:

* Stable releases:
  * Ruby 2.3.0<br>
    sha256: ...
  * Ruby 2.2.4<br>
    sha256: ...
  * Ruby 2.1.8<br>
    sha256: ...

* In security maintenance phase (will EOL soon!):
  * Ruby 2.0.0-p648<br>
    sha256: ...

* Snapshots:
  * Stable Snapshot: ...