### PR TITLE
Add a reference to macOS Sierra

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -122,7 +122,7 @@ This should install the latest stable Ruby version.
 ### Homebrew (OS X)
 {: #homebrew}
 
-On OS X El Capitan, Yosemite, and Mavericks, Ruby 2.0 is included.
+On OS X El Capitan, Yosemite, Mavericks, and macOS Sierra, Ruby 2.0 is included.
 OS X Mountain Lion, Lion, and Snow Leopard ship with Ruby 1.8.7.
 
 Many people on OS X use [Homebrew][homebrew] as a package manager.


### PR DESCRIPTION
This may help clarify any confusion over which version of Ruby ships with the newest version of the OS — or whether it’s included at all. For the record, a fresh copy of macOS Sierra 10.12 (Build 16A323), released on September 20, 2016 via the Mac App Store has this version of Ruby installed: `ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin16]`.

Change only made in English. This needs to be translated.