### PR TITLE
add links to rvm, rbenv and rubyinstaller on installation page

### DIFF
--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -15,10 +15,10 @@ lang: bg
 
 * За Linux/UNIX може да бъде използван пакетният мениджър на
   дистрибуцията (apt-get, yum, pacman, etc.) или приложение за
-  управление на ruby версии (rbenv и RVM).
+  управление на ruby версии ([rbenv][rbenv] и [RVM][rvm]).
 * За OS X може да се използва инструмент за управление на ruby версии
-  (rbenv и RVM).
-* За Windows машини може да бъде използван RubyInstaller.
+  ([rbenv][rbenv] и [RVM][rvm]).
+* За Windows машини може да бъде използван [RubyInstaller][rubyinstaller].
 
 Вижте страницата за [Инсталация][installation] за по-подробна
 информация за инсталиране.
@@ -73,3 +73,6 @@ Ruby може да бъде инсталиран и от изходен код �
 [license]: {{ site.license.url }}
 [installation]: /bg/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -15,9 +15,9 @@ Auf allen wichtigen Plattformen gibt es mehrere Möglichkeiten,
 Ruby zu installieren:
 
 * Auf Linux/UNIX kann man das Paketverwaltungssystem der jeweiligen
-  Distribution oder Drittanbieter-Werkzeuge (rbenv und RVM) verwenden.
-* Auf OS X kann man Drittanbieter-Werkzeuge verwenden (rbenv und RVM).
-* Auf Windows kann man RubyInstaller verwenden.
+  Distribution oder Drittanbieter-Werkzeuge ([rbenv][rbenv] und [RVM][rvm]) verwenden.
+* Auf OS X kann man Drittanbieter-Werkzeuge verwenden ([rbenv][rbenv] und [RVM][rvm]).
+* Auf Windows kann man [RubyInstaller][rubyinstaller] verwenden.
 
 Siehe die [Installationsanleitung][installation] für Details zu
 den verschiedenen Paketverwaltungssystemen und Drittanbieter-Werkzeugen.
@@ -72,3 +72,6 @@ Bitte nutze einen Mirror in deiner Nähe.
 [license]: {{ site.license.url }}
 [installation]: /de/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -14,9 +14,9 @@ Please be sure to read [Ruby’s License][license].
 We have several tools on each major platform to install Ruby:
 
 * On Linux/UNIX, you can use the package management system of your
-  distribution or third-party tools (rbenv and RVM).
-* On OS X machines, you can use third-party tools (rbenv and RVM).
-* On Windows machines, you can use RubyInstaller.
+  distribution or third-party tools ([rbenv][rbenv] and [RVM][rvm]).
+* On OS X machines, you can use third-party tools ([rbenv][rbenv] and [RVM][rvm]).
+* On Windows machines, you can use [RubyInstaller][rubyinstaller].
 
 See the [Installation][installation] page for details on using
 package management systems or third-party tools.
@@ -82,3 +82,6 @@ Please try to use a mirror that is near you.
 [releases]: /en/downloads/releases/
 [branches]: /en/downloads/branches/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -14,9 +14,9 @@ Por favor asegúrate de leer la [licencia de Ruby][license].
 Tenemos herramientas para instalar Ruby para las plataformas más importantes.
 
 * En Linux/Unix, puedes utilizar el sistema de gestión de paquetes de tu
-  distribución o herramientas de terceros (rbenv y RVM).
-* En computadoras con sistema operativo OS X, puedes utilizar herramientas de terceros (rbenv y RVM).
-* En computadoras con sistema operativo Windows, puedes utilizar RubyInstaller.
+  distribución o herramientas de terceros ([rbenv][rbenv] y [RVM][rvm]).
+* En computadoras con sistema operativo OS X, puedes utilizar herramientas de terceros ([rbenv][rbenv] y [RVM][rvm]).
+* En computadoras con sistema operativo Windows, puedes utilizar [RubyInstaller][rubyinstaller].
 
 Consulta la página de [Instalación][installation] para obtener detalles de como usar
 sistemas de gestión de paquetes de tu distribución o herramientas de terceros.
