### PR TITLE
Translate Fukuoka Ruby Award 2017 news (id)

### DIFF
--- a/id/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/id/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -1,0 +1,70 @@
+---
+layout: news_post
+title: "2017 Fukuoka Ruby Award Competition - Peserta akan dinilai oleh Matz"
+author: "Fukuoka Ruby"
+translator: "meisyal"
+date: 2016-10-20 00:00:00 +0000
+lang: id
+---
+
+Penggemar Ruby terhomat,
+
+Pemerintah Fukuoka, Jepang, bersama dengan "Matz" Matsumoto ingin
+mengundang Anda mengikuti kompetisi Ruby berikut. Jika Anda pernah
+mengembangkan sebuah program Ruby yang menarik, dianjurkan untuk mengikuti
+kompetisi ini.
+
+2017 Fukuoka Ruby Award Competition - Grand Prize - 1 Juta Yen!
+
+Batas akhir masuk: 27 Desember 2016
+
+![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz dan sebuah grup dari panelis akan memilih pemenang kompetisi ini.
+Hadiah utama kompetisi ini adalah 1 juta yen.
+Hadiah utama pemenang sebelumnya termasuk *Rhomobile* (USA) dan *APEC
+Climate Center* (Korea).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Program-program yang masuk dalam kompetisi tidak harus ditulis seluruhnya
+dengan Ruby, tetapi harus mengambil kemudahan dari karateristik unik yang
+diberikan oleh Ruby.
+
+Proyek harus dikembangkan atau diselesaikan selama 12 bulan untuk
+memenuhi persyaratan. Silakan kunjungi laman Fukuoka berikut untuk detail
+tambahan atau pengajuan:
+
+[http://www.digitalfukuoka.jp/events/114](http://www.digitalfukuoka.jp/events/114)
+atau
+[http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc)
+
+Silakan kirim formulir pengajuan ke award@f-ruby.com
+
+Tahun ini, Fukuoka Ruby memiliki hadiah spesial berikut:
+
+Pemenang *AWS Prize* akan menerima:
+
+* *Amazon Fire Tablet* (dapat berubah sewaktu-waktu)
+* *AWS architect technical consultation*
+
+Pemenang *GMO Pepabo Prize* akan menerima:
+
+* *Gift basket* yang berisi makanan lokal dan makanan ringan (senilai 30,000
+  yen)
+* 50,000 yen *gift certificate* untuk layanan domain
+
+Pemenang *IIJ GIO Prize* akan menerima:
+
+* Kupon gratis *IIJ GIO* senilai 500,000 yen (hingga 6 bulan)
+
+Pemenang *Salesforce Prize* akan menerima:
+
+* *Item* spesial salesforce.com
+
+"Matz akan menguji dan meninjaui kode sumber Anda sepenuhnya, sehingga ini
+sangat berarti untuk mengajukan! Kompetisi ini gratis untuk diikuti."
+
+Terima kasih!


### PR DESCRIPTION
Just translated the latest news about Fukuoka Ruby Award 2017 into bahasa Indonesia. This translation needs a review. cc: @gozali and @stomar.

Thank you.
