### PR TITLE
Add Fukuoka Ruby Award 2017 news (en)

### DIFF
--- a/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -1,0 +1,65 @@
+---
+layout: news_post
+title: "2017 Fukuoka Ruby Award Competition - Entries to be judged by Matz"
+author: "Fukuoka Ruby"
+translator:
+date: 2016-10-20 00:00:00 +0000
+lang: en
+---
+
+Dear Ruby Enthusiasts,
+
+The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to
+invite you to enter the following Ruby competition. If you have developed an
+interesting Ruby program, please be encouraged to apply.
+
+2017 Fukuoka Ruby Award Competition
+ - Grand Prize - 1 Million Yen!
+
+Entry Deadline: December 27, 2016
+
+Matz and a group of panelists will select the winners of the Fukuoka Competition.
+The grand prize for the Fukuoka Competition is 1 million yen.
+Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Programs entered in the competition do not have to be written entirely in Ruby
+but should take advantage of the unique characteristics of Ruby.
+
+Projects must have been developed or completed within the past 12 months to be
+eligible. Please visit the following Fukuoka website for additional details or
+to enter:
+
+[http://www.digitalfukuoka.jp/events/114](http://www.digitalfukuoka.jp/events/114)
+or
+[http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc)
+
+Please email the application form to award@f-ruby.com.
+
+This year, we have the following special prizes:
+
+The winner of the AWS Prize will receive:
+
+* Amazon Fire Tablet(subject to change)
+* AWS architect technical consultation
+
+The winner of the GMO Pepabo Prize will receive:
+
+* Gift basket filled with local foods and snacks (30,000 yen value)
+* 50,000 yen gift certificate toward domain services
+
+The winner of the IIJ GIO Prize will receive:
+
+* IIJ GIO free coupon worth 500,000 yen (up to 6 months)
+
+The winner of the Salesforce Prize will receive:
+
+* salesforce.com novelty goods
+
+"Matz will be testing and reviewing your source code thoroughly, so it's very
+meaningful to apply! The competition is free to enter."
+
+Thanks!

--- a/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -9,27 +9,21 @@ lang: en
 
 Dear Ruby Enthusiasts,
 
-The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to
-invite you to enter the following Ruby competition. If you have developed an
-interesting Ruby program, please be encouraged to apply.
+The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to invite you to enter the following Ruby competition. If you have developed an interesting Ruby program, please be encouraged to apply.
 
-2017 Fukuoka Ruby Award Competition
- - Grand Prize - 1 Million Yen!
+2017 Fukuoka Ruby Award Competition - Grand Prize - 1 Million Yen!
 
 Entry Deadline: December 27, 2016
 
-Matz and a group of panelists will select the winners of the Fukuoka Competition.
-The grand prize for the Fukuoka Competition is 1 million yen.
-Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
+![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
 
 [http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
 
-Programs entered in the competition do not have to be written entirely in Ruby
-but should take advantage of the unique characteristics of Ruby.
+Programs entered in the competition do not have to be written entirely in Ruby but should take advantage of the unique characteristics of Ruby.
 
-Projects must have been developed or completed within the past 12 months to be
-eligible. Please visit the following Fukuoka website for additional details or
-to enter:
+Projects must have been developed or completed within the past 12 months to be eligible. Please visit the following Fukuoka websites for additional details or to enter:
 
 [http://www.digitalfukuoka.jp/events/114](http://www.digitalfukuoka.jp/events/114)
 or
@@ -59,7 +53,6 @@ The winner of the Salesforce Prize will receive:
 
 * salesforce.com novelty goods
 
-"Matz will be testing and reviewing your source code thoroughly, so it's very
-meaningful to apply! The competition is free to enter."
+"Matz will be testing and reviewing your source code thoroughly, so it's very meaningful to apply! The competition is free to enter."
 
 Thanks!


### PR DESCRIPTION
Add Fukuoka Ruby Award 2017 news. Please review and merge.