### PR TITLE
Add Podcasts section to Community

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -42,13 +42,18 @@ to start:
   work-in-progress, discuss the future of Ruby, and welcome newcomers to
   the Ruby community.
 
+[Podcasts](podcasts/)
+: If you like to hear about Ruby rather than read about you can listen
+  to podcasts which cover new Ruby or gem releases, interviews and
+  discussions between Ruby programmers, contributors, and maintainers.
+
 General Ruby Information
-: * [Ruby Central][3]
-  * [Ruby at Open Directory Project][4]
-  * [Rails at Open Directory Project][5]
+: * [Ruby Central][ruby-central]
+  * [Ruby at Open Directory Project][ruby-opendir]
+  * [Rails at Open Directory Project][rails-opendir]
 
 
 
-[3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[ruby-central]: http://rubycentral.org/
+[ruby-opendir]: http://dmoz.org/Computers/Programming/Languages/Ruby/
+[rails-opendir]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/en/community/podcasts/index.md
+++ b/en/community/podcasts/index.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: "Podcasts"
+lang: en
+---
+
+Listen to news, interviews, and discussions about Ruby and its community.
+
+[Ruby Rogues][rogues]
+: The Ruby Rogues podcast is a panel discussion about topics relating to
+  programming, careers, community, and Ruby.
+
+[Ruby on Rails Podcast][rorpodcast]
+: The Ruby on Rails Podcast, a weekly conversation about Ruby on Rails,
+  open source software, and the programming profession.
+
+[rorpodcast]: http://5by5.tv/rubyonrails
+[rogues]: https://devchat.tv/ruby-rogues


### PR DESCRIPTION
This is definitely a little self-serving since I just launched
http://rubyfacets.com/ today but I've listed the other existing Ruby podcasts
that I know are still publishing new episodes at the moment. For now that
includes Ruby Rogues and the Ruby on Rails Podcast but I'm sure others will
find more relevant podcasts in languages other than English.
