### PR TITLE
Add latest news posts (ja): Rubyist Magazine 0055

### DIFF
--- a/ja/news/_posts/2017-03-26-rubyist-magazine-0055-published.md
+++ b/ja/news/_posts/2017-03-26-rubyist-magazine-0055-published.md
@@ -1,0 +1,28 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0055号 発行"
+author: "miyohide"
+date: 2017-03-26 23:00:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0055号][3]がリリースされました([\[ruby-list:50505\]][4])。
+
+今号は、
+
+* [巻頭言](http://magazine.rubyist.net/?0055-ForeWord)
+* [PyCallがあればRubyで機械学習ができる](http://magazine.rubyist.net/?0055-pycall)
+* [RubyKaigi 2016 託児室運営記録（技術カンファレンスにおける託児サービス提供について）](http://magazine.rubyist.net/?0055-RubyKaigi2016Nursery)
+* [RubyConf 2016 参加レポート](http://magazine.rubyist.net/?0055-RubyConf2016Report)
+* [RegionalRubyKaigi レポート (60) 川崎 Ruby 会議 01](http://magazine.rubyist.net/?0055-KawasakiRubyKaigi01Report)
+* [るびまアクセスランキング Vol.55](http://magazine.rubyist.net/?0055-RubyistMagazineRanking)
+
+という構成となっています。
+
+お楽しみください。
+
+[1]: http://ruby-no-kai.org
+[2]: http://magazine.rubyist.net/
+[3]: http://magazine.rubyist.net/?0054
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50505
+


### PR DESCRIPTION
RubiMa Editors have released Rubyist Magazine 0055 (in japanese).
Please add this post to the news page.
http://magazine.rubyist.net/?0055
