### PR TITLE
Translate CVE-2017-14064: Heap exposure vulnerability in generating JSON (pt)

### DIFF
--- a/pt/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
+++ b/pt/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "CVE-2017-14064: Vulnerabilidade de exposição de heap no JSON gerado"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: pt
+---
+
+Existe uma vulnerabilidade de exposição de heap no JSON empacotado pelo Ruby.
+Esta vulnerabilidade recebeu o identificador CVE [CVE-2017-14064](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14064).
+
+## Detalhes
+
+O método `generate` do módulo `JSON` aceita opcionalmente uma instância da classe `JSON::Ext::Generator::State`.
+Se uma instância maliciosa for passada, o resultado poderá incluir conteúdos do heap.
+
+Todos os usuários rodando uma versão afetada devem fazer upgrade ou usar uma das soluções alternativas imediatamente.
+
+## Versões Afetadas
+
+* Série Ruby 2.2: 2.2.7 e anteriores
+* Série Ruby 2.3: 2.3.4 e anteriores
+* Série Ruby 2.4: 2.4.1 e anteriores
+* antes da revisão do tronco 58323
+
+## Soluções Alternativas
+
+A biblioteca JSON também é distribuida como uma gem.
+Se você não puder fazer upgrade do Ruby, instale uma versão da gem JSON mais nova do que 2.0.4.
+
+## Crédito
+
+Agradecimentos a [ahmadsherif](https://hackerone.com/ahmadsherif) por reportar este problema.
+
+## Histórico
+
+* Originalmente publicado em 14/09/2017 12:00:00 (UTC)


### PR DESCRIPTION
Post translated from English to Portuguese