### PR TITLE
Add posting guidelines for ruby-talk

### DIFF
--- a/en/community/mailing-lists/index.md
+++ b/en/community/mailing-lists/index.md
@@ -12,7 +12,7 @@ Ruby has four primary English speaking mailing lists:
 
 Ruby-Talk
 : This is the most popular mailing-list and deals with general topics
-  about Ruby. ([Archives][3])
+  about Ruby. ([Archives][3], [Posting Guidelines][guidelines])
 
 Ruby-Core
 : This list deals with core and implementation topics about Ruby, often
@@ -42,6 +42,7 @@ subscribing the [manual way](manual-instructions/).
 
 
 
+[guidelines]: ruby-talk-guidelines/
 [clrFAQ]: http://rubyhacker.com/clrFAQ.html
 [3]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
 [4]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml

--- a/en/community/mailing-lists/ruby-talk-guidelines/index.md
+++ b/en/community/mailing-lists/ruby-talk-guidelines/index.md
@@ -1,17 +1,15 @@
 ---
 layout: page
-title: "Posting Guidelines for comp.lang.ruby"
+title: "Posting Guidelines for the Ruby-Talk Mailing List"
 lang: en
 ---
 
-_These are the posting guidelines for comp.lang.ruby,
-adopted from the [comp.lang.ruby FAQ][clrFAQ]._
+You should follow these guidelines when posting to the ruby-talk mailing list.
+{: .summary}
 
-You should also follow these guidelines for the ruby-list mail list,
-since it is mirrored to comp.lang.ruby.
 
 1. ALWAYS be friendly, considerate, tactful, and tasteful. We want to
-   keep this forum hospitable to the growing ranks of newbies, very
+   keep this list hospitable to the growing ranks of newbies, very
    young people, and their teachers, as well as cater to fire breathing
    wizards. :-)
 
@@ -19,7 +17,7 @@ since it is mirrored to comp.lang.ruby.
    content brief and to the point, but also try to include all relevant
    information.
 
-   1. The general format guidelines (aka USENET Netiquette) are
+   1. The general format guidelines (aka Netiquette) are
       matters of common sense and common courtesy that make life
       easier for 3rd parties to follow along (in real time or when
       perusing archives):
@@ -27,8 +25,8 @@ since it is mirrored to comp.lang.ruby.
       * PLEASE NOTE! Include quoted text from previous posts
         **before** your responses. And **selectively** quote as much
         as is relevant.
-      * Use **plain** text; don't use HTML, RTF, or Word. Most mail
-        or newsreader programs have an option for this; if yours
+      * Use **plain** text; don't use HTML, RTF, or Word.
+        Most mail programs have an option for this; if yours
         doesn't, get a (freeware) program or use a web-based
         service that does.
       * Include examples from files as **in-line** text; don't use
@@ -74,6 +72,9 @@ since it is mirrored to comp.lang.ruby.
    appropriate, check the Ruby home page, check the Ruby FAQ and other
    documentation, use google.com to search past comp.lang.ruby
    postings, and so on.
+
+
+_These guidelines where adopted from the [comp.lang.ruby FAQ][clrFAQ]._
 
 
 

--- a/en/community/mailing-lists/ruby-talk-guidelines/index.md
+++ b/en/community/mailing-lists/ruby-talk-guidelines/index.md
@@ -8,7 +8,7 @@ You should follow these guidelines when posting to the ruby-talk mailing list.
 {: .summary}
 
 
-1. ALWAYS be friendly, considerate, tactful, and tasteful. We want to
+1. **Always** be friendly, considerate, tactful, and tasteful. We want to
    keep this list hospitable to the growing ranks of newbies, very
    young people, and their teachers, as well as cater to fire breathing
    wizards. :-)
@@ -19,16 +19,15 @@ You should follow these guidelines when posting to the ruby-talk mailing list.
 
    1. The general format guidelines (aka Netiquette) are
       matters of common sense and common courtesy that make life
