### PR TITLE
Add that Postgres Code of Conduct is a draft

### DIFF
--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -4,8 +4,9 @@ title: "The Ruby Community Code of Conduct"
 lang: en
 ---
 
-We have picked the following code of conduct based on an early draft of the
-PostgreSQL CoC, for Ruby developer's community for safe, productive collaboration.
+We have picked the following code of conduct based on an early proposed draft
+of a CoC for PostgreSQL, for Ruby developer's community for safe,
+productive collaboration.
 Each Ruby related community (conference etc.) may pick their own CoC.
 {: .summary}
 

--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -4,9 +4,9 @@ title: "The Ruby Community Code of Conduct"
 lang: en
 ---
 
-We have picked the following code of conduct based on PostgreSQL CoC, for Ruby
-developer's community for safe, productive collaboration. Each Ruby related
-community (conference etc.) may pick their own CoC.
+We have picked the following code of conduct based on an early draft of the
+PostgreSQL CoC, for Ruby developer's community for safe, productive collaboration.
+Each Ruby related community (conference etc.) may pick their own CoC.
 {: .summary}
 
 This document provides community guidelines for a safe, respectful, productive,


### PR DESCRIPTION
A member of the PostgreSQL core team recently clarified that although the Ruby Code of Conduct claims to be based on the PostgreSQL one, it's actually based on a "very early draft".

This PR fixes the wording, so that people know the Ruby Code of Conduct is based on an early draft of the PostgreSQL one, rather than their actual code of conduct. 

PostgeSQL currently doesn't have a Code of Conduct, but [they're working with a professional consultant and have a plan for developing one](http://www.postgresql.org/message-id/56A8516B.8000105@agliodbs.com), which seems like the right way to go about it.

Source tweets:
*"Just FYI: the Ruby CoC is NOT based on the PostgreSQL CoC, since the PostgreSQL one is still in progress."* ([src](https://twitter.com/fuzzychef/status/700003388927291392))

*"...given that our CoC process is expected to take another 7 months, that's a very early draft"* ([src](https://twitter.com/fuzzychef/status/700004321421824001))