### PR TITLE
Add Newsletters section to Community

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -31,7 +31,7 @@ to start:
 : Now is a fantastic time to follow Ruby’s development.
   If you are interested in helping with Ruby, start here.
 
-[Weblogs About Ruby](weblogs/)
+[Weblogs](weblogs/)
 : Very little happens in the Ruby community that is not talked about on
   the blogs. We’ve got a nice list of suggestions for you here for
   getting plugged in.
@@ -41,6 +41,9 @@ to start:
   more conferences, where they get together to share reports on
   work-in-progress, discuss the future of Ruby, and welcome newcomers to
   the Ruby community.
+
+[Newsletters](newsletters/)
+: Sometimes it's easier to receive Ruby news in your email inbox.
 
 General Ruby Information
 : * [Ruby Central][3]

--- a/en/community/newsletters/index.md
+++ b/en/community/newsletters/index.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: "Newsletters"
+lang: en
+---
+
+An easy way to stay up-to-date with Ruby news.
+{: .summary}
+
+### [Ruby Weekly][1]
+
+Ruby Weekly is a free, once–weekly e-mail round-up of Ruby news and articles.
+
+[1]: http://rubyweekly.com/


### PR DESCRIPTION
Ruby Weekly is regularly the source of Ruby news I recommend the most. It was
surprised not to find it in the community resources.

I doubt @peterc will object. :-)

**Community Preview**
![image](https://cloud.githubusercontent.com/assets/65950/18731364/7573ca24-8029-11e6-9614-00dbf32d1379.png)

**Newsletters page preview**
![image](https://cloud.githubusercontent.com/assets/65950/18731391/a2d7e28e-8029-11e6-9c81-8a26bcc9452d.png)
