### PR TITLE
Translate Ruby 2.4.1 released post (id)

### DIFF
--- a/id/news/_posts/2017-03-22-ruby-2-4-1-released.md
+++ b/id/news/_posts/2017-03-22-ruby-2-4-1-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 2.4.1 Rilis"
+author: "naruse"
+translator: "meisyal"
+date: 2017-03-22 03:00:00 +0000
+lang: id
+---
+
+Kami dengan senang hati mengumumkan rilis dari Ruby 2.4.1.
+Ini adalah versi rilis TEENY pertama dari rangkaian 2.4 yang *stable*.
+
+Lihat [commit logs](https://github.com/ruby/ruby/compare/v2_4_0...v2_4_1) untuk
+detail.
+
+## Unduh
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2>
+
+      SIZE:   12571597 bytes
+      SHA1:   b0bec75c260dcb81ca386fafef27bd718f8c28ad
+      SHA256: ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c
+      SHA512: 1c80d4c30ecb51758a193b26b76802a06d214de7f15570f1e85b5fae4cec81bda7237f086b81f6f2b5767f2e93d347ad1fa3f49d7b5c2e084d5f57c419503f74
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz>
+
+      SIZE:   14174752 bytes
+      SHA1:   47909a0f77ea900573f027d27746960ad6d07d15
+      SHA256: a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250
+      SHA512: 6cddac19733870f372750a276a2c59f99dea9a17731cd7c24a44b615794ff1a5d194660949628217107f2301f3b1ff3b6c18223896c87c76e84c64f4078769dc
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.xz>
+
+      SIZE:   9939188 bytes
+      SHA1:   eb3e25346431214379e3b92c6f6b6e02f7b2503f
+      SHA256: 4fc8a9992de3e90191de369270ea4b6c1b171b7941743614cc50822ddc1fe654
+      SHA512: e6fd290b6edd166348b70f0f1c56f7ed9d956c4c1eb91d97d0548041ca4196b9b75ec1ad35c745bdbfd4de195899093e7205d7f02b014ecf1c48e6f31cf25903
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.zip>
+
+      SIZE:   15830344 bytes
+      SHA1:   19bdb47299a39316df2c80107314940d17b26d88
+      SHA256: f98a3b50439ffdd270f9ae86d99ff0be431c81b85215c9aafac942ef40b89cbf
+      SHA512: 4dc8991a5f8751a5853798b2e438eb3879c959a02517aa4d0efa045412e47ba7036679fd4c6797249a502f0bfac9ef43740f7bff29b017d10e0b3f51d63f161f
+
+## Komentar Rilis
+
+Banyak *committers*, pengembang, dan pengguna yang menyediakan laporan *bug*
+telah membantu kami untuk membuat rilis ini.
+Terima kasih atas kontribusinya.


### PR DESCRIPTION
Ruby 2.4.1 released news has been translated into Bahasa Indonesia. Please, help me to review this translation @gozali!

Thank you.