### PR TITLE
Translate CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 decode news (id)

### DIFF
--- a/id/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
+++ b/id/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
@@ -1,0 +1,40 @@
+---
+layout: news_post
+title: "CVE-2017-14033: Kerentanan buffer underrun pada OpenSSL ASN1 decode"
+author: "usa"
+translator: "meisyal"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan *buffer underrun* pada OpenSSL yang di-*bundle* oleh Ruby.
+Kerentanan ini telah ditetapkan sebagai [CVE-2017-14033](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14033).
+
+## Detail
+
+Jika sebuah *malicious string* melewati *method* `decode` dari `OpenSSL:ASN1`, *buffer underrun* bisa jadi penyebab dan penerjemah Ruby *crash*.
+
+Semua pengguna yang sedang menggunakan rilis yang terkena imbas ini sebaiknya segera memperbarui atau menggunakan solusi yang ada.
+
+## Versi Terimbas
+
+* rangkaian Ruby 2.2: 2.2.7 dan sebelumnya
+* rangkaian Ruby 2.3: 2.3.4 dan sebelumnya
+* rangkaian Ruby 2.4: 2.4.1 dan sebelumnya
+* sebelum revisi *trunk* 56946
+
+## Solusi
+
+Pustaka OpenSSL juga didistribusikan dalam sebuah *gem*.
+Jika Anda tidak dapat memperbarui Ruby itu sendiri, pasang *gem* lebih baru dari versi 2.0.0.
+Solusi ini hanya berlaku untuk rangkaian Ruby 2.4.
+Saat menggunakan rangkaian Ruby 2.2 dan 2.3, *gem* tidak dapat menimpa versi OpenSSL yang telah ter-*bundle*.
+
+## Rujukan
+
+Terima kasih kepada [asac](https://hackerone.com/asac) yang telah melaporkan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2017-09-14 12:00:00 (UTC)


### PR DESCRIPTION
As titled, please help me to review this translation @gozali!

Thanks.