### PR TITLE
Update about page to reflect Windows OS'

### DIFF
--- a/en/about/index.md
+++ b/en/about/index.md
@@ -177,8 +177,8 @@ Ruby has a wealth of other features, among which are the following:
   supports it or not, even on MS-DOS!
 
 * Ruby is highly portable: it is developed mostly on GNU/Linux, but
-  works on many types of UNIX, Mac OS X, Windows 95/98/Me/NT/2000/XP,
-  DOS, BeOS, OS/2, etc.
+  works on many types of UNIX, Windows 95/98/Me/NT/2000/XP/Vista/7/8/10,
+  Mac OS X, DOS, BeOS, OS/2, etc.
 
 ### Other Implementations of Ruby
 


### PR DESCRIPTION
The Windows OS' listed were 10 years out of date, swapped the order with Mac OS X so they would fit on a line in the file and added Vista/7/8/10.