@@ -64,3 +64,6 @@ Intenta usar el mirror site que te quede más cerca.
 [license]: {{ site.license.url }}
 [installation]: /es/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -15,9 +15,9 @@ Pour installer Ruby, les principales plateformes proposent un ensemble
 d'outils spécifiques :
 
 * Sur Linux/UNIX, vous pouvez utiliser le système de gestion des
-  paquets de votre distribution ou des outils tiers (rbenv et RVM).
-* Sur les machines OS X, vous pouvez utiliser des outils tiers (rbenv et RVM).
-* Sur les machines Windows, vous pouvez utiliser RubyInstaller.
+  paquets de votre distribution ou des outils tiers ([rbenv][rbenv] et [RVM][rvm]).
+* Sur les machines OS X, vous pouvez utiliser des outils tiers ([rbenv][rbenv] et [RVM][rvm]).
+* Sur les machines Windows, vous pouvez utiliser [RubyInstaller][rubyinstaller].
 
 Voir la page d'[Installation][installation] pour les détails sur l'usage des
 systèmes de gestion de paquets ou outils tiers.
@@ -68,3 +68,6 @@ Utilisez s'il-vous-plaît un miroir proche de vous.
 [license]: {{ site.license.url }}
 [installation]: /fr/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/id/downloads/index.md
+++ b/id/downloads/index.md
@@ -14,9 +14,9 @@ Pastikan Anda membaca [Lisensi Ruby][license] terlebih dahulu.
 Kami memiliki beberapa kakas bantu untuk memasang Ruby pada perangkat berikut:
 
 * Di Linux/UNIX, Anda dapat menggunakan *package management system* dari
-  distribusi Linux/UNIX Anda atau kakas pihak ketiga (rbenv dan RVM).
-* Di OS X, Anda dapat menggunakan kakas pihak ketiga (rbenv dan RVM).
-* Di Windows, Anda dapat menggunakan RubyInstaller.
+  distribusi Linux/UNIX Anda atau kakas pihak ketiga ([rbenv][rbenv] dan [RVM][rvm]).
+* Di OS X, Anda dapat menggunakan kakas pihak ketiga ([rbenv][rbenv] dan [RVM][rvm]).
+* Di Windows, Anda dapat menggunakan [RubyInstaller][rubyinstaller].
 
 Lihat halaman [Instalasi][installation] untuk detail menggunakan
 *package management system* atau kakas bantu pihak ketiga.
@@ -69,3 +69,6 @@ Coba gunakan salah satu *mirror* yang dekat dengan Anda.
 [license]: {{ site.license.url }}
 [installation]: /id/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -16,9 +16,9 @@ Per installare Ruby sulla maggiori piattaforme abbiamo a disposizione
 diversi tool:
 
 * Su Linux/UNIX puoi usare il gestore di pacchetti della tua
-  distribuzione o i tool di terze parti (rbenv e RVM).
-* Su OS X puoi usare i tool di terze parti (rbenv e RVM).
-* Su Windows puoi usare RubyInstaller.
+  distribuzione o i tool di terze parti ([rbenv][rbenv] e [RVM][rvm]).
+* Su OS X puoi usare i tool di terze parti ([rbenv][rbenv] e [RVM][rvm]).
+* Su Windows puoi usare [RubyInstaller][rubyinstaller].
 
 Guarda la pagina [Installation][installation] per i dettagli su
 come utilizzare i gestori di pacchetti o i tool di terze parti.

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -13,9 +13,9 @@ lang: ja
 
 メジャーなプラットフォームでは Ruby をインストールする方法はいくつかあります。
 
-* Linux/UNIX マシンでは、そのシステムのパッケージ管理ツールや、rbenv、RVMなどのサードパーティツールが使えます。
-* OS Xマシンでは、rbenv、RVMなどのサードパーティのパッケージ管理ツールが使えます。
-* Windowsマシンでは、RubyInstallerといったツールが使えます。
+* Linux/UNIX マシンでは、そのシステムのパッケージ管理ツールや、[rbenv][rbenv]、[RVM][rvm]などのサードパーティツールが使えます。
+* OS Xマシンでは、[rbenv][rbenv]、[RVM][rvm]などのサードパーティのパッケージ管理ツールが使えます。
+* Windowsマシンでは、[RubyInstaller][rubyinstaller]といったツールが使えます。
 
 各パッケージマネージャ及びサードパーティーツールの詳細は、[インストールガイド][installation] ページを参照して下さい。
 
@@ -75,3 +75,5 @@ Windows向けのバイナリが有志により配布されています。
 [active-script-ruby]: http://www.artonx.org/data/asr/
 [rubyinstaller]: https://rubyinstaller.org/
 [railsinstaller]: http://railsinstaller.org/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -14,9 +14,9 @@ lang: ko
 각 주요 플랫폼에서 루비를 설치할 수 있는 몇 가지 도구들이 있습니다.
 
 * Linux/UNIX에서는 시스템에 포함된 패키지 관리 시스템이나
-  서드파티 도구(rbenv나 RVM)를 사용할 수 있습니다.
-* OS X에서는 서드파티 도구(rbenv나 RVM)를 사용할 수 있습니다.
-* Windows에서는 RubyInstaller를 사용할 수 있습니다.
+  서드파티 도구([rbenv][rbenv]나 [RVM][rvm])를 사용할 수 있습니다.
+* OS X에서는 서드파티 도구([rbenv][rbenv]나 [RVM][rvm])를 사용할 수 있습니다.
+* Windows에서는 [RubyInstaller][rubyinstaller]를 사용할 수 있습니다.
 
 패키지 관리 시스템이나 서드파티 도구에 대한 좀 더 자세한
 설명은 [설치][installation] 페이지를 보세요.
@@ -68,3 +68,6 @@ lang: ko
 [license]: {{ site.license.url }}
 [installation]: /ko/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -15,9 +15,9 @@ Mamy dostępnych wiele narzędzi dla każdej znaczącej platformy by zainstalowa
 Rubiego:
 
 * dla maszyn z systemem Linux/UNIX możesz użyć systemowego menedżera pakietów
-  lub narzędzi osób trzecich (rbenv lub RVM),
-* dla maszyn z systemem OS X możesz użyć narzędzi osób trzecich (rbenv lub RVM),
-* dla maszyn z systemem Windows możesz użyć narzędzia RubyInstaller.
+  lub narzędzi osób trzecich ([rbenv][rbenv] lub [RVM][RVM]),
+* dla maszyn z systemem OS X możesz użyć narzędzi osób trzecich ([rbenv][rbenv] lub [RVM][rvm]),
+* dla maszyn z systemem Windows możesz użyć narzędzia [RubyInstaller][rubyinstaller].
 
 Zobacz stronę [Instalacja][installation] po więcej szczegółów dotyczących
 systemów zarządzania pakietami lub narzędzi osób trzecich.
@@ -67,3 +67,6 @@ Spróbuj użyć jakiegoś blisko ciebie.
 [license]: {{ site.license.url }}
 [installation]: /pl/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -14,9 +14,9 @@ Por favor certifique-se de ter lido a [Licença do Ruby][license].
 Existem diversas ferramentas para instalar o Ruby em cada grande plataforma:
 
 * No Linux/UNIX, você pode usar o sistema de gerenciamento de pacotes da
-  sua distribuição ou ferramentas de terceiros (rbenv e RVM).
-* Em máquinas com OS X, você pode usar ferramentas de terceiros (rbenv e RVM).
-* Em máquinas com Windows, você pode usar o RubyInstaller ou o pik.
+  sua distribuição ou ferramentas de terceiros ([rbenv][rbenv] e [RVM][rvm]).
+* Em máquinas com OS X, você pode usar ferramentas de terceirol ([rbenv][rbenv] e [RVM][rvm]).
+* Em máquinas com Windows, você pode usar o [RubyInstaller][rubyinstaller] ou o pik.
 
 Consulte a página [Instalação][installation] para mais detalhes sobre
 como usar sistemas de gerenciamento de pacotes ou ferramentas de terceiros.
@@ -71,3 +71,6 @@ usar um _mirror_ que está próximo de você.
 [license]: {{ site.license.url }}
 [installation]: /pt/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -14,9 +14,9 @@ lang: ru
 У нас имеются инструменты для всех основных платформ для установки Ruby:
 
 * На Linux/UNIX, вы можете использовать систему управления пакетами вашей
-  операционной системы или сторонние инструменты (rbenv и RVM).
-* На OS X вы можете использовать сторонние инструменты (rbenv и RVM).
-* На Windows вы можете использовать RubyInstaller.
+  операционной системы или сторонние инструменты ([rbenv][rbenv] и [RVM][rvm]).
+* На OS X вы можете использовать сторонние инструменты ([rbenv][rbenv] и [RVM][rvm]).
+* На Windows вы можете использовать [RubyInstaller][rubyinstaller].
 
 Смотрите на странице [Установка][installation] подробности об использовании
 систем управления пакетами или сторонних инструментов.
@@ -71,3 +71,6 @@ lang: ru
 [license]: {{ site.license.url }}
 [installation]: /ru/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -15,9 +15,9 @@ Xin tham khảo [giấy phép][license] trước khi dùng.
 Chúng ta có một vài công cụ trên các nền tảng chính để cài đặt Ruby:
 
 * Trên Linux/UNIX bạn có thể dùng hệ thống quản lý gói của bản
-  phân phối hoặc các công cụ của bên thứ ba (rbenv và RVM).
-* Trên OSX bạn có thể dùng các công cụ của bên thứ ba (rbenv và RVM)
-* Trên Windows bạn có thể dùng RubyInstaller.
+  phân phối hoặc các công cụ của bên thứ ba ([rbenv][rbenv] và [RVM][rvm]).
+* Trên OSX bạn có thể dùng các công cụ của bên thứ ba ([rbenv][rbenv] và [RVM][rvm])
+* Trên Windows bạn có thể dùng [RubyInstaller][rubyinstaller].
 
 Xem trang [Cài đặt][installation] để biết thêm chi tiết về
 hệ thống quản lý gói hoặc các công cụ của bên thứ ba.
@@ -70,3 +70,6 @@ Xin hãy sử dụng mirror gần bạn nhất.
 [license]: {{ site.license.url }}
 [installation]: /vi/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -12,9 +12,9 @@ lang: zh_cn
 
 每个流行的平台都有多种工具可用于安装 Ruby：
 
-* Linux/UNIX 平台，可以使用第三方工具（如 rbenv 或 RVM）或使用系统中的包管理系统。
-* OS X 平台，可以使用第三方工具（如 rbenv 或 RVM）。
-* Windows 平台，可以使用 RubyInstaller。
+* Linux/UNIX 平台，可以使用第三方工具（如 [rbenv][rbenv] 或 [RVM][rvm]）或使用系统中的包管理系统。
+* OS X 平台，可以使用第三方工具（如 [rbenv][rbenv] 或 [RVM][rvm]）。
+* Windows 平台，可以使用 [RubyInstaller][rubyinstaller]。
 
 使用包管理系统或第三方工具的详细说明，参见[安装页面][installation]。
 
@@ -55,3 +55,6 @@ Ruby 源代码可从世界各地的[镜像站][mirrors]获得。请尝试离您�
 [license]: {{ site.license.url }}
 [installation]: /zh_cn/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -12,9 +12,9 @@ lang: zh_tw
 
 每個主要的平台都有多種工具可安裝 Ruby：
 
-* Linux/UNIX 平台，可以使用第三方工具（如 rbenv 或 RVM）或使用系統套件管理工具；
-* OS X 平台，可以使用第三方工具（如 rbenv 或 RVM）；
-* Windows 平台，可以使用 RubyInstaller。
+* Linux/UNIX 平台，可以使用第三方工具（如 [rbenv][rbenv] 或 [RVM][rvm]）或使用系統套件管理工具；
+* OS X 平台，可以使用第三方工具（如 [rbenv][rbenv] 或 [RVM][rvm]）；
+* Windows 平台，可以使用 [RubyInstaller][rubyinstaller]。
 
 進一步了解請參考[安裝][installation]頁面上關於套件管理工具與第三方工具的內容。
 
@@ -58,3 +58,6 @@ Ruby 原始碼可從世界各地的[鏡像站][mirrors]獲得。請嘗試離您�
 [license]: {{ site.license.url }}
 [installation]: /zh_tw/documentation/installation/
 [mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/


### PR DESCRIPTION
This PR fixes #1587 by adding links to the rvm, rbenv and rubyinstaller projects on the download pages where referenced.