### PR TITLE
Translate CVE-2017-0898 post (id)

### DIFF
--- a/id/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
+++ b/id/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
@@ -1,0 +1,34 @@
+---
+layout: news_post
+title: "CVE-2017-0898: Kerentanan buffer underrun pada Kernel.sprintf"
+author: "usa"
+translator: "meisyal"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan *buffer underrun* pada *method* `sprintf` dari modul `Kernel`.
+Kerentanan ini telah ditetapkan sebagai penanda [CVE-2017-0898](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0898).
+
+## Detail
+
+Jika sebuah *malicious format string* yang berisi sebuah *precious specifier* (`*`) lewat dan sebuah nilai minus yang sangat besar juga lewat *specifier*, *buffer underrun* bisa jadi terjadi.
+Dalam situasi seperti ini, hasilnya bisa berisi *heap*, atau penerjemah Ruby *crash*.
+
+Semua pengguna yang sedang menggunakan rilis yang terkena imbas sebaiknya memperbarui segera.
+
+## Versi Terimbas
+
+* rangkaian Ruby 2.2: 2.2.7 dan sebelumnya
+* rangkaian Ruby 2.3: 2.3.4 dan sebelumnya
+* rangkaian Ruby 2.4: 2.4.1 dan sebelumnya
+* sebelum revisi *trunk* 58453
+
+## Rujukan
+
+Terima kasih kepada [aerodudrizzt](https://hackerone.com/aerodudrizzt) yang telah melaporkan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2017-09-14 12:00:00 (UTC)


### PR DESCRIPTION
Just translated "CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf" post into Bahasa Indonesia. This PR need to review @gozali. Thanks.