### PR TITLE
Translate Ruby Prize 2017 (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2017-07-21-ruby-prize-2017.md
+++ b/zh_tw/news/_posts/2017-07-21-ruby-prize-2017.md
@@ -1,0 +1,25 @@
+---
+layout: news_post
+title: "Ruby Prize 2017 開始提名"
+author: "Ruby Association"
+translator: "Vincent Lin"
+date: 2017-07-21 00:00:00 +0000
+lang: zh_tw
+---
+
+我們十分高興的宣布今年 Ruby Prize 將會舉行！
+
+Ruby Prize 係為了認可具有傑出努力與成就的社群成員。獎項將會由執行委員會所頒發，執行委員會由 Ruby 協會、一般社團法人日本 Ruby no Kai 以及松江市三方組成。
+
+Ruby Prize 得獎者以及最終候選人（1 至 2 人）會在 RubyWorld Conference 2017 大會上頒獎，大會將在 11 月 1 至 2 日於日本松江市舉辦。
+
+除此之外，Ruby Prize 得獎者將會頒發 100 萬日圓！
+
+提名者會由以下成員進行遴選：
+
+* 執行委員會中“過往受獎者”的推薦
+* 大眾的推薦（你）
+
+請參考下文來了解更多細節。
+
+[Nominations now being accepted for Ruby Prize 2017](http://www.ruby.or.jp/rubyprize2017/about_en.html)


### PR DESCRIPTION
zh_tw Translation for Ruby Prize 2017

- zh_tw/news/_posts/2017-07-21-ruby-prize-2017.md

Thank you.
