### PR TITLE
Add 2.3.5 and 2.2.8 to releases page

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -24,6 +24,9 @@
 
 # 2.3 series
 
+- version: 2.3.5
+  date: 2017-09-14
+  post: /en/news/2017/09/14/ruby-2-3-5-released/
 - version: 2.3.4
   date: 2017-03-30
   post: /en/news/2017/03/30/ruby-2-3-4-released/
@@ -48,6 +51,9 @@
 
 # 2.2 series
 
+- version: 2.2.8
+  date: 2017-09-14
+  post: /en/news/2017/09/14/ruby-2-2-8-released/
 - version: 2.2.7
   date: 2017-03-28
   post: /en/news/2017/03/28/ruby-2-2-7-released/


### PR DESCRIPTION
This is a follow-up of #1637.