### PR TITLE
Update format for bundler 1.12.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,5 +109,8 @@ DEPENDENCIES
   unicorn
   validate-website (~> 0.9)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.3


### PR DESCRIPTION
bundler 1.12.x added entry of ruby version to `Gemfile.lock` when Gemfile use `ruby` version declaration for heroku usage. I added it.

/cc @stomar 