-      easier for 3rd parties to follow along (in real time or when
+      easier for third parties to follow along (in real time or when
       perusing archives):
 
-      * PLEASE NOTE! Include quoted text from previous posts
-        **before** your responses. And **selectively** quote as much
-        as is relevant.
-      * Use **plain** text; don't use HTML, RTF, or Word.
-        Most mail programs have an option for this; if yours
-        doesn't, get a (freeware) program or use a web-based
-        service that does.
+      * **Please note:**
+        Include quoted text from previous posts **before** your responses
+        and **selectively** quote as much as is relevant.
+      * Use **plain text**; don't use HTML, RTF, or Word.
+        Most email programs have an option for this; if yours doesn't,
+        get a (free) program or use a web-based service that does.
       * Include examples from files as **in-line** text; don't use
         attachments.
 
@@ -37,11 +36,11 @@ You should follow these guidelines when posting to the ruby-talk mailing list.
 
       When appropriate, include:
 
-      * The version of Ruby. (`ruby -v`)
-      * The compiler name and version used to build Ruby.
-      * The OS type and level. (`uname -a`)
-      * The actual error messages.
-      * An example (preferably simple) that produces the problem.
+      * an example (preferably simple) that produces the problem
+      * the actual error messages
+      * the version of Ruby (`ruby -v`)
+      * the OS type and version (`uname -a`)
+      * the compiler name and version used to build Ruby
 
 3. Make the subject line maximally informative, so that people who
    should be interested will read your post and so that people who
@@ -69,13 +68,15 @@ You should follow these guidelines when posting to the ruby-talk mailing list.
 
 4. Finally, be considerate: Don't be too lazy. If you are seeking
    information, first make a reasonable effort to look it up. As
-   appropriate, check the Ruby home page, check the Ruby FAQ and other
-   documentation, use google.com to search past comp.lang.ruby
-   postings, and so on.
+   appropriate, check the [Ruby home page][ruby-lang],
+   check the [Ruby FAQ][faq] and other documentation,
+   use a search engine to search past postings, and so on.
 
 
 _These guidelines where adopted from the [comp.lang.ruby FAQ][clrFAQ]._
 
 
 
+[ruby-lang]: /en/
+[faq]: /en/documentation/faq/
 [clrFAQ]: http://rubyhacker.com/clrFAQ.html

--- a/en/community/mailing-lists/ruby-talk-guidelines/index.md
+++ b/en/community/mailing-lists/ruby-talk-guidelines/index.md
@@ -1,0 +1,80 @@
+---
+layout: page
+title: "Posting Guidelines for comp.lang.ruby"
+lang: en
+---
+
+_These are the posting guidelines for comp.lang.ruby,
+adopted from the [comp.lang.ruby FAQ][clrFAQ]._
+
+You should also follow these guidelines for the ruby-list mail list,
+since it is mirrored to comp.lang.ruby.
+
+1. ALWAYS be friendly, considerate, tactful, and tasteful. We want to
+   keep this forum hospitable to the growing ranks of newbies, very
+   young people, and their teachers, as well as cater to fire breathing
+   wizards. :-)
+
+2. Keep your content relevant and easy to follow. Try to keep your
+   content brief and to the point, but also try to include all relevant
+   information.
+
+   1. The general format guidelines (aka USENET Netiquette) are
+      matters of common sense and common courtesy that make life
+      easier for 3rd parties to follow along (in real time or when
+      perusing archives):
+
+      * PLEASE NOTE! Include quoted text from previous posts
+        **before** your responses. And **selectively** quote as much
+        as is relevant.
+      * Use **plain** text; don't use HTML, RTF, or Word. Most mail
+        or newsreader programs have an option for this; if yours
+        doesn't, get a (freeware) program or use a web-based
+        service that does.
+      * Include examples from files as **in-line** text; don't use
+        attachments.
+
+   2. If reporting a problem, give **all** the relevant information
+      the first time; this isn't the psychic friends newsgroup. :-)
+
+      When appropriate, include:
+
+      * The version of Ruby. (`ruby -v`)
+      * The compiler name and version used to build Ruby.
+      * The OS type and level. (`uname -a`)
+      * The actual error messages.
+      * An example (preferably simple) that produces the problem.
+
+3. Make the subject line maximally informative, so that people who
+   should be interested will read your post and so that people who
+   wouldn't be interested can easily avoid it.
+
+   **Usefully** describe the contents of your post.
+
+   This is OK:
+
+   * "How can I do x with y on z?"
+   * "Problem: did x, expected y, got z."
+   * "BUG: doing x with module y crashed z."
+
+   This is **not** OK:
+
+   * "Please help!!!"
+   * "Newbie question"
+   * "Need Ruby guru to tell me what's wrong"
+
+   These prefixes have become common for subject lines:
+
+   * `[ANN]` (for announcements)
+   * `[BUG]` (for bug reports)
+   * `[OT]`  (for off-topic, if you must post off-topic)
+
+4. Finally, be considerate: Don't be too lazy. If you are seeking
+   information, first make a reasonable effort to look it up. As
+   appropriate, check the Ruby home page, check the Ruby FAQ and other
+   documentation, use google.com to search past comp.lang.ruby
+   postings, and so on.
+
+
+
+[clrFAQ]: http://rubyhacker.com/clrFAQ.html


### PR DESCRIPTION
This adds a page with posting guidelines for the ruby-talk mailing list.

This replaces the previously linked [comp.lang.ruby FAQ](http://rubyhacker.com/clrFAQ.html). The link was removed recently because the FAQ is not really maintained anymore and contains many dead links and outdated information.
