### PR TITLE
Add language heading(vi)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1804,7 +1804,7 @@ locales:
     bg: "Този сайт на други езици:"
     de: "Diese Website in anderen Sprachen:"
     en: "This site in other languages:"
-    fr: "Autres langues disponibles :"
+    fr: "Autres langues disponibles:"
     id: "Situs ini dalam bahasa lain:"
     it: "Questo sito in altre lingue:"
     pl: "Ta strona w innych językach:"
@@ -1812,6 +1812,7 @@ locales:
     ru: "Этот сайт на других языках:"
     tr: "Diğer dillerde bu site:"
     zh_cn: "本站其他语言版本："
+    vi: "Ngôn ngữ khác:"
 
   credits:
     bg: |


### PR DESCRIPTION
## Summary
- Add language heading for `vi`.
- Remove a redundant space in `fr`'s language heading.