### PR TITLE
Translate CVE-2017-14064: Heap exposure vulnerability in generating JSON news (id)

### DIFF
--- a/id/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
+++ b/id/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "CVE-2017-14064: Kerentanan tereksposnya heap saat menghasilkan JSON"
+author: "usa"
+translator: "meisyal"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan tereksposnya *heap* pada JSON yang di-*bundle* oleh Ruby.
+Kerentanan ini telah ditetapkan sebagai [CVE-2017-14064](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14064).
+
+## Detail
+
+*Method* `generate` dari modul JSON opsional menerima sebuah objek dari kelas `JSON::Ext::Generator::State`.
+Jika sebuah objek yang berbahaya dilewati, hasilnya mungkin mengandung isi dari *heap*.
+
+Semua pengguna yang sedang menggunakan rilis yang terkena imbas ini sebaiknya segera memperbarui atau menggunakan solusi yang ada.
+
+## Versi Terimbas
+
+* rangkaian Ruby 2.2: 2.2.7 dan sebelumnya
+* rangkaian Ruby 2.3: 2.3.4 dan sebelumnya
+* rangkaian Ruby 2.4: 2.4.1 dan sebelumnya
+* sebelum revisi *trunk* 58323
+
+## Solusi
+
+Pustaka JSON juga didistribusikan dalam sebuah *gem*.
+Jika Anda tidak dapat memperbarui Ruby itu sendiri, pasang *gem* JSON lebih baru dari versi 2.0.4.
+
+## Rujukan
+
+Terima kasih kepada [ahmadsherif](https://hackerone.com/ahmadsherif) yang telah melaporkan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2017-09-14 12:00:00 (UTC)


### PR DESCRIPTION
Another news translation, "CVE-2017-14064: Heap exposure vulnerability in generating JSON". Please, review the translation @gozali. Thank you.