### PR TITLE
Switch pygments to rouge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby ENV['CUSTOM_RUBY_VERSION'] || '2.3.0'
 
 gem 'rake',   '~> 10.0'
 gem 'jekyll', '~> 2.0'
+gem 'rouge',  '~> 1.10'
 
 gem 'unicorn'
 gem 'lanyon', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
+    rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sawyer (0.6.0)
@@ -104,6 +105,7 @@ DEPENDENCIES
   rack-rewrite
   rack-ssl
   rake (~> 10.0)
+  rouge (~> 1.10)
   spidr (~> 0.4)
   unicorn
   validate-website (~> 0.9)

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 markdown: kramdown
 permalink: pretty
-highlighter: pygments
+highlighter: rouge
 
 timezone: UTC
 


### PR DESCRIPTION
This is a new PR to replace #1255.

Repost the origin message below:

On rouge's project site, it says "[Rouge's] HTML output is compatible with stylesheets designed for pygments." And I use rouge on my personal Jekyll site since a bit long time ago, it woks very well.

The main advantage of rouge is it's pure Ruby, no need to invoke Python to highlight.

So, I don't see any reasons to use pygments any more.

I test locally but not on Heroku, so maybe should give it a test run before switching.

What do you think about this change?

cc @stomar 