### PR TITLE
Mention API incompatibility of Ruby 2.3.4 (ko)

### DIFF
--- a/ko/news/_posts/2017-03-30-ruby-2-3-4-released.md
+++ b/ko/news/_posts/2017-03-30-ruby-2-3-4-released.md
@@ -19,6 +19,16 @@ lang: ko
 참고하세요.
 
 
+## 알려진 문제점(2017년 4월 11일에 추가됨)
+
+API가 호환되지 않는 문제점이 Ruby 2.3.4에서 발견되었습니다.
+이는 의도치 않게 API 함수 `rb_thread_fd_close`를 삭제했기 때문입니다.
+다음 릴리스에서 이 문제를 해결할 예정이지만, 이 때문에 문제를 겪고 있고 지금
+당장 해결해야 한다면 다음 패치를 이용하세요.
+
+* [rb_thread_fd_close 문제를 위한 패치](https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/branches/ruby_2_3/thread.c?r1=58289&r2=58288&pathrev=58289&view=patch)
+
+
 ## 다운로드
 
 * [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2)


### PR DESCRIPTION
See #1581.

@ruby/www-ruby-lang-org-i18n-ko Please review.