### PR TITLE
Add latest news posts (ja): Rubyist Magazine 0054

### DIFF
--- a/ja/news/_posts/2016-08-22-rubyist-magazine-0054-published.md
+++ b/ja/news/_posts/2016-08-22-rubyist-magazine-0054-published.md
@@ -1,0 +1,30 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0054号 発行"
+author: "miyohide"
+date: 2016-08-22 21:22:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0054号][3]がリリースされました([\[ruby-list:50387\]][4])。
+
+今号は、
+
+* [巻頭言](http://magazine.rubyist.net/?0054-ForeWord)
+* [Ruby に型があると便利か](http://magazine.rubyist.net/?0054-typestruct)
+* [書籍紹介「プログラミング Elixir」](http://magazine.rubyist.net/?0054-ElixirBook)
+* [tDiary 15th anniversary party レポート](http://magazine.rubyist.net/?0054-tDiary15thAnniversary)
+* [RegionalRubyKaigi レポート (58) 東京 Ruby 会議 11](http://magazine.rubyist.net/?0054-TokyoRubyKaigi11Report)
+* [東京 Ruby 会議 11 運営記録](http://magazine.rubyist.net/?0054-TokyoRubyKaigi11OrganizeReport)
+* [RegionalRubyKaigi レポート (59) TokyuRuby 会議 10](http://magazine.rubyist.net/?0054-TokyuRubyKaigi10Report)
+* [Rails Girls Tokyo 6th 開催レポート](http://magazine.rubyist.net/?0054-RailsGirlsTokyo6thReport)
+* [るびまアクセスランキング Vol.54](http://magazine.rubyist.net/?0054-RubyistMagazineRanking)
+
+という構成となっています。
+
+お楽しみください。
+
+[1]: http://ruby-no-kai.org
+[2]: http://magazine.rubyist.net/
+[3]: http://magazine.rubyist.net/?0054
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50378


### PR DESCRIPTION
RubiMa Editors have released Rubyist Magazine 0054 (in japanese).
Please add this post to the news page.
http://magazine.rubyist.net/?0054
