### PR TITLE
Fix hint on evaluation strategy of methods

### DIFF
--- a/de/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/de/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -113,8 +113,8 @@ Es gibt allerdings deutlich mehr Unterschiede als Gemeinsamkeiten zwischen Ruby 
   irrelevant, dementsprechend gibt es keine Pointer und kein `sizeof`.
 * Es gibt keine `enum`s. Es gibt zwar *Symbole*, die aber keinen
   implizit zugeordneten Zahlenwert haben.
-* Parameter von Methoden (oder Funktionen) werden immer als Referenz
-  übergeben.
+* Parameter von Methoden (oder Funktionen) werden immer als Wertparameter
+  übergeben, wobei die Werte selbst stets Referenzen sind
 * Lokale Variablen werden nicht explizit deklariert. Es wird einfach ein
   typenloser Name vergeben und Wert zugewiesen, wo gerade eine lokale
   Variable benötigt wird.

--- a/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -81,8 +81,8 @@ Unlike C, in Ruby,...
 * There’s no `#define`. Just use constants instead.
 * All variables live on the heap. Further, you don’t need to free them
   yourself—the garbage collector takes care of that.
-* Arguments to methods (i.e. functions) are passed by reference, not by
-  value.
+* Arguments to methods (i.e. functions) are passed by value, whereas the
+  values are always references
 * It’s `require 'foo'` instead of `#include <foo>` or `#include "foo"`.
 * You cannot drop down to assembly.
 * There’s no semicolons ending lines.

--- a/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/en/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -81,7 +81,7 @@ Unlike C, in Ruby,...
 * There’s no `#define`. Just use constants instead.
 * All variables live on the heap. Further, you don’t need to free them
   yourself—the garbage collector takes care of that.
-* Arguments to methods (i.e. functions) are passed by value, whereas the
+* Arguments to methods (i.e. functions) are passed by value, where the
   values are always references
 * It’s `require 'foo'` instead of `#include <foo>` or `#include "foo"`.
 * You cannot drop down to assembly.


### PR DESCRIPTION
After investigating this question, I'm convinced that Ruby does not use *call-by-reference*, as stated in the section "To Ruby From C and C++" . It is using *call-by-value* as evaluation strategy for methods in canonical terminology.  

See [this blogpost](http://robertheaton.com/2014/07/22/is-ruby-pass-by-reference-or-pass-by-value) or [this stackoverflow discussion](http://stackoverflow.com/questions/1872110/is-ruby-pass-by-reference-or-by-value) for deeper discussions on that question.

Obviously this information causes some confusion. For example, [the wikipedia article on evaluation strategies](https://en.wikipedia.org/wiki/Evaluation_strategy) referenced the ruby-lang documentation as a proof that Ruby does use *call-by-reference*:
> whereas in the Ruby community, they say that Ruby is call-by-reference

That's why I'd suggest changing the information contained on the mentioned section. 

### Translations

I added the fix for German and English version, but since I'm not able to serve verified suggestions for the other languages, maybe the lang maintainers could assist?

- [ ] bg @mytrile
- [ ] fr @nono 
- [ ] id @gozali
- [ ] it @kennyadsl
- [ ] ja @take 
- [ ] zh_cn @AndorChen
- [ ] zh_tw @JuanitoFatas
- [ ] pt_br @fuadsaud
- [ ] pl @crabonature
- [x] ru @gazay
- [ ] vi @joneslee85

Thanks!