### PR TITLE
Add Rubyland aggregator to blog source list

### DIFF
--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -14,6 +14,7 @@ describing new techniques, or speculating on Ruby’s future.
 * [**RubyFlow**][rubyflow], “the Ruby and Rails community linklog”,
   is a Ruby news site with links to libraries, blog posts, tutorials,
   and other Ruby resources.
+* [**Rubyland**][rubyland], aggregates news and blog posts about ruby from rss feeds.
 
 ### Blogs of Note
 
@@ -45,6 +46,7 @@ some brilliant code out there, be sure to let them know!
 
 
 
+[rubyland]: http://rubyland.news/
 [rubyflow]: http://www.rubyflow.com/
 [8]: http://oreillynet.com/ruby/
 [9]: http://weblog.rubyonrails.org/


### PR DESCRIPTION
Rubyland is an RSS/Atom feed aggregator of ruby news and blogs.
It's been up since November 2016, and is going well. It is the
only current ruby 'planet' style aggregator I know of. I
think it's a valuable source of ruby news and of finding
blogs.

Disclosure: I am the creator of rubyland.