### PR TITLE
Translate Escape sequence injection vulnerability (pt)

### DIFF
--- a/pt/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
+++ b/pt/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
@@ -1,0 +1,36 @@
+---
+layout: news_post
+title: "CVE-2017-10784: Vulnerabilidade de injeção de sequência de escape na autenticação Basic de WEBrick"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+tags: segurança
+lang: pt
+---
+
+Existe uma vulnerabilidade de injeção de sequência de escape na autenticação _Basic_ do WEBrick empacotado com Ruby.
+Essa vulnerabilidade foi assinada com o identificador CVE [CVE-2017-10784](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10784).
+
+## Detalhes
+
+Quando usando autenticação _Basic_ do WEBrick, clientes podem passar _strings_ arbitrárias como nome de usuário.
+WEBrick produz saídas com o nome de usuário intacto no _log_, então o atacante pode injetar sequências de escape maliciosas para o _log_ e _control characters_ perigosos podem ser executados no emulador de terminal da vítima.
+
+Essa vulnerabilidade é similar a [uma vulnerabilidade já corrigida](/en/news/2010/01/10/webrick-escape-sequence-injection/) (Em inglês), mas isso não foi corrigido na autenticação _Basic_.
+
+Todos os usuários rodando uma versão com essa vulnerabilidade devem atualizá-la imediatamente.
+
+## Versões Afetadas
+
+* Série Ruby 2.2: 2.2.7 e anteriores
+* Série Ruby 2.3: 2.3.4 e anteriores
+* Série Ruby 2.4: 2.4.1 e anteriores
+* anterior à revisão de árvore 58453
+
+## Créditos
+
+Obrigado Yusuke Endoh <mame@ruby-lang.org> por reportar este problema.
+
+## History
+
+* Originalmente publicado em 14 de setembro de 2017 12:00:00 (UTC)


### PR DESCRIPTION
Control characters é um termo de computação e optei por não traduzi-lo.
A notícia referenciada não existe traduzida. Algo misterioso aconteceu com as notícias de 2010?