### PR TITLE
Fix statement about evaluation strategy of methods (id)

### DIFF
--- a/id/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/id/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -126,8 +126,8 @@ Tidak seperti C, di Ruby,...
   di *compile* ke *machine-code* ataupun ke *byte-code*.
 * Semua variabel ada di heap. Lebih jauh, Anda tidak perlu membebaskan
   variabel, sudah ada garbage collector untuk itu.
-* Argument-argument di metode (atau function) di pass by reference,
-  bukan by value.
+* Argument-argument di metode (atau function) di pass by value, di mana
+  value selalu objek reference.
 * `require 'foo'` bukan `#include <foo>` atau `#include "foo"`.
 * Anda tidak bisa drop down ke assembly.
 * Tidak pakai semicolon (titik koma `;`) di tiap akhir baris kode.


### PR DESCRIPTION
As mentioned on #1425, just fixed this documentation for bahasa Indonesia.
Please, review this pull request @gozali @stomar!

Edited: fix translation `value selalu reference` to `value selalu objek reference` (line 130). A new commit is squashed with the old one.