### PR TITLE
Fix typos (en)

### DIFF
--- a/en/news/_posts/2010-08-18-ruby-1-9-2-released.md
+++ b/en/news/_posts/2010-08-18-ruby-1-9-2-released.md
@@ -17,7 +17,7 @@ The new 1.9.2 is almost compatible with 1.9.1, except these changes:
 * New Random class which supports several random numbers generators
 * Time is reimplemented. The bug with year 2038 is fixed.
 * regex improvements
-* $: doesn\'t include the current direcotry.
+* $: doesn\'t include the current directory.
 * dl is reimplemented on top of libffi.
 * new psych library wrapping libyaml which can replace syck.
 

--- a/en/news/_posts/2011-02-18-fileutils-is-vulnerable-to-symlink-race-attacks.md
+++ b/en/news/_posts/2011-02-18-fileutils-is-vulnerable-to-symlink-race-attacks.md
@@ -32,7 +32,7 @@ should not be world writable except when the sticky bit set.
 
 ### Updates
 
-* Fixed typo. (vulnerabile -&gt; vulnerable)
+* Fixed typo. (vulnerable -&gt; vulnerable)
 * 1\.8.7-334 was released to fix this issue. 1.8.7 users are encouraged
   to upgrade.
   * [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz][1]

--- a/en/news/_posts/2011-08-01-ruby-1-9-3-preview1-has-been-released.md
+++ b/en/news/_posts/2011-08-01-ruby-1-9-3-preview1-has-been-released.md
@@ -33,7 +33,7 @@ Ruby Inside has published [a review of this release][3].
 ## Differences from previous version
 
 Previous Ruby versions was licensed under \"GPLv2\" and \"Ruby\" license
-but \"2-clause BSDL\"(AKA Simplfied BSD License) and \"Ruby\" lisence
+but \"2-clause BSDL\"(AKA Simplfied BSD License) and \"Ruby\" license
 been replacement of them.
 
 ### Encoding

--- a/en/news/_posts/2013-12-17-maintenance-of-1-8-7-and-1-9-2.md
+++ b/en/news/_posts/2013-12-17-maintenance-of-1-8-7-and-1-9-2.md
@@ -54,7 +54,7 @@ and Zachary will support these versions for security maintenance as part of a
 corporate sponsorship.
 
 In the past we have supported vendors who wish to maintain legacy versions. In
-2009 the maintenance of Ruby 1.8.6 was transfered to Engine Yard when they
+2009 the maintenance of Ruby 1.8.6 was transferred to Engine Yard when they
 released 1.8.6-p369.
 
 ### Words of encouragement


### PR DESCRIPTION
```shell
go get -u github.com/client9/misspell/cmd/misspell
misspell  -w -error -source=text en/
```