### PR TITLE
Update ConFoo Vancouver 2016 post (id)

### DIFF
--- a/id/news/_posts/2016-05-16-confoo-cfp.md
+++ b/id/news/_posts/2016-05-16-confoo-cfp.md
@@ -12,12 +12,12 @@ mendatang.
 
 ![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yvr2016/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}ConFoo dengan gembira membuka [call for papers][1] Vancouver
 edisi 2016! Jika Anda tertarik untuk berbicara tentang Ruby atau topik pengembangan
-*web* lainnya, silakan mengajukan hingga 6 Juni. Kami akan menanggung perjalanan dan
-hotel untuk pembicara yang memerlukannya.
+*web* lainnya, silakan mengajukan hingga 6 Juni. ConFoo akan menanggung perjalanan
+dan hotel untuk pembicara yang memerlukannya.
 
 ConFoo Vancouver akan diselenggarakan pada 5-7 Desember 2016. Bagi mereka yang
-terbiasa dengan ConFoo Montreal, konferensi ini akan tetap berlanjut setiap tahun
-disamping Vancouver. [Kunjungi situs kami][2] untuk mempelajari lebih lanjut.
+kenal dengan ConFoo Montreal, konferensi tersebut akan tetap berlanjut setiap tahun
+di samping Vancouver. [Kunjungi situs ConFoo][2] untuk mempelajari lebih lanjut.
 
 Perbincangan topik berlangsung 35 menit dan tanya jawab 10 menit, total 45 menit.
 Kami tidak sabar untuk menunggu ajuan Anda!


### PR DESCRIPTION
The changes:
- Avoid use of "we" as mentioned on #1405.
- Fix some translations.

Please, review this post update @gozali @stomar!
Thank you.