### PR TITLE
Link to translated security fixes details (id)

### DIFF
--- a/id/news/_posts/2017-09-14-ruby-2-2-8-released.md
+++ b/id/news/_posts/2017-09-14-ruby-2-2-8-released.md
@@ -11,11 +11,11 @@ Ruby 2.2.8 telah dirilis.
 Rilis ini mencakup beberapa perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk detail.
 
-* [CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Escape sequence injection vulnerability in the Basic authentication of WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
-* [CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 decode](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
-* [CVE-2017-14064: Heap exposure vulnerability in generating JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
-* [Multiple vulnerabilities in RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* [CVE-2017-0898: Kerentanan buffer underrun pada Kernel.sprintf](/id/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Kerentanan escape sequence injection pada Basic authentication WEBrick](/id/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Kerentanan buffer underrun pada OpenSSL ASN1 decode](/id/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Kerentanan tereksposnya heap saat menghasilkan JSON](/id/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Beberapa Kerentanan di RubyGems](/id/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
 * Memperbarui libyaml yang di-*bundle* ke versi 0.1.7
 
 Ruby 2.2 saat ini dalam fase perawatan keamanan, hingga akhir Maret 2018.

--- a/id/news/_posts/2017-09-14-ruby-2-3-5-released.md
+++ b/id/news/_posts/2017-09-14-ruby-2-3-5-released.md
@@ -12,11 +12,11 @@ Ruby 2.3.5 telah dirilis.
 Rilis ini mencakup sekitar 70 perbaikan *bug* setelah rilis sebelumnya, dan juga beberapa perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk detail.
 
-* [CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Escape sequence injection vulnerability in the Basic authentication of WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
-* [CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 decode](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
-* [CVE-2017-14064: Heap exposure vulnerability in generating JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
-* [Multiple vulnerabilities in RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* [CVE-2017-0898: Kerentanan buffer underrun pada Kernel.sprintf](/id/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Kerentanan escape sequence injection pada Basic authentication WEBrick](/id/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Kerentanan buffer underrun pada OpenSSL ASN1 decode](/id/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Kerentanan tereksposnya heap saat menghasilkan JSON](/id/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Beberapa Kerentanan di RubyGems](/id/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
 * Memperbarui libyaml yang di-*bundle* ke versi 0.1.7
 
 Lihat [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_3_5/ChangeLog) untuk detail.

--- a/id/news/_posts/2017-09-14-ruby-2-4-2-released.md
+++ b/id/news/_posts/2017-09-14-ruby-2-4-2-released.md
@@ -10,11 +10,11 @@ lang: id
 Kami dengan senang hati mengumumkan rilis dari Ruby 2.4.2.
 Rilis ini mencakup beberapa perbaikan keamanan.
 
-* [CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
-* [CVE-2017-10784: Escape sequence injection vulnerability in the Basic authentication of WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
-* [CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 decode](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
-* [CVE-2017-14064: Heap exposure in generating JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
-* [Multiple vulnerabilities in RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* [CVE-2017-0898: Kerentanan buffer underrun pada Kernel.sprintf](/id/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Kerentanan escape sequence injection pada Basic authentication WEBrick](/id/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Kerentanan buffer underrun pada OpenSSL ASN1 decode](/id/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Kerentanan tereksposnya heap saat menghasilkan JSON](/id/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Beberapa Kerentanan di RubyGems](/id/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
 * Memperbarui libyaml yang di-*bundle* ke versi 0.1.7.
 
 Ada juga perbaikan *bug* lainnya.


### PR DESCRIPTION
The translated security fixes details on the latest Ruby released posts (`id`) are available. I updated the link titles and addresses.