### PR TITLE
Rubyist Magazine 0053 published!

### DIFF
--- a/ja/news/_posts/2016-04-03-rubyist-magazine-0053-published.md
+++ b/ja/news/_posts/2016-04-03-rubyist-magazine-0053-published.md
@@ -1,0 +1,29 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0053号 発行"
+author: "kurotaky"
+date: 2016-04-03 18:50:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0053号][3]がリリースされました([\[ruby-list:50299\]
+
+今号は、
+
+* [巻頭言](http://magazine.rubyist.net/?0053-ForeWord)
+* [Rubyist Hotlinks 【第 36 回】 須藤功平さん](http://magazine.rubyist.net/?0053-Hotlinks)
+* [YARV Maniacs 【第 13 回】 事前コンパイルへの道](http://magazine.rubyist.net/?0053-YarvManiacs)
+* [RegionalRubyKaigi レポート (56) TokyuRuby 会議 09](http://magazine.rubyist.net/?0053-TokyuRubyKaigi09Report)
+* [RegionalRubyKaigi レポート (57) 大江戸 Ruby 会議 05](http://magazine.rubyist.net/?0053-OoedoRubyKaigi05Report)
+* [TRICK2015 開催報告＆入賞作品紹介](http://magazine.rubyist.net/?0053-TRICK2015)
+* [るびまアクセスランキング Vol.53](http://magazine.rubyist.net/?0053-RubyistMagazineRanking)
+* [0053 号 読者プレゼント](http://magazine.rubyist.net/?0053-Present)
+
+という構成となっています。
+
+お楽しみください。
+
+[1]: http://ruby-no-kai.org
+[2]: http://magazine.rubyist.net/
+[3]: http://magazine.rubyist.net/?0053
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50299


### PR DESCRIPTION
RubiMa Editors has released Rubyist Magazine 0053(in japanese)!!
Please add this post to the news page.
http://magazine.rubyist.net/?0053