### PR TITLE
Remove the feature of Ruby 1.8 (en)

### DIFF
--- a/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -78,7 +78,7 @@ Unlike C, in Ruby,...
 * There are no header files. You just define your functions (usually
   referred to as “methods”) and classes in the main source code files.
 * There’s no `#define`. Just use constants instead.
-* As of Ruby 1.8, code is interpreted at run-time rather than compiled
+* Code is interpreted at run-time rather than compiled
   to any sort of machine- or byte-code.
 * All variables live on the heap. Further, you don’t need to free them
   yourself—the garbage collector takes care of that.


### PR DESCRIPTION
Because I think any newcomer don't want to get the information of old Ruby version and it can be misleading information given on the feature of current Ruby.