### PR TITLE
Add link to ruby issues

### DIFF
--- a/en/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/en/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -74,7 +74,7 @@ Try and enjoy programming with Ruby 2.4.0-preview2, and
 ## Other notable changes since 2.3
 
 * Support OpenSSL 1.1.0
-* ext/tk is now removed from stdlib [Feature #8539]
+* ext/tk is now removed from stdlib [Feature #8539](https://bugs.ruby-lang.org/issues/8539)
 
 See [NEWS](https://github.com/ruby/ruby/blob/v2_4_0_preview2/NEWS)
 and [ChangeLog](https://github.com/ruby/ruby/blob/v2_4_0_preview2/ChangeLog)

--- a/en/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/en/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -87,8 +87,8 @@ Try and enjoy programming with Ruby 2.4.0-preview3, and
 ## Other notable changes since 2.3
 
 * Support OpenSSL 1.1.0
-* ext/tk is now removed from stdlib [Feature #8539]
-* XMLRPC is now removed from stdlib [Feature #12160]
+* ext/tk is now removed from stdlib [Feature #8539](https://bugs.ruby-lang.org/issues/8539)
+* XMLRPC is now removed from stdlib [Feature #12160](https://bugs.ruby-lang.org/issues/12160)
 
 See [NEWS](https://github.com/ruby/ruby/blob/v2_4_0_preview3/NEWS)
 and [ChangeLog](https://github.com/ruby/ruby/blob/v2_4_0_preview3/ChangeLog)


### PR DESCRIPTION
this pr have changes like this:

- Add link from feature text to redmine.

I wonder It just missed or not, anyway, It's better to have the link I think. :)