### PR TITLE
Translate Ruby 2.2.5 Released (zh-TW)

### DIFF
--- a/zh_tw/news/_posts/2016-04-26-ruby-2-2-5-released.md
+++ b/zh_tw/news/_posts/2016-04-26-ruby-2-2-5-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.2.5 發佈"
+author: "usa"
+translator: "Vincent Lin"
+date: 2016-04-26 12:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.2.5 釋出。
+
+本次發行版包含了許多錯誤修正。
+請參考 [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_2_5/ChangeLog) 來進一步了解。
+
+## 下載
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2)
+
+      SIZE:   13350551 bytes
+      SHA1:   f78473fe60a632b778599374ae64612592c2c9c1
+      SHA256: 22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700
+      SHA512: d3224814361c297bc36646c2e40f63c461ccf5a77fea5a3acdcb2c7ad1705bb229ac6abbd7ad1ae61cbe0fefd7a008c6102568d11366ad3107179302cd3e734e
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz)
+
+      SIZE:   16654395 bytes
+      SHA1:   457707459827bd527347a5cee7b4dc509b486713
+      SHA256: 30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3
+      SHA512: 3dd8688c64b8b143bdd6b0f123b7c2ecdd1b93c7c9ee51b2774a3b0b864897789932c7ad406293a6ab12c9eb9db9cfb2940fc14e2afc4f79718994f7668cbd5f
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz)
+
+      SIZE:   10457620 bytes
+      SHA1:   58484284dd613e139e8f7023b1168e9034a8766d
+      SHA256: f86feaa0a578e8da0924ced3ec68b25b50d69fc9a72cc8d919bc3c73f85f87d7
+      SHA512: 6da4bdb0a43d56c7a8e4dddbcacf237e998ebb54706c8f835b53713dbdf924e40d5f89f63017515e1d66904ca01f28058cf296567104e06540c57f036dcdd0fe
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip)
+
+      SIZE:   18493821 bytes
+      SHA1:   e4f497e5b79768ae93dd73ac26da4ff5dd722bfe
+      SHA256: d5094d7cc50266772a8352c68b7fcd865889fd174c09e2f11bb003696cd04bb3
+      SHA512: b3789063252e361aa4598ecd9170fc360f0d5685497975ce09442fe5815c438b67b95fc67e56b99ab4044a49715ed1a8b1fb089f757c7c0d1a777536e06de8cf
+
+## 發佈記
+
+感謝所有幫助此次發佈的朋友。
+
+同時，Ruby 2.2 的維護者由 nagachika-san 換成 usa。
+包含此次的發佈，大約有三分之二的變動是出自 nagachika-san 之手。
+感謝他巨大的貢獻。
+
+Ruby 2.2 的維護（包含本版本）是基於 [Ruby 協會](http://www.ruby.or.jp/)關於穩定版本的協議。


### PR DESCRIPTION
zh-TW Translation for Ruby 2.2.5 Released

- zh_tw/news/_posts/2016-04-26-ruby-2-2-5-released.md

Thank you.