### PR TITLE
Add Rubyist Magazine 0056 published

### DIFF
--- a/ja/news/_posts/2017-08-27-rubyist-magazine-0056-published.md
+++ b/ja/news/_posts/2017-08-27-rubyist-magazine-0056-published.md
@@ -1,0 +1,29 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0056号 発行"
+author: "miyohide"
+date: 2017-08-27 15:55:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0056号][3]がリリースされました([\[ruby-list:50565\]][4])。
+
+今号は、
+
+* [巻頭言](http://magazine.rubyist.net/?0056-ForeWord)
+* [HanamiはRubyの救世主(メシア)となるか、愚かな星と散るのか](http://magazine.rubyist.net/?0056-hanami)
+* [なるほど Erlang プロセス](http://magazine.rubyist.net/?0056-naruhodo_erlang_process)
+* [RegionalRubyKaigi レポート (61) 松江 Ruby 会議 08](http://magazine.rubyist.net/?0056-MatsueRubyKaigi08Report)
+* [RegionalRubyKaigi レポート (62) 名古屋Ruby会議03](http://magazine.rubyist.net/?0056-NagoyaRubyKaigi03Report)
+* [RegionalRubyKaigi レポート (63) 関西 Ruby 会議 2017](http://magazine.rubyist.net/?0056-KansaiRubyKaigi2017Report)
+* [るびまアクセスランキング Vol.56](http://magazine.rubyist.net/?0056-RubyistMagazineRanking)
+
+という構成となっています。
+
+お楽しみください。
+
+[1]: http://ruby-no-kai.org
+[2]: http://magazine.rubyist.net/
+[3]: http://magazine.rubyist.net/?0056
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50565
+


### PR DESCRIPTION
RubiMa Editors have released Rubyist Magazine 0056 (in japanese).
Please add this post to the news page.
http://magazine.rubyist.net/?0056