### PR TITLE
Fix "inscrire" link on 2007-10-20-euruko-2007

### DIFF
--- a/fr/news/_posts/2007-10-20-euruko-2007.md
+++ b/fr/news/_posts/2007-10-20-euruko-2007.md
@@ -7,7 +7,7 @@ lang: fr
 
 La conférence Ruby européenne [Euruko 2007][1] se tiendra à [Vienne][2]
 (Autriche) les samedi et dimanche 10 et 11 novembre. Vous pouvez vous
-[inscrire](:http://www.approximity.com/cgi-bin/europeRuby/tiki.cgi?c=v&amp;p=Registration2007)
+[inscrire](http://www.approximity.com/cgi-bin/europeRuby/tiki.cgi?c=v&amp;p=Registration2007)
 et prendre connaissance des [informations d’ordre général][1] à propos
 de la conférence.
 


### PR DESCRIPTION
Generated as https://www.ruby-lang.org//fr/news/2007/10/20/euruko-2007/:http://www.approximity.com/cgi-bin/europeRuby/tiki.cgi?c=v&p=Registration2007
On https://www.ruby-lang.org//fr/news/2007/10/20/euruko-2007/