### PR TITLE
Add 2.4.2 to Releases page

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,5 +1,8 @@
 # 2.4 series
 
+- version: 2.4.2
+  date: 2017-09-14
+  post: /en/news/2017/09/14/ruby-2-4-2-released/
 - version: 2.4.1
   date: 2017-03-22
   post: /en/news/2017/03/22/ruby-2-4-1-released/


### PR DESCRIPTION
It looks like this is breaking the official Docker builds for Ruby (https://github.com/docker-library/ruby/pull/152#issuecomment-329588704).