### PR TITLE
Add lang to html start tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
-<html>
+{% if page.lang != null %}
+<html lang="{{ page.lang }}">
+{% else %}
+<html lang="en">
+{% endif %}
   <head>
     <meta charset="utf-8">
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 {% if page.lang != null %}
-<html lang="{{ page.lang }}">
+{% assign lang_code = site.locales.feed[page.lang].lang_code %}
+<html lang="{{ lang_code }}">
 {% else %}
 <html lang="en">
 {% endif %}


### PR DESCRIPTION
Fix warning:

`Warning: This document appears to be written in French. Consider adding lang="fr" (or variant) to the html start tag.`