### PR TITLE
Add Installation OSX version Capitan  (en ja)

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -122,7 +122,7 @@ This should install the latest stable Ruby version.
 ### Homebrew (OS X)
 {: #homebrew}
 
-On OS X Yosemite and Mavericks, Ruby 2.0 is included.
+On OS X Yosemite and Capitan, Mavericks, Ruby 2.0 is included.
 OS X Mountain Lion, Lion, and Snow Leopard ship with Ruby 1.8.7.
 
 Many people on OS X use [Homebrew][homebrew] as a package manager.

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -161,7 +161,7 @@ $ sudo pacman -S ruby
 ### Homebrew (OS X)
 {: #homebrew}
 
-Ruby 2.0.0 は OS X Mavericks に含まれています。
+Ruby 2.0.0 は OS X Capitan、Mavericks に含まれています。
 また、OS X Mountain Lion、 Lion および Snow Leopard には 1.8.7 が含まれています。
 
 すでに 2.0 も 1.8 も古いバージョンです。


### PR DESCRIPTION
OS X newest version name is Capitan.
But Installation OS X document has not this version.
I added this word to en and ja documents.