### PR TITLE
bundle update jekyll 3.2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
+    colorator (1.1.0)
     ffi (1.9.14)
-    jekyll (3.1.6)
-      colorator (~> 0.1)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.4.0)
@@ -17,7 +19,7 @@ GEM
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kgio (2.10.0)
-    kramdown (1.11.1)
+    kramdown (1.12.0)
     lanyon (0.4.0)
       jekyll (>= 2.0, < 4.0)
       rack (>= 1.6, < 3.0)
@@ -32,6 +34,8 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     paint (0.9.0)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
     pkg-config (1.1.7)
     rack (2.0.1)
     rack-protection (1.5.3)
@@ -76,4 +80,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1


### PR DESCRIPTION
I tried to apply https://github.com/ruby/www.ruby-lang.org/pull/1435 again.

I confirmed to generate normally with jekyll-3.2.x and https://github.com/ruby/heroku-buildpack-www-ruby-lang/pull/1

/cc @stomar 