### PR TITLE
Announcement of Ruby 2.1.10 release.

### DIFF
--- a/en/news/_posts/2016-04-01-ruby-2-1-10-released.md
+++ b/en/news/_posts/2016-04-01-ruby-2-1-10-released.md
@@ -8,11 +8,11 @@ lang: en
 ---
 
 Ruby 2.1.10 has been released.
-This release is not for production environment, but for compatibility test with two-digit version number.
+This release is not intended for production use, but for compatibility tests with two-digit version numbers.
 You don't have to replace Ruby 2.1.9 by 2.1.10 in normal use.
 
-[As announced in 2.1.9 release](https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/), Ruby 2.1.10 does not include any changes from 2.1.9, except for its version number. (And, this includes only one small change in its test suite.)
-Please test your applications and/or libraries for testing compatibility with two-digit version number.
+[As announced in 2.1.9 release post](https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/), Ruby 2.1.10 does not include any changes from 2.1.9, except for its version number (and only one small related change in its test suite).
+Please test your applications and/or libraries for compatibility with two-digit version numbers.
 
 ## Download
 

--- a/en/news/_posts/2016-04-01-ruby-2-1-10-released.md
+++ b/en/news/_posts/2016-04-01-ruby-2-1-10-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 2.1.10 Released"
+author: "usa"
+translator:
+date: 2016-04-01 02:00:00 +0000
+lang: en
+---
+
+Ruby 2.1.10 has been released.
+This release is not for production environment, but for compatibility test with two-digit version number.
+You don't have to replace Ruby 2.1.9 by 2.1.10 in normal use.
+
+[As announced in 2.1.9 release](https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/), Ruby 2.1.10 does not include any changes from 2.1.9, except for its version number. (And, this includes only one small change in its test suite.)
+Please test your applications and/or libraries for testing compatibility with two-digit version number.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2)
+
+      SIZE:   12015299 bytes
+      SHA1:   22dcd759d8cbb14c8735988fbc7ee5c35f9d4720
+      SHA256: a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1
+      SHA512: 4b7213695416876e4de3cbce912f61ac89db052c74f0daa8424477991cfc49b07300e9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz)
+
+      SIZE:   15165837 bytes
+      SHA1:   2a5194b1fd42a3f1f23f1e0844ae78332a9efd5d
+      SHA256: fb2e454d7a5e5a39eb54db0ec666f53eeb6edc593d1d2b970ae4d150b831dd20
+      SHA512: 5f9c0cc3d10b4e04c63f001b4add782c34b9f260368f48b443b397cea57680d328f7c28cbb2a9be4c2f5acd114bac07dacb100d57018fa4d2a1792fc03083418
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz)
+
+      SIZE:   9362868 bytes
+      SHA1:   adcc9e10b8f7add0e19f8c70afc134c069a862ca
+      SHA256: 5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
+      SHA512: 72406ac133af7f057d4633d2a300e49e133881f6b36ff4cdf6c72b4ff4325de332fc5a45c96ea407140a8bf09cdc307e13107c539196902e5b67b7d24cd72dc9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip)
+
+      SIZE:   16706304 bytes
+      SHA1:   402158192b7673cb4e7a67f48f6d93945bc9fd13
+      SHA256: 21cf83156ec782d17827fb9c8a945626dfd68cf0d9eb5ca7a78b12eb91c6f1fb
+      SHA512: 5490fc4726a1efaea8c7c541ca3102013b00a0af2903d15009307265c93b218bb13aab0007d279823c740a9b173d957ca79f2d8f25932f04763ec1aa18d164e8
+
+## Release Comment
+
+Thanks to everyone who helped with this release.

--- a/ja/news/_posts/2016-04-01-ruby-2-1-10-released.md
+++ b/ja/news/_posts/2016-04-01-ruby-2-1-10-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Ruby 2.1.10 リリース"
+author: "usa"
+translator:
+date: 2016-04-01 02:00:00 +0000
+lang: ja
+---
+
+Ruby 2.1.10 がリリースされました。
+これは安定版 2.1 系列の TEENY リリースです。
+が、これは正規のリリースではありますが、プロダクション環境での利用を意図したものではありません。
+一般のユーザーは、先日リリースされた 2.1.9 を 2.1.10 で置き換える必要はありません。
+
+2.1.9 のリリース時に[予告されていた](https://www.ruby-lang.org/ja/news/2016/03/30/ruby-2-1-9-released/)ように、2.1.10 は 2.1.9 とバージョン番号が異なるだけのパッケージです。(実際には、同梱のテストスイートの修正も 1 件含まれています。)
+2.1.10 は 2 桁のバージョン番号に対するテスト用のリリースです。
+Ruby のバージョン番号に依存したコードが含まれうるアプリケーション・ライブラリの作者の方は、これを使って互換性の検証を行うようお願いします。
+
+## ダウンロード
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2)
+
+      SIZE:   12015299 bytes
+      SHA1:   22dcd759d8cbb14c8735988fbc7ee5c35f9d4720
+      SHA256: a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1
+      SHA512: 4b7213695416876e4de3cbce912f61ac89db052c74f0daa8424477991cfc49b07300e9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz)
+
+      SIZE:   15165837 bytes
+      SHA1:   2a5194b1fd42a3f1f23f1e0844ae78332a9efd5d
+      SHA256: fb2e454d7a5e5a39eb54db0ec666f53eeb6edc593d1d2b970ae4d150b831dd20
+      SHA512: 5f9c0cc3d10b4e04c63f001b4add782c34b9f260368f48b443b397cea57680d328f7c28cbb2a9be4c2f5acd114bac07dacb100d57018fa4d2a1792fc03083418
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz)
+
+      SIZE:   9362868 bytes
+      SHA1:   adcc9e10b8f7add0e19f8c70afc134c069a862ca
+      SHA256: 5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
+      SHA512: 72406ac133af7f057d4633d2a300e49e133881f6b36ff4cdf6c72b4ff4325de332fc5a45c96ea407140a8bf09cdc307e13107c539196902e5b67b7d24cd72dc9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip)
+
+      SIZE:   16706304 bytes
+      SHA1:   402158192b7673cb4e7a67f48f6d93945bc9fd13
+      SHA256: 21cf83156ec782d17827fb9c8a945626dfd68cf0d9eb5ca7a78b12eb91c6f1fb
+      SHA512: 5490fc4726a1efaea8c7c541ca3102013b00a0af2903d15009307265c93b218bb13aab0007d279823c740a9b173d957ca79f2d8f25932f04763ec1aa18d164e8
+
+## リリースコメント
+
+いつもながら、リリースに協力してくれた皆様に感謝します。


### PR DESCRIPTION
Please review my poor English.

Note that this PR does not include `_config.yml`.
It's intentional because 2.1.10 is for testing, not for production.