### PR TITLE
Fix /id/about/website/ link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1834,7 +1834,7 @@ locales:
       ou contactez le <a href="mailto:webmaster@ruby-lang.org">webmaster</a>
       pour toute question ou tout commentaire.
     id: |
-      <a href="/id/about/website"/">Situs ini</a>
+      <a href="/id/about/website/">Situs ini</a>
       dengan bangga dirawat oleh anggota komunitas Ruby.
     it: |
       <a href="/it/about/website/">Questo sito web</a>


### PR DESCRIPTION
Fix this error https://validator.nu/?doc=https%3A%2F%2Fwww.ruby-lang.org%2Fid%2Fabout%2Fwebsite&charset=&schema=&preset=&parser=&nsfilter=
Cheers