### PR TITLE
Fix ConFoo post

### DIFF
--- a/en/news/_posts/2016-08-26-confoo-cfp.md
+++ b/en/news/_posts/2016-08-26-confoo-cfp.md
@@ -7,13 +7,13 @@ date: 2016-08-26 16:00:00 +0000
 lang: en
 ---
 
-![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}Want to get your web development ideas in front of a live audience? The [call for papers][1] for the ConFoo Montreal 2017 conference is open! If you have a burning desire to hold forth about Ruby, databases, JavaScript, or any other web development topics, we want to see your proposals.
+Want to get your web development ideas in front of a live audience? The [call for papers][1] for the ConFoo Montreal 2017 conference is open! If you have a burning desire to hold forth about Ruby, databases, JavaScript, or any other web development topics, ConFoo wants to see your proposals.
 
-The window is open only from August 21 to September 20, 2016, so hurry. An added benefit: If your proposal is selected and you live outside of the Montreal area, we will cover your travel and hotel.
+![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}The window is open only from August 21 to September 20, 2016, so hurry. An added benefit: If your proposal is selected and you live outside of the Montreal area, ConFoo will cover your travel and hotel.
 
-You’ll have 45 minutes to wow the crowd, with 35 minutes for your topic and 10 minutes for Q&A. We can’t wait to see your proposals. Knock us out!
+You’ll have 45 minutes to wow the crowd, with 35 minutes for your topic and 10 minutes for Q&A. ConFoo can’t wait to see your proposals. Knock us out!
 
-ConFoo Montreal will be held on March 8-10, 2017. For those of you who already know about our conference, be aware that this annual tradition will still be running in addition to ConFoo Vancouver. Visit [our site][2] to learn more about both events.
+ConFoo Montreal will be held on March 8-10, 2017. For those of you who already know about our conference, be aware that this annual tradition will still be running in addition to ConFoo Vancouver. Visit [ConFoo's site][2] to learn more about both events.
 
 [1]: https://confoo.ca/en/yul2017/call-for-papers
 [2]: https://confoo.ca/en

--- a/fr/news/_posts/2016-08-26-confoo-cfp.md
+++ b/fr/news/_posts/2016-08-26-confoo-cfp.md
@@ -7,9 +7,9 @@ date: 2016-08-26 16:00:00 +0000
 lang: fr
 ---
 
-![ConFoo - Conférence pour développeurs](https://confoo.ca/images/propaganda/yul2017/fr/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}Vous voulez mettre vos idées de développement web devant un public? [L'appel aux conférenciers][1] pour la conférence ConFoo Montréal 2017 est ouvert! Si vous avez un désir ardent de présenter sur Ruby, les bases de données, JavaScript, ou d'autres sujets de développement web, nous voulons lire vos propositions.
+Vous voulez mettre vos idées de développement web devant un public? [L'appel aux conférenciers][1] pour la conférence ConFoo Montréal 2017 est ouvert! Si vous avez un désir ardent de présenter sur Ruby, les bases de données, JavaScript, ou d'autres sujets de développement web, nous voulons lire vos propositions.
 
-L'appel est ouvert seulement du 21 août au 20 septembre 2016, alors faites vite. Un avantage supplémentaire: si votre proposition est sélectionnée et que vous êtes à l'extérieur de la région de Montréal, nous allons couvrir le transport et l'hôtel.
+![ConFoo - Conférence pour développeurs](https://confoo.ca/images/propaganda/yul2017/fr/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}L'appel est ouvert seulement du 21 août au 20 septembre 2016, alors faites vite. Un avantage supplémentaire: si votre proposition est sélectionnée et que vous êtes à l'extérieur de la région de Montréal, nous allons couvrir le transport et l'hôtel.
 
 Vous avez 45 minutes pour impressionner la foule, avec 35 minutes pour votre sujet et 10 minutes pour les questions. Nous avons hâte de voir vos propositions. Impressionnez-nous!
 

--- a/id/news/_posts/2016-08-26-confoo-cfp.md
+++ b/id/news/_posts/2016-08-26-confoo-cfp.md
@@ -7,12 +7,12 @@ date: 2016-08-26 16:00:00 +0000
 lang: id
 ---
 
-![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}Ingin ide pengembangan web Anda di depan audiensi langsung?
+Ingin ide pengembangan web Anda di depan audiensi langsung?
 [Call for papers][1] untuk konferensi Confoo Montreal dibuka! Jika Anda memiliki
 hasrat mendalam untuk berbicara tentang Ruby, basis data, JavaScript, atau topik
 pengembangan web lainnya, Confoo ingin melihat ajuan proposal Anda.
 
-Kesempatan hanya dibuka mulai 21 Agustus hingga 20 September 2016, sehingga segera.
+![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}Kesempatan hanya dibuka mulai 21 Agustus hingga 20 September 2016, sehingga segera.
 Keuntungan tambahan: Jika ajuan proposal Anda dipilih dan Anda tinggal di luar
 Montreal, Confoo akan menanggung perjalanan dan penginapan Anda.
 

--- a/id/news/_posts/2016-08-26-confoo-cfp.md
+++ b/id/news/_posts/2016-08-26-confoo-cfp.md
@@ -8,21 +8,21 @@ lang: id
 ---
 
 Ingin ide pengembangan web Anda di depan audiensi langsung?
-[Call for papers][1] untuk konferensi Confoo Montreal dibuka! Jika Anda memiliki
+[Call for papers][1] untuk konferensi ConFoo Montreal dibuka! Jika Anda memiliki
 hasrat mendalam untuk berbicara tentang Ruby, basis data, JavaScript, atau topik
-pengembangan web lainnya, Confoo ingin melihat ajuan proposal Anda.
+pengembangan web lainnya, ConFoo ingin melihat ajuan proposal Anda.
 
 ![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}Kesempatan hanya dibuka mulai 21 Agustus hingga 20 September 2016, sehingga segera.
 Keuntungan tambahan: Jika ajuan proposal Anda dipilih dan Anda tinggal di luar
-Montreal, Confoo akan menanggung perjalanan dan penginapan Anda.
+Montreal, ConFoo akan menanggung perjalanan dan penginapan Anda.
 
 Anda akan memiliki waktu 45 menit untuk mengesankan audiensi, dengan rincian 35 menit
-untuk topik Anda dan 10 menit untuk tanya jawab. Confoo tidak sabar untuk melihat
+untuk topik Anda dan 10 menit untuk tanya jawab. ConFoo tidak sabar untuk melihat
 ajuan proposal Anda. Taklukkan!
 
-Confoo Montreal akan diselenggarakan pada 8-10 Maret 2017. Bagi Anda yang telah
+ConFoo Montreal akan diselenggarakan pada 8-10 Maret 2017. Bagi Anda yang telah
 mengenal konferensi ini, catat bahwa acara tahunan ini akan masih berjalan di
-samping Confoo Vancouver. Kunjungi [situs Confoo][2] untuk mempelajari lebih lanjut
+samping ConFoo Vancouver. Kunjungi [situs ConFoo][2] untuk mempelajari lebih lanjut
 kedua acara ini.
 
 [1]: https://confoo.ca/en/yul2017/call-for-papers

--- a/ko/news/_posts/2016-08-26-confoo-cfp.md
+++ b/ko/news/_posts/2016-08-26-confoo-cfp.md
@@ -7,9 +7,9 @@ date: 2016-08-26 16:00:00 +0000
 lang: ko
 ---
 
-![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}청중의 앞에서 웹 개발에 대해 말하고 싶으신가요? ConFoo 몬트리올 2017 콘퍼런스의 [발표자 모집][1]을 하고 있습니다! 루비, 데이터베이스, 자바스크립트는 물론 웹 개발에 관한 주제라면 무엇이든 길게 말하고 싶으시면 저희에게 제안을 보내주세요.
+청중의 앞에서 웹 개발에 대해 말하고 싶으신가요? ConFoo 몬트리올 2017 콘퍼런스의 [발표자 모집][1]을 하고 있습니다! 루비, 데이터베이스, 자바스크립트는 물론 웹 개발에 관한 주제라면 무엇이든 길게 말하고 싶으시면 저희에게 제안을 보내주세요.
 
-모집은 2016년 8월 21일부터 9월 20일까지이므로 서두르세요. 덧붙여 몬트리올에 살지 않는 분의 제안이 채택된다면, 여행비와 숙박비를 지원해드립니다.
+![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}모집은 2016년 8월 21일부터 9월 20일까지이므로 서두르세요. 덧붙여 몬트리올에 살지 않는 분의 제안이 채택된다면, 여행비와 숙박비를 지원해드립니다.
 
 총 45분의 시간이 주어지며, 주제에 대해서 이야기할 시간이 35분, 질의응답에 10분이 주어집니다. 우리는 제안을 기대하고 있습니다. 연락해주세요!
 

--- a/zh_tw/news/_posts/2016-08-26-confoo-cfp.md
+++ b/zh_tw/news/_posts/2016-08-26-confoo-cfp.md
@@ -7,9 +7,9 @@ date: 2016-08-26 16:00:00 +0000
 lang: zh_tw
 ---
 
-![ConFoo—開發者研討會](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}想要在大家面前發表網路開發的概念嗎？ConFoo Montreal 2017 研討會[現正接受投稿][1]！有關於 Ruby、資料庫、JavaScript，或是任何 Web 相關的主題，我們都歡迎投稿。
+想要在大家面前發表網路開發的概念嗎？ConFoo Montreal 2017 研討會[現正接受投稿][1]！有關於 Ruby、資料庫、JavaScript，或是任何 Web 相關的主題，我們都歡迎投稿。
 
-投稿期間是 2016 年 8 月 21 日至 9 月 20 日，時間有限請盡早投稿。若不住在蒙特婁區域，投稿錄取會補助機票與旅館。
+![ConFoo—開發者研討會](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}投稿期間是 2016 年 8 月 21 日至 9 月 20 日，時間有限請盡早投稿。若不住在蒙特婁區域，投稿錄取會補助機票與旅館。
 
 你有 45 分鐘可以驚豔全場，其中 35 分鐘主題演講，10 分鐘答疑。我們等不及要看到你的投稿。放馬過來！
 


### PR DESCRIPTION
* remove banner from first paragraph: this paragraph is shown as excerpt on the main page and archive pages and should not have banners in it
* avoid use of "we" [**only fixed in `en` version**]: "we" suggests ruby-core or ruby-lang.org, so it should be avoided in third-party posts (see #1405)
* fix typo for `id` (s/Confoo/ConFoo/)