### PR TITLE
Translate Support of Ruby 2.1 has ended (id)

### DIFF
--- a/id/news/_posts/2017-04-01-support-of-ruby-2-1-has-ended.md
+++ b/id/news/_posts/2017-04-01-support-of-ruby-2-1-has-ended.md
@@ -1,0 +1,48 @@
+---
+layout: news_post
+title: "Dukungan Ruby 2.1 telah berakhir"
+author: "usa"
+translator: "meisyal"
+date: 2017-04-01 00:00:00 +0000
+lang: id
+---
+
+Kami mengumumkan semua dukungan dari rangkaian Ruby 2.1 telah berakhir.
+
+Setelah Ruby 2.1.10 rilis pada akhir bulan Maret tahun lalu,
+dukungan dari rangkaian Ruby 2.1 pada fase perawatan keamanan.
+Sekarang, setelah satu tahun berlalu, fase tersebut telah berakhir.
+Sehingga, pada 31 Maret 2017, semua dukungan dari rangkaian Ruby 2.1 telah
+berakhir.
+Perbaikan *bug* dan keamanan dari versi Ruby terbaru tidak akan lagi
+di-*backported* ke 2.1, dan tidak ada *patch* dari 2.1 akan dirilis.
+Kami sangat merekomendasikan Anda untuk meng-*upgrade* ke Ruby 2.4 atau 2.3
+segera mungkin.
+
+
+## Tentang versi Ruby yang didukung saat ini
+
+### Rangkaian Ruby 2.4
+
+Saat ini pada fase perawatan yang biasa dilakukan.
+Kami akan *backported bug fixes* dan rilis dengan perbaikan-perbaikan setiap
+kali diperlukan.
+Dan, jika sebuah masalah keamanan serius ditemukan, kami akan rilis sebuah
+*urgent fix*.
+
+### Rangkaian Ruby 2.3
+
+Saat ini pada fase perawatan yang biasa dilakukan.
+Kami akan *backported bug fixes* dan rilis dengan perbaikan-perbaikan setiap
+kali diperlukan.
+Dan, jika sebuah masalah keamanan serius ditemukan, kami akan rilis sebuah
+*urgent fix*.
+
+### Rangkaian Ruby 2.2
+
+Saat ini pada fase perawatan keamanan.
+Kami tidak akan pernah *backport bug fixes* ke 2.2 kecuali perbaikan keamanan.
+Jika sebuah masalah keamanan serius ditemukan, kami akan rilis sebuah *urgent
+fix*.
+Kami sedang merencanakan untuk mengakhiri dukungan dari rangkaian Ruby 2.2 pada
+akhir bulan Maret 2018.


### PR DESCRIPTION
Just translated "Support of Ruby 2.1 has ended". Please, help me to review this translation @gozali!
Let me know if there are typos or translation mistakes.