### PR TITLE
Provide a 'build' task for all languages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,17 +27,28 @@ end
 
 namespace :build do
 
-  desc "Build the Jekyll site (`en' language part only)"
-  task :en do
+  def build_subpage(lang)
     require "yaml"
     require "lanyon"
 
     exclude_config = YAML.load_file(CONFIG)["exclude"]
-    exclude_langs  = (LANGUAGES - ["en"]).map {|lang| "#{lang}/" }
+    exclude_langs  = (LANGUAGES - [lang]).map {|x| "#{x}/" }
 
     exclude = exclude_config + exclude_langs
 
     Lanyon.build(exclude: exclude)
+  end
+
+  desc "Build the Jekyll site (`lang' language part only)"
+  task :lang do
+    puts 'Please specify one of the valid language codes:'
+    puts LANGUAGES.join(', ') << '.'
+  end
+
+  LANGUAGES.each do |lang|
+    task lang.to_sym do
+      build_subpage(lang)
+    end
   end
 end
 


### PR DESCRIPTION
`rake build:en` is useful to preview the **English** page.
I want to change the task that builds only one of the languages(**bg de en es fr id it ja ko pl pt ru tr vi zh_cn zh_tw**)
Thank you.