### PR TITLE
Validate with libtidy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+---
 language: ruby
 sudo: false
 rvm: 2.5.1
 cache:
   bundler: true
-script: bundle exec rake ci
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/htacg/tidy-html5/releases/download/5.4.0/tidy-5.4.0-64bit.deb; sudo apt-get remove '^libtidy.*';  sudo dpkg -i tidy-5.4.0-64bit.deb; fi
+script:
+  - bundle exec rake ci
+  - bundle exec rake check:markup
 # Notifications, used by our Gitter channel.
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 language: ruby
 sudo: false
 rvm: 2.5.1

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,5 @@ end
 group :development do
   gem 'minitest'
   gem 'spidr', '~> 0.6'
-  gem 'validate-website', '~> 1.6'
+  gem 'validate-website', '~> 1.9'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ DEPENDENCIES
   spidr (~> 0.6)
   sqreen
   unicorn
-  validate-website (~> 1.6)
+  validate-website (~> 1.9)
 
 RUBY VERSION
    ruby 2.5.1p57


### PR DESCRIPTION
Use libtidy https://github.com/htacg/tidy-html5
for complete validation of the website, just excluding `examples` directory (inserted in javascript).
Also update validate-website gem.

Time ~ 40sec for `check:markup` cf https://travis-ci.org/ruby/www.ruby-lang.org/builds/501125031#L582

Cheers
