### PR TITLE
Add atom to editor list on documentation page (ja)

### DIFF
--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -77,16 +77,19 @@ Rubyistに人気のあるソフトウェアには次のようなものがあり�
   * [SciTe][28]
   * [NetBeans][36]
   * [Sublime Text][37]
+  * [Atom][atom]
 
 * Windows
   * [Notepad++][29]
   * [E-TextEditor][30]
   * [Ruby In Steel][31]
+  * [Atom][atom]
 
 * OS X
   * [TextMate][32]
   * [TextWrangler][33]
   * [Dash][39] (ドキュメント表示ツール)
+  * [Atom][atom]
 
 Posted by Shugo Maeda on 26 May 2006
 {: .post-info}
@@ -136,3 +139,4 @@ Posted by Shugo Maeda on 26 May 2006
 [36]: https://netbeans.org/
 [37]: http://www.sublimetext.com/
 [39]: http://kapeli.com/dash
+[atom]: https://atom.io/


### PR DESCRIPTION
I found that the atom described in the English documentation page isn't in the Japanese documentation page. So I add atom to the list.