### PR TITLE
Update Homebrew section on installation page (es)

### DIFF
--- a/es/documentation/installation/index.md
+++ b/es/documentation/installation/index.md
@@ -122,7 +122,7 @@ Esto debería instalar la última versión estable de Ruby.
 ### Homebrew (OS X)
 {: #homebrew}
 
-Ruby 2.0.0 ya viene instalado en OS X Yosemite y Mavericks.
+Ruby 2.0 ya viene instalado en OS X El Capitan, Yosemite, Mavericks y macOS Sierra.
 OS X Mountain Lion, Lion, y Snow Leopard vienen con Ruby 1.8.7 instalado.
 
 Algunas personas en OS X usan [Homebrew][homebrew] como gestor de paquetes.


### PR DESCRIPTION
El Capitan and macOS Sierra were not there. Also change 2.0.0 to use 2.0 as used on english documentation