### PR TITLE
Simplify build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,11 +17,9 @@ task :default => [:build]
 
 desc "Build the Jekyll site"
 task :build do
-  require 'jekyll'
-  options = Jekyll.configuration
-  puts "Building site: #{options['source']} -> #{options['destination']}"
-  $stdout.flush
-  Jekyll::Site.new(options).process
+  require "lanyon"
+
+  Lanyon.build
 end
 
 desc "Serve the Jekyll site locally"

--- a/Rakefile
+++ b/Rakefile
@@ -18,11 +18,6 @@ task :default => [:build]
 desc "Build the Jekyll site"
 task :build do
   require 'jekyll'
-  # workaround for LANG=C environment
-  module Jekyll::Convertible
-    Encoding.default_external = Encoding::UTF_8
-  end
-
   options = Jekyll.configuration
   puts "Building site: #{options['source']} -> #{options['destination']}"
   $stdout.flush


### PR DESCRIPTION
Removes a now obsolete workaround for LC_ALL=C environments.
Furthermore, it switches the site generation (`rake build`) to Lanyon's `build` method, which handles Jekyll configuration and build process.