### PR TITLE
Release announcements of Ruby 2.2.5.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,17 +35,17 @@ downloads:
         gz: ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507
         xz: 70125af0cfd7048e813a5eecab3676249582bfb65cfd57b868c3595f966e4097
         zip: 8270bdcbc6b62a18fdf1b75bd28d5d6fc0fc26b9bd778d422393a1b98006020a
-    - version: 2.2.4
+    - version: 2.2.5
       url:
-        bz2: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2
-        gz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz
-        xz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.xz
-        zip: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.zip
+        bz2: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2
+        gz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz
+        xz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz
+        zip: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip
       sha256:
-        bz2: 31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76
-        gz: b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761
-        xz: d28bff4641e382681c58072ddc244d025ac47ff71dd9426a92fcfc3830d1773c
-        zip: 9b7f9e96ef84eef97f44bd5ab1fa70ece1668a52585a88ba6a3487579f12e6f4
+        bz2: 22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700
+        gz: 30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3
+        xz: f86feaa0a578e8da0924ced3ec68b25b50d69fc9a72cc8d919bc3c73f85f87d7
+        zip: d5094d7cc50266772a8352c68b7fcd865889fd174c09e2f11bb003696cd04bb3
     - version: 2.1.9
       url:
         bz2: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2

--- a/en/news/_posts/2016-04-26-ruby-2-2-5-released.md
+++ b/en/news/_posts/2016-04-26-ruby-2-2-5-released.md
@@ -1,0 +1,54 @@
+---
+layout: news_post
+title: "Ruby 2.2.5 Released"
+author: "usa"
+translator:
+date: 2016-04-26 12:00:00 +0000
+lang: en
+---
+
+Ruby 2.2.5 has been released.
+
+This release includes many bug fixes.
+See [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_2_5/ChangeLog)
+for details.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2)
+
+      SIZE:   13350551 bytes
+      SHA1:   f78473fe60a632b778599374ae64612592c2c9c1
+      SHA256: 22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700
+      SHA512: d3224814361c297bc36646c2e40f63c461ccf5a77fea5a3acdcb2c7ad1705bb229ac6a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz)
+
+      SIZE:   16654395 bytes
+      SHA1:   457707459827bd527347a5cee7b4dc509b486713
+      SHA256: 30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3
+      SHA512: 3dd8688c64b8b143bdd6b0f123b7c2ecdd1b93c7c9ee51b2774a3b0b864897789932c7ad406293a6ab12c9eb9db9cfb2940fc14e2afc4f79718994f7668cbd5f
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz)
+
+      SIZE:   10457620 bytes
+      SHA1:   58484284dd613e139e8f7023b1168e9034a8766d
+      SHA256: f86feaa0a578e8da0924ced3ec68b25b50d69fc9a72cc8d919bc3c73f85f87d7
+      SHA512: 6da4bdb0a43d56c7a8e4dddbcacf237e998ebb54706c8f835b53713dbdf924e40d5f89f63017515e1d66904ca01f28058cf296567104e06540c57f036dcdd0fe
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip)
+
+      SIZE:   18493821 bytes
+      SHA1:   e4f497e5b79768ae93dd73ac26da4ff5dd722bfe
+      SHA256: d5094d7cc50266772a8352c68b7fcd865889fd174c09e2f11bb003696cd04bb3
+      SHA512: b3789063252e361aa4598ecd9170fc360f0d5685497975ce09442fe5815c438b67b95fc67e56b99ab4044a49715ed1a8b1fb089f757c7c0d1a777536e06de8cf
+
+## Release Comment
+
+Thanks to everyone who helped with this release.
+
+From this release, the maintainer of Ruby 2.2 is switched from nagachika-san to usa.
+About 2/3 part of the changes included in this release is made by nagachika-san.
+Thanks for his great contributions.
+
+The maintenance of Ruby 2.2, including this release, is based on the "Agreement for the Ruby stable version" of the [Ruby Association](http://www.ruby.or.jp/).

--- a/en/news/_posts/2016-04-26-ruby-2-2-5-released.md
+++ b/en/news/_posts/2016-04-26-ruby-2-2-5-released.md
@@ -47,8 +47,8 @@ for details.
 
 Thanks to everyone who helped with this release.
 
-From this release, the maintainer of Ruby 2.2 is switched from nagachika-san to usa.
-About 2/3 part of the changes included in this release is made by nagachika-san.
+With this release, the maintainer of Ruby 2.2 changed from nagachika-san to usa.
+About two thirds of the changes included in this release were made by nagachika-san.
 Thanks for his great contributions.
 
 The maintenance of Ruby 2.2, including this release, is based on the "Agreement for the Ruby stable version" of the [Ruby Association](http://www.ruby.or.jp/).

--- a/ja/news/_posts/2016-04-26-ruby-2-2-5-released.md
+++ b/ja/news/_posts/2016-04-26-ruby-2-2-5-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.2.5 リリース"
+author: "usa"
+translator:
+date: 2016-04-26 12:00:00 +0000
+lang: ja
+---
+
+Ruby 2.2.5 がリリースされました。
+これは安定版 2.2 系列の TEENY リリースです。
+
+今回のリリースでは、多数のバグ修正が行われています。
+詳しくは、対応する [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_2_5/ChangeLog) を参照してください。
+
+## ダウンロード
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2)
+
+      SIZE:   13350551 bytes
+      SHA1:   f78473fe60a632b778599374ae64612592c2c9c1
+      SHA256: 22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700
+      SHA512: d3224814361c297bc36646c2e40f63c461ccf5a77fea5a3acdcb2c7ad1705bb229ac6a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz)
+
+      SIZE:   16654395 bytes
+      SHA1:   457707459827bd527347a5cee7b4dc509b486713
+      SHA256: 30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3
+      SHA512: 3dd8688c64b8b143bdd6b0f123b7c2ecdd1b93c7c9ee51b2774a3b0b864897789932c7ad406293a6ab12c9eb9db9cfb2940fc14e2afc4f79718994f7668cbd5f
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz)
+
+      SIZE:   10457620 bytes
+      SHA1:   58484284dd613e139e8f7023b1168e9034a8766d
+      SHA256: f86feaa0a578e8da0924ced3ec68b25b50d69fc9a72cc8d919bc3c73f85f87d7
+      SHA512: 6da4bdb0a43d56c7a8e4dddbcacf237e998ebb54706c8f835b53713dbdf924e40d5f89f63017515e1d66904ca01f28058cf296567104e06540c57f036dcdd0fe
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip)
+
+      SIZE:   18493821 bytes
+      SHA1:   e4f497e5b79768ae93dd73ac26da4ff5dd722bfe
+      SHA256: d5094d7cc50266772a8352c68b7fcd865889fd174c09e2f11bb003696cd04bb3
+      SHA512: b3789063252e361aa4598ecd9170fc360f0d5685497975ce09442fe5815c438b67b95fc67e56b99ab4044a49715ed1a8b1fb089f757c7c0d1a777536e06de8cf
+
+## リリースコメント
+
+リリースに協力してくれた皆様に感謝します。
+
+今回のリリースより、2.2 系列のメンテナが前任の nagachika さんから usa に交替しました。
+今回のリリースに含まれる変更のうち、およそ 2/3 に当たる分は nagachika さんによるものです。ありがとうございました。
+
+このリリースを含む Ruby 2.2 系列の保守は、[一般財団法人 Ruby アソシエーション](http://www.ruby.or.jp/)の Ruby 安定版保守委託事業に基いています。


### PR DESCRIPTION
Please review!

Note: this release is planned at 4/26 12:00:00 UTC.
I will merge and deploy by myself.
