### PR TITLE
Translate Ruby 2.3.1 Released (zh-TW)

### DIFF
--- a/zh_tw/news/_posts/2016-04-26-ruby-2-3-1-released.md
+++ b/zh_tw/news/_posts/2016-04-26-ruby-2-3-1-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 2.3.1 發佈"
+author: "nagachika"
+translator: "Vincent Lin"
+date: 2016-04-26 12:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.3.1 釋出。
+
+這是穩定 2.3 系列的第一個小版本釋出。
+
+本次發行版包含了許多錯誤修正。
+請參考 [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_1/ChangeLog) 來進一步了解。
+
+## 下載
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2)
+
+      SIZE:   14432088 bytes
+      SHA1:   4ee76c7c1b12d5c5b0245fc71595c5635d2217c9
+      SHA256: 4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d
+      SHA512: a8659b96a3a481a3dbdbb6997eb18ff1f8cd926a9707a90d071e937315c21d372c89252f0d44732ae5007d2678fda8c8fbceafa4e4b4ff500d236fb796284d8d
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz)
+
+      SIZE:   17797997 bytes
+      SHA1:   c39b4001f7acb4e334cb60a0f4df72d434bef711
+      SHA256: b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd
+      SHA512: 7399d59b54764e02760ed6cac525a43c5e7212aebbbff8a04234dc45adbc0cd9fe1ff9a9328eefd38f02d3b6c5b2e3ca843808784755ff4e66ded624f55c150a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.xz)
+
+      SIZE:   11407048 bytes
+      SHA1:   83499c14c674cf2d88e495031434a94c06330879
+      SHA256: 6725b5534d5a3a21ec4f14d6d7b9921a0d00d08acb88fd04cd50b47b70496338
+      SHA512: e9d89aeefb1b1e72cee9d3d414b27c793cf09ff3ed5e0ea5277a2b6ae1cae9fdbf6b404a84b42c0c6835754eb04674fc4f1470fbfedabeee3f57e518f13db633
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.zip)
+
+      SIZE:   19842037 bytes
+      SHA1:   ab9dec602b11ee4cfc295d6aa87ebe712372d123
+      SHA256: 4c8ae431b33f78d64cabb31911e0890e9a3ac380b4f22b11738f9baeeda51763
+      SHA512: a26d3ab5983c6f3ea454e3e75554137305525479e4c15c0ae424689e870e2c5a9f0fe194975cf362cc5528ce601e31a0a15b87c7af200fd0d1da17459435b953
+
+## 發佈記
+
+許多提交者、開發者、和回報錯誤的用戶幫助我們完成這次釋出。
+感謝他們的貢獻。


### PR DESCRIPTION
zh-TW Translation for Ruby 2.3.1 Released

- zh_tw/news/_posts/2016-04-26-ruby-2-3-1-released.md

Thank you.