### PR TITLE
Remove rubyfrance association

### DIFF
--- a/fr/community/index.md
+++ b/fr/community/index.md
@@ -8,9 +8,7 @@ La communauté se développant autour d’un langage de programmation
 constitue évidemment une de ses qualités essentielles. Ruby possède une
 communauté grandissante qui s’avère accueillante, indépendamment du
 niveau technique de ses visiteurs. Attention toutefois, la plupart des
-communautés utilisateurs utilisent l’anglais comme base de travail. Si
-vous recherchez spécifiquement des programmeurs francophones,
-[RubyFrance][1] est certainement ce qu’il vous faut !
+communautés utilisateurs utilisent l’anglais comme base de travail.
 {: .summary}
 
 Quelques liens à visiter:
@@ -54,7 +52,6 @@ Informations générales
 
 
 
-[1]: http://rubyfrance.org
 [3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/

--- a/fr/community/user-groups/index.md
+++ b/fr/community/user-groups/index.md
@@ -30,12 +30,6 @@ pour le partage des connaissances et, si vous êtes chanceux, des
 réunions et conférences (la mode étant aux barcamp, rencontres autour
 d’un verre dans un lieu adapté aux présentations).
 
-[Ruby France][1]
-: L’association française de promotion du language Ruby fédère un
-  certains nombre de groupes locaux (Paris, Lyon…) et constitue par
-  elle-même un groupe d’utilisateurs, centré autour de la liste de
-  diffusion publique.
-
 [Meetup][2]
 : Un nombre non négligeable de groupes ont choisi de promouvoir leurs
   évènements chez Meetup. Cet outil propose des services variés
@@ -108,7 +102,6 @@ détail [comment organiser un apéro Ruby][19].
 
 
 
-[1]: http://www.rubyfrance.org/
 [2]: http://ruby.meetup.com
 [3]: http://www.meetup.com/parisrb/
 [4]: http://groups.google.com/group/parisrb

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -6,9 +6,7 @@ lang: fr
 
 Vous trouverez ici des manuels, tutoriels et références pour apprendre
 Ruby. Une bonne partie de ces ressources est en langue anglaise. Sachez
-qu’il existe une association française pour la promotion du langage
-Ruby, [Ruby France][1], qui propose des tutoriels en français ; il
-existe également plusieurs livres en français. Toutefois, la pratique de
+qu’il existe plusieurs livres en français. Toutefois, la pratique de
 l’anglais est recommandée car il s’agit *de facto* de la langue
 dominante en informatique. Bon courage !
 {: .summary}
@@ -144,7 +142,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 
 
 
-[1]: http://www.rubyfrance.org
 [2]: http://jeveuxapprendreruby.fr/
 [3]: http://tryruby.org/
 [4]: http://rubykoans.com/


### PR DESCRIPTION
The rubyfrance association does not longer exist. Also, the hostname http://www.rubyfrance.org/ is not relevant anymore.