### PR TITLE
Add Ruby file extension to docs

### DIFF
--- a/en/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
+++ b/en/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
@@ -80,4 +80,5 @@ Unlike Python, in Ruby,...
   then immediately resume.
 * Python supports just one kind of anonymous functions, lambdas, while
   Ruby contains blocks, Procs, and lambdas.
+* Ruby scripts have the file extension `.rb`
 


### PR DESCRIPTION
Added "Ruby scripts have the file extension `.rb`" to the switching from python page, as it took me a long time to initialy find this info.