### PR TITLE
Translate security fixes to de

### DIFF
--- a/de/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
+++ b/de/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Mehrere Sicherheitslücken in RubyGems"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-08-29 12:00:00 +0000
+tags: security
+lang: de
+---
+
+Es gibt mehrere Sicherheitslücken in dem in Ruby enthaltenen RubyGems,
+wie [auf dem offiziellen RubyGems-Blog berichtet wird](http://blog.rubygems.org/2017/08/27/2.6.13-released.html).
+
+## Details
+
+Die folgenden Sicherheitslücken wurden entdeckt.
+
+* Eine Sicherheitslücke, die die DNS-Auflösung betrifft (_DNS request hijacking_). (CVE-2017-0902)
+* Eine Sicherheitslücke bei der Auflösung von ANSI-Escape-Sequenzen. (CVE-2017-0899)
+* Eine DoS-Schwachstelle im query-Befehl. (CVE-2017-0900)
+* Eine Schwachstelle im Gem-Installer erlaubte einem böswilligen Gem beliebige Dateien zu überschreiben.  (CVE-2017-0901)
+
+Alle Ruby-Nutzer sind aufgerufen, so schnell wie möglich zu
+aktualisieren oder einen der folgenden Workarounds anzuwenden.
+
+## Betroffene Versionen
+
+* 2.2er Serie: 2.2.7 und früher
+* 2.3er Serie: 2.3.4 und früher
+* 2.4er Serie: 2.4.1 und früher
+* Trunk vor Revision 59672
+
+## Workarounds
+
+Wenn Sie Ruby selbst nicht aktualisieren können, aktualisieren Sie
+RubyGems auf die aktuelle Version. Die Sicherheitslücken wurden in
+RubyGems 2.6.13 und später behoben.
+
+```
+gem update --system
+```
+
+Wenn Sie RubyGems nicht aktualisieren können, können Sie die folgenden
+Patches als Workaround anwenden.
+
+* [für Ruby 2.2.7](https://bugs.ruby-lang.org/attachments/download/6690/rubygems-2613-ruby22.patch)
+* [für Ruby 2.3.4](https://bugs.ruby-lang.org/attachments/download/6691/rubygems-2613-ruby23.patch)
+* f+r Ruby 2.4.1: benötigt 2 Patches. In folgender Reihenfolge nacheinander anwenden:
+  1. [RubyGems 2.6.11 zu 2.6.12](https://bugs.ruby-lang.org/attachments/download/6692/rubygems-2612-ruby24.patch)
+  2. [RubyGems 2.6.12 zu 2.6.13](https://bugs.ruby-lang.org/attachments/download/6693/rubygems-2613-ruby24.patch)
+
+Trunk-Nutzer aktualisieren auf die neueste Revision.
+
+## Danksagung
+
+Diese Meldung basiert auf [dem offiziellen RubyGems-Blog](http://blog.rubygems.org/2017/08/27/2.6.13-released.html).
+
+## Historie
+
+* Erstmals veröffentlicht am 2017-08-29 12:00:00 UTC
+* CVE-Nummern hinzugefügt am 2017-08-31 2:00:00 UTC
+* Hinweis zur Ruby-Aktualisierung am 2017-09-15 12:00:00 UTC

--- a/de/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
+++ b/de/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
@@ -45,7 +45,7 @@ Patches als Workaround anwenden.
 
 * [für Ruby 2.2.7](https://bugs.ruby-lang.org/attachments/download/6690/rubygems-2613-ruby22.patch)
 * [für Ruby 2.3.4](https://bugs.ruby-lang.org/attachments/download/6691/rubygems-2613-ruby23.patch)
-* f+r Ruby 2.4.1: benötigt 2 Patches. In folgender Reihenfolge nacheinander anwenden:
+* für Ruby 2.4.1: benötigt 2 Patches. In folgender Reihenfolge nacheinander anwenden:
   1. [RubyGems 2.6.11 zu 2.6.12](https://bugs.ruby-lang.org/attachments/download/6692/rubygems-2612-ruby24.patch)
   2. [RubyGems 2.6.12 zu 2.6.13](https://bugs.ruby-lang.org/attachments/download/6693/rubygems-2613-ruby24.patch)
 

--- a/de/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
+++ b/de/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
@@ -34,7 +34,7 @@ oder umgehend einen der folgenden Workarounds anwenden.
 ## Workaround
 
 Die JSON-Bibliothek wird auch als Gem verteilt. Wenn Sie Ruby selbst
-nicht aktualisieren können, installieren Sie stattdessen den JSON-Gem
+nicht aktualisieren können, installieren Sie stattdessen das JSON-Gem
 in einer Version neuer als 2.0.4.
 
 ## Danksagung

--- a/de/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
+++ b/de/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: de
+---
+
+Es gibt ein Sicherheitsproblem mit dem in Ruby enthaltenen JSON-Modul,
+bei dem Teile des Heaps öffentlich werden können. Dieser Schwachstelle
+wurde die CVE-Nummer
+[CVE-2017-14064](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14064)
+zugewiesen.
+
+## Details
+
+Die Methode `generate` des Moduls `JSON` akzeptiert optional eine
+Instanz der Klasse `JSON::Ext::Generator::State`. Wenn eine böswillige
+Instanz übergeben wird, kann das Ergebnis Inhalte aus dem Heap
+enthalten.
+
+Alle Nutzer einer betroffenen Version sollten entweder aktualisieren
+oder umgehend einen der folgenden Workarounds anwenden.
+
+## Betroffene Versionen
+
+* 2.2er Serie: 2.2.7 und früher
+* 2.3er Serie: 2.3.4 und früher
+* 2.4er Serie: 2.4.1 und früher
+* Trunk vor Revision 58323
+
+## Workaround
+
+Die JSON-Bibliothek wird auch als Gem verteilt. Wenn Sie Ruby selbst
+nicht aktualisieren können, installieren Sie stattdessen den JSON-Gem
+in einer Version neuer als 2.0.4.
+
+## Danksagung
+
+Dank an [ahmadsherif](https://hackerone.com/ahmadsherif) für die
+Meldung des Problems.
+
+## Historie
+
+* Erstmals veröffentlicht am 2017-09-14 12:00:00 (UTC)

--- a/de/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
+++ b/de/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
@@ -24,18 +24,18 @@ oder umgehend einen der folgenden Workarounds anwenden.
 
 ## Betroffene Versionen
 
-* 2.2er Serie: 2.2.7 und früher
-* 2.3er Serie: 2.3.4 und früher
-* 2.4er Serie: 2.4.1 und früher
+* 2.2er-Serie: 2.2.7 und früher
+* 2.3er-Serie: 2.3.4 und früher
+* 2.4er-Serie: 2.4.1 und früher
 * Trunk vor Revision 56946
 
 ## Workaround
 
 Die OpenSSL-Bibliothek wird auch als Gem verteilt. Wenn Sie Ruby
-selbst nicht aktualisieren können, installieren Sie den OpenSSL-Gem in
+selbst nicht aktualisieren können, installieren Sie das OpenSSL-Gem in
 einer Version neuer als 2.0.0. Dieser Workaround funktioniert
-allerdings nur mit der 2.4er Serie von Ruby, denn bei der 2.2er und
-2.3er Serie hat der Gem keinen Vorrang vor der mitgelieferten Version
+allerdings nur mit der 2.4er-Serie von Ruby, denn bei der 2.2er- und
+2.3er-Serie hat das Gem keinen Vorrang vor der mitgelieferten Version
 von OpenSSL.
 
 ## Danksagung

--- a/de/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
+++ b/de/news/_posts/2017-09-14-openssl-asn1-buffer-underrun-cve-2017-14033.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: de
+---
+
+Es gibt ein Sicherheitsproblem mit einem Pufferunterlauf in der in
+Ruby enthaltenen OpenSSL-Bibliothek, dem die CVE-Nummer
+[CVE-2017-14033](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14033)
+zugewiesen worden ist.
+
+## Details
+
+Wenn ein böswilliger String an die Methode `decode` von
+`OpenSSL::ASN1` übergeben wird, kann ein Pufferunterlauf verursacht
+werden, der zum Absturz des Ruby-Interpreters führen kann.
+
+Alle Nutzer einer betroffenen Version sollten entweder aktualisieren
+oder umgehend einen der folgenden Workarounds anwenden.
+
+## Betroffene Versionen
+
+* 2.2er Serie: 2.2.7 und früher
+* 2.3er Serie: 2.3.4 und früher
+* 2.4er Serie: 2.4.1 und früher
+* Trunk vor Revision 56946
+
+## Workaround
+
+Die OpenSSL-Bibliothek wird auch als Gem verteilt. Wenn Sie Ruby
+selbst nicht aktualisieren können, installieren Sie den OpenSSL-Gem in
+einer Version neuer als 2.0.0. Dieser Workaround funktioniert
+allerdings nur mit der 2.4er Serie von Ruby, denn bei der 2.2er und
+2.3er Serie hat der Gem keinen Vorrang vor der mitgelieferten Version
+von OpenSSL.
+
+## Danksagung
+
+Dank geht an [asac](https://hackerone.com/asac) für die Meldung des Problems.
+
+## Historie
+
+* Erstmals veröffentlicht am 2017-09-14 12:00:00 (UTC)

--- a/de/news/_posts/2017-09-14-ruby-2-2-8-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-2-8-released.md
@@ -12,7 +12,7 @@ Sicherheitsprobleme behoben worden; siehe die folgenden Links für
 weitere Informationen.
 
 * [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authentisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
 * [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
 * [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
 * [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)

--- a/de/news/_posts/2017-09-14-ruby-2-2-8-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-2-8-released.md
@@ -1,0 +1,60 @@
+---
+layout: news_post
+title: "Ruby 2.2.8 veröffentlicht"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+lang: de
+---
+
+Ruby 2.2.8 ist veröffentlicht worden. In dieser Version sind einige
+Sicherheitsprobleme behoben worden; siehe die folgenden Links für
+weitere Informationen.
+
+* [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Das enthaltene libyaml wurde auf Version 0.1.7 aktualisiert
+
+Ruby 2.2 befindet sich noch bis Ende März 2018 in der Phase der
+Sicherheitsunterstützung. Danach wird die Unterstützung für Ruby 2.2
+eingestellt. Wir empfehlen Ihnen daher, mit der Planung der Migration
+auf eine neuere Ruby-Version wie 2.4 oder 2.3 zu beginnen.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2)
+
+      SIZE:   13374522 bytes
+      SHA1:   d851324bf783221108ce79343fabbcd559b9e60b
+      SHA256: b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e
+      SHA512: aa1c65f76a51a57d9059a38a13a823112b53850a9e7d6f72c3f3e38d381412014521049f7065c1b00877501b3b554235135d0f308045c2a9da133c766f5b9e46
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz)
+
+      SIZE:   16681654 bytes
+      SHA1:   15a6fca1bfe0488b24a204708a287904028aa367
+      SHA256: 8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a
+      SHA512: b9d355232c1ca3e17b5d4dcb70f0720da75b82787e45eb4ede281290bf42643665385e55428495eb55c17f744395130b4d64ef78ca66c5a5ecb9f4c3b732fdea
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz)
+
+      SIZE:   10520648 bytes
+      SHA1:   3a25914aafedc81952899298a18f9c3a4881d2d1
+      SHA256: 37eafc15037396c26870f6a6c5bcd0658d14b46cd5e191a3b56d89dd22d561b0
+      SHA512: e21004bee537f0c706f4ac9526507b414ddb6a8d721e8fad8d7fe88992a4f048eb5eb79f8d8b8af2a8b331dcfa74b560490218a1acb3532c2cdb4fb4909da3c9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip)
+
+      SIZE:   18521461 bytes
+      SHA1:   3b0142bad47e29f429903f6c4ca84540764b5e93
+      SHA256: 58bf98b62d21d6cc622e6ef5c7d024db0458c6860199ab4c1bf68cdc4b36fa9d
+      SHA512: 08cadfa72713f9e3348093c96af4c53f06f681bc29ada2d80f1c55faca6a59a3b2913aa2443bf645fea6f3840b32ce8ce894b358f972b1a295ee0860b656eb02
+
+## Veröffentlichungskommentar
+
+Dank an alle, die bei der Veröffentlichung dieser Version mitgeholfen
+haben. Besonderer Dank geht an die Leute, die Sicherheitslücken
+gemeldet haben.

--- a/de/news/_posts/2017-09-14-ruby-2-3-5-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-3-5-released.md
@@ -11,10 +11,10 @@ Ruby 2.3.5 ist veröffentlicht worden.
 
 Diese Version enthält etwa 70 Fehlerkorrekturen seit der
 Vorgängerversion sowie einige Sicherheitsfixes. Siehe die
-nachfolgenden Links für weitre Informationen.
+nachfolgenden Links für weitere Informationen.
 
 * [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authentisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
 * [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
 * [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
 * [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)

--- a/de/news/_posts/2017-09-14-ruby-2-3-5-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-3-5-released.md
@@ -1,0 +1,72 @@
+---
+layout: news_post
+title: "Ruby 2.3.5 veröffentlicht"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+lang: de
+---
+
+Ruby 2.3.5 ist veröffentlicht worden.
+
+Diese Version enthält etwa 70 Fehlerkorrekturen seit der
+Vorgängerversion sowie einige Sicherheitsfixes. Siehe die
+nachfolgenden Links für weitre Informationen.
+
+* [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Das enthaltene libyaml wurde auf Version 0.1.7 aktualisiert
+
+Siehe das [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_3_5/ChangeLog) für Details.
+
+## Bekanntes Problem
+
+_(Dieser Abschnitt ist am 15. September 2017 hinzugefügt worden)_
+
+In Ruby 2.3.5 ist eine Inkompatbilität gefunden worden. Diese Version
+kann weder gegen libgmp noch gegen jemalloc gelinkt werden. Wir werden
+das Problem mit der nächsten Version beheben. Bis dahin können Sie den
+Patch unter folgendem Link nutzen:
+
+* [Ruby 2.4.2 und 2.3.5 können weder gegen libgmp noch gegen jemalloc gelinkt werden](https://bugs.ruby-lang.org/issues/13899)
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2)
+
+      SIZE:   14439326 bytes
+      SHA1:   48302800c78ef9bbfc293ffcc4b6e2c728705bca
+      SHA256: f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b
+      SHA512: 3ecc7c0ac10672166e1a58cfcd5ae45dfc637c22cec549a30975575cbe59ec39945d806e47661f45071962ef9404566007a982aedccb7d4241b4459cb88507df
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz)
+
+      SIZE:   17836997 bytes
+      SHA1:   3247e217d6745c27ef23bdc77b6abdb4b57a118f
+      SHA256: 5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc
+      SHA512: cd6bbba4fb5a0ab5ce7aa6f3b89d021ea742c5aa7934e24b87554d10e2a3233d416051c11aee90f3d8714d168db523a7bf56ef4dafdd256fc8595169c2db496a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz)
+
+      SIZE:   11437868 bytes
+      SHA1:   ef388992fa71cd77c5be960dd7e3bec1280c4441
+      SHA256: 7d3a7dabb190c2da06c963063342ca9a214bcd26f2158e904f0ec059b065ffda
+      SHA512: c55e3b71241f505b6bbad78b3bd40235064faae3443ca14b77b6356556caed6a0d055dc2e2cd7ebdb5290ab908e06d2b7d68f72469af5017eda4b29664b0d889
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip)
+
+      SIZE:   19887946 bytes
+      SHA1:   09c80f9021fa2bfc04ae30a1939faad03b0f5b14
+      SHA256: c9971e1ccb6e2f1ab32b1fe05416fce0b19a1cd9ba8fa095c77c4bdf2058e514
+      SHA512: 6f14d0cc48d6eaf6168316cb45e22af8d2118ba058fd888ce930f12a22cf7e849e2e185cc7c516fe980f30ee9a942accf9d9e2d4b8a2e79c97b87d4bab704495
+
+## Veröffentlichungskommentar
+
+Dank an alle Leute, die bei dieser Veröffentlichung geholfen haben.
+
+Die Unterstützung von Ruby 2.3, einschließlich dieser Veröffentlichung,
+basiert auf der „Vereinbarung über die stabile Ruby-Version“ der
+[Ruby Association](http://www.ruby.or.jp/).

--- a/de/news/_posts/2017-09-14-ruby-2-4-2-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-4-2-released.md
@@ -11,7 +11,7 @@ Wir freuen uns, die Veröffentlichung von Ruby 2.4.2 ankündigen zu
 können. Diese Version behebt einige Sicherheitsprobleme.
 
 * [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authentisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
 * [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
 * [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
 * [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
@@ -64,6 +64,6 @@ Patch unter folgendem Link nutzen:
 
 ## Veröffentlichungskommentar
 
-Viele Commiter, Entwickler und Nutzer, die Fehler gemeldet haben,
+Viele Committer, Entwickler und Nutzer, die Fehler gemeldet haben,
 halfen uns bei der Veröffentlichung dieser Version. Vielen Dank für
 ihre Beiträge.

--- a/de/news/_posts/2017-09-14-ruby-2-4-2-released.md
+++ b/de/news/_posts/2017-09-14-ruby-2-4-2-released.md
@@ -1,0 +1,69 @@
+---
+layout: news_post
+title: "Ruby 2.4.2 Released"
+author: "nagachika"
+translator: "Marvin Gülker"
+date: 2017-09-14 00:00:00 +0000
+lang: de
+---
+
+Wir freuen uns, die Veröffentlichung von Ruby 2.4.2 ankündigen zu
+können. Diese Version behebt einige Sicherheitsprobleme.
+
+* [CVE-2017-0898: Pufferunterlauf in Kernel.sprintf](/de/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick](/de/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Pufferunterlauf-Problem bei Dekodierung von OpenSSL-ASN1](/de/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Sicherheitsproblem mit dem Heap beim Erzeugen von JSON](/de/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Mehrere Sicherheitslücken in RubyGems](/de/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Das enthaltene libyaml wurde auf Version 0.1.7 aktualisiert
+
+Daneben gab es viele Bugfixes. Siehe die
+[Commit-Logs](https://github.com/ruby/ruby/compare/v2_4_1...v2_4_2)
+für weitere Informationen.
+
+## Bekanntes Problem
+
+_(Dieser Abschnitt ist am 15. September 2017 hinzugefügt worden)_
+
+In Ruby 2.4.2 ist eine Inkompatbilität gefunden worden. Diese Version
+kann weder gegen libgmp noch gegen jemalloc gelinkt werden. Wir werden
+das Problem mit der nächsten Version beheben. Bis dahin können Sie den
+Patch unter folgendem Link nutzen:
+
+* [Ruby 2.4.2 und 2.3.5 können weder gegen libgmp noch gegen jemalloc gelinkt werden](https://bugs.ruby-lang.org/issues/13899)
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2>
+
+      SIZE:   12607283 bytes
+      SHA1:   a8a50a9297ff656e5230bf0f945acd69cc02a097
+      SHA256: 08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc
+      SHA512: 1a5302d2558089a6b91b815fff9b75a29e690f10861de5fdd48211f3f45025a70dad7495f216e6af9c62d72e69ed316f1a52fada704bdc7e6d8c094d141ea77c
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz>
+
+      SIZE:   14187859 bytes
+      SHA1:   b096124469e31e4fc3d00d2b61b11d36992e6bbd
+      SHA256: 93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c
+      SHA512: 96c236bdcd09b2e7cf429da631a487fc00f1255443751c03c8abeb4c2ce57079ad60ef566fecc0bf2c7beb2f080e2b8c4d30f321664547b2dc7d2a62aa1075ef
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.xz>
+
+      SIZE:   10046412 bytes
+      SHA1:   8373e32c63bba2180799da091b572664aa9faf6f
+      SHA256: 748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
+      SHA512: c1d42272fb0d94b693452e703b0ea4942bf59cbd4b08ba83bf039f54be97ebc88511632413da0164970b4cf97bc302bccb88aab48edfa8fa147498e7ee741595
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.zip>
+
+      SIZE:   15645325 bytes
+      SHA1:   861b51de9db0d822ef141ad04383c76aa3cd2fff
+      SHA256: 37d7cb27d8abd4b143556260506306659930548652343076f7f8470f07818824
+      SHA512: 234765091528be1310ac315868f84ae6c505aa696672929df2f00828c1bbdc7cbcb2fc690eab4e73efde6be9104584ba7b6944853861f6d05e775b124ce8dfd5
+
+## Veröffentlichungskommentar
+
+Viele Commiter, Entwickler und Nutzer, die Fehler gemeldet haben,
+halfen uns bei der Veröffentlichung dieser Version. Vielen Dank für
+ihre Beiträge.

--- a/de/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
+++ b/de/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "CVE-2017-0898: Pufferunterlauf in Kernel.sprintf"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: de
+---
+
+Es gibt ein Sicherheitsproblem mit einem Pufferunterlauf in der
+Methode `sprintf` des `Kernel`-Moduls. Der Sicherheitslücke wurde die
+CVE-Nummer
+[CVE-2017-0898](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0898)
+zugewiesen.
+
+## Details
+
+Wenn ein böswilliger Format-String den Spezifizierer `*` enthält und
+ihm dabei ein sehr großer negativer Wert übergeben wird, kann es zu
+einem Pufferunterlauf kommen. Dies kann dazu führen, dass der
+Rückgabewert Teile des Heaps enthält oder der Ruby-Interpreter
+abstürzt.
+
+Alle Nutzer einer betroffenen Version sollten umgehend aktualisieren.
+
+## Betroffene Versionen
+
+* 2.2er Serie: 2.2.7 und früher
+* 2.3er Serie: 2.3.4 und früher
+* 2.4er Serie: 2.4.1 und früher
+* Trunk vor Revision 58453
+
+## Danksagung
+
+Dank an [aerodudrizzt](https://hackerone.com/aerodudrizzt) für die
+Meldung des Problems.
+
+## History
+
+* Erstmals veröffentlicht am 2017-09-14 12:00:00 (UTC)

--- a/de/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
+++ b/de/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick"
+author: "usa"
+translator: "Marvin Gülker"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: de
+---
+
+Es gibt eine Schwachstelle in der Basic-Authentisierung des in Ruby
+enthaltenen WEBrick, bei der durch Einschleusung von Escape-Sequenzen
+ein Sicherheitsrisiko ausgelöst werden kann _(escape sequence
+injection vulnerability)_. Der Schwachstelle wurde die CVE-Nummer
+[CVE-2017-10784](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10784)
+zugewiesen.
+
+## Details
+
+Wenn die Basic-Authentisierung von WEBrick benutzt wird, können
+Clients als Nutzernamen eine beliebige Zeichenkette übergeben. WEBrick
+gibt diesen Nutzernamen in seine Logdatei aus, was einem Angreifer
+ermöglicht, böswillige Escape-Sequenzen in die Logdatei einzuschleusen
+und dadurch möglicherweise gefährliche Steuerbefehle im
+Terminal-Emulator des Opfers auszuführen.
+
+Diese Schwachstelle ähnelt [einer bereits
+behobenen](/de/news/2010/01/10/webrick-escape-sequence-injection/),
+bei der jedoch die Basic-Authentisierung übersehen worden ist.
+
+Alle Nutzer einer betroffenen Version sollten umgehend aktualisieren.
+
+## Betroffene Versionen
+
+* 2.2er Serie: 2.2.7 und früher
+* 2.3er Serie: 2.3.4 und früher
+* 2.4er Serie: 2.4.1 und früher
+* Trunk vor Revision 58453
+
+## Danksagung
+
+Dank an Yusuke Endoh <mame@ruby-lang.org> für die Meldung des
+Problems.
+
+## Historie
+
+* Erstmals veröffentlicht am 2017-09-14 12:00:00 (UTC)

--- a/de/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
+++ b/de/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
@@ -1,6 +1,6 @@
 ---
 layout: news_post
-title: "CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authenisierung von WEBrick"
+title: "CVE-2017-10784: Sicherheitsproblem durch Einschleusung von Escape-Sequenzen in der Basic-Authentisierung von WEBrick"
 author: "usa"
 translator: "Marvin Gülker"
 date: 2017-09-14 12:00:00 +0000


### PR DESCRIPTION
This PR translates all the security fix posts to German. There were some difficulties in translating the termini technici (e.g. "JSON Heap Exposure") to German, so I thought I file this as a PR rather than merging directly.

Marvin