### PR TITLE
Translate Ruby 2.1.9 released (pt)

### DIFF
--- a/pt/news/_posts/2016-03-30-ruby-2-1-9-released.md
+++ b/pt/news/_posts/2016-03-30-ruby-2-1-9-released.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Ruby 2.1.9 lançado"
+author: "usa"
+translator: "fpgentil"
+date: 2016-03-30 12:00:00 +0000
+lang: pt
+---
+
+Ruby 2.1.9 foi lançado.
+
+Esta versão inclui várias correções de *bugs*.
+Consulte o [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_1_9/ChangeLog)
+para detalhes.
+
+[Como anunciado anteriormente](https://www.ruby-lang.org/pt/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/),
+esta é a última *release* normal para a série Ruby 2.1. Depois disso, nós nunca
+mais iremos portar nenhuma correção de *bug* para 2.1 com exceção de correções
+de segurança. Nós recomandamos que você comece a planejar o *upgrade* para Ruby
+2.3 ou 2.2.
+
+A propósito, nós estamos planejando lançar o Ruby 2.1.10 em alguns dias.
+Ruby 2.1.10 não incluirá nenhuma alteração da versão 2.1.9, com exceção do
+número da versão. Você não deve utilizá-la em produção, mas deve testá-la pois
+é um número de versão com dois dígitos.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2)
+
+      SIZE:   12016421 bytes
+      SHA1:   39524185b580a3390a3b5019819c8b28d3249766
+      SHA256: 4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e
+      SHA512: a86422132e4c64007a84a91696f4557bdcbc8716fbfe1962f1eef3754ee7f994f4de0b
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz)
+
+      SIZE:   15166126 bytes
+      SHA1:   dd68afc652fe542f83a9a709a74f4da2662054bf
+      SHA256: 034cb9c50676d2c09b3b6cf5c8003585acea05008d9a29fa737c54d52c1eb70c
+      SHA512: 1e03aa720e932f019c4651c355e8ef35b87fdf69b054c9d39a319467d2a8e5bfe4995cbacd9add36b832c77761a47c9d1040f00e856ad5888d69ec7221455e35
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.xz)
+
+      SIZE:   9395648 bytes
+      SHA1:   5e89efa5189c3def8ee8de18ce750a7e4a20ac32
+      SHA256: 39f203f7498aed2456fb500147fada5adcbf102d89d4f6aca773ebcadd8ea82a
+      SHA512: 1f331a8910fd7a9ab9c41bf56aef12041dd413ad49c696f6df2c9a7ec3a3d5cdf383f2a3d30949ea37b8ecb39f50355e526412b36ed4e07b60733d9db4d2bd14
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.zip)
+
+      SIZE:   16696728 bytes
+      SHA1:   4aa288b65fbf12692ac53577adc561c9a0f6a6ca
+      SHA256: 8610fdb1836d493c19600cfed4828083f85197096c0aea3f73fa1ed532cbb5a7
+      SHA512: a212b6a58637f6bf4f456d7ecc7bbd8ceaa0c3f16cb844b872eb62eaf261b5874fdb79705241d05a356fcdc1d3fdd8a94fcd8e6ca62190e9f544c8f45a9f41af
+
+## Comentário da *release*
+
+Obrigado a todos que ajudaram nessa *release*.
+
+A manutenção do Ruby 2.1, incluindo essa *release*, baseia-se no "Agreement for
+the Ruby stable version" da [Ruby Association](http://www.ruby.or.jp/).


### PR DESCRIPTION
This PR contains the translation for the post `Ruby 2.1.9 Released` :smile: 