### PR TITLE
Change NaCl to Ruby Association

### DIFF
--- a/en/about/website/index.md
+++ b/en/about/website/index.md
@@ -34,7 +34,7 @@ to this website.
 
 Also many thanks to the organizations that support us:
 
- * [NaCl][nacl] (hosting)
+ * [Ruby Association][rubyassociation] (hosting)
  * [Heroku][heroku] (hosting)
  * [IIJ][iij] (hosting)
  * [GlobalSign][globalsign] (SSL certification)
@@ -51,7 +51,7 @@ Also many thanks to the organizations that support us:
 [github-repo]: https://github.com/ruby/www.ruby-lang.org/
 [github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
 [github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki
-[nacl]: http://www.netlab.jp
+[rubyassociation]: http://www.ruby.or.jp
 [heroku]: https://www.heroku.com/
 [iij]: http://www.iij.ad.jp
 [globalsign]: https://www.globalsign.com

--- a/ja/about/website/index.md
+++ b/ja/about/website/index.md
@@ -33,7 +33,7 @@ Ruby Visual Identity Team による初期のデザインが元になっていま
 
 また、われわれをサポートしてくれる以下の機関にも大きな感謝をいたします:
 
- * [NaCl][nacl] (ホスティング)
+ * [Rubyアソシエーション][rubyassociation] (ホスティング)
  * [Heroku][heroku] (ホスティング)
  * [IIJ][iij] (ホスティング)
  * [GlobalSign][globalsign] (SSL 証明書)
@@ -50,7 +50,7 @@ Ruby Visual Identity Team による初期のデザインが元になっていま
 [github-repo]: https://github.com/ruby/www.ruby-lang.org/
 [github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
 [github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki
-[nacl]: http://www.netlab.jp
+[rubyassociation]: http://www.ruby.or.jp/ja/sponsors/list/
 [heroku]: https://www.heroku.com/
 [iij]: http://www.iij.ad.jp
 [globalsign]: https://www.globalsign.com


### PR DESCRIPTION
Please change NaCl to Ruby Association because hosting is now sponsored by Ruby Association and their sponsors.
