### PR TITLE
Fix changelog link of 2.3.3 post (en ja ko)

### DIFF
--- a/en/news/_posts/2016-11-21-ruby-2-3-3-released.md
+++ b/en/news/_posts/2016-11-21-ruby-2-3-3-released.md
@@ -15,7 +15,7 @@ This is a regression on Ruby 2.3.2 released last week.
 See [[Bug #12920]](https://bugs.ruby-lang.org/issues/12920) for details.
 
 There are some bugfixes too.
-See the [ChangeLog](https://github.com/ruby/ruby/compare/v2_3_2...v2_3_3#diff-02f0b547c2779d25cff89672135f20e3)
+See the [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_3/ChangeLog)
 for details.
 
 ## Download

--- a/ja/news/_posts/2016-11-21-ruby-2-3-3-released.md
+++ b/ja/news/_posts/2016-11-21-ruby-2-3-3-released.md
@@ -15,7 +15,7 @@ Ruby 2.3.3 がリリースされました。
 詳しくは [[Bug #12920]](https://bugs.ruby-lang.org/issues/12920) を参照してください。
 
 他にもいくつかの不具合修正がありました。
-その他詳細は [ChangeLog](https://github.com/ruby/ruby/compare/v2_3_2...v2_3_3#diff-02f0b547c2779d25cff89672135f20e3) を参照してください。
+その他詳細は [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_3/ChangeLog) を参照してください。
 
 ## ダウンロード
 

--- a/ko/news/_posts/2016-11-21-ruby-2-3-3-released.md
+++ b/ko/news/_posts/2016-11-21-ruby-2-3-3-released.md
@@ -17,7 +17,7 @@ lang: ko
 
 또한 몇몇 버그 수정도 포함되었습니다.
 자세한 사항은
-[ChangeLog](https://github.com/ruby/ruby/compare/v2_3_2...v2_3_3#diff-02f0b547c2779d25cff89672135f20e3)를
+[ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_3/ChangeLog)를
 확인해주세요.
 
 ## 다운로드


### PR DESCRIPTION
Follow the [previous conventions](https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/en/news/_posts/2016-11-15-ruby-2-3-2-released.md).