### PR TITLE
Update translations: ruby-core and manual instructions (id)

### DIFF
--- a/id/community/index.md
+++ b/id/community/index.md
@@ -52,7 +52,9 @@ untuk memulai petualangan Anda:
   juga orang Indonesia yang sedang tinggal di luar negeri). Berdiskusi
   tentang Ruby berikut semua varian-varian Ruby (seperti JRuby,
   Rubinius, XRuby, IronRuby, dan lain sebagainya) termasuk juga
-  aplikasi-aplikasi yang dibuat dengan Ruby seperti Rails.
+  aplikasi-aplikasi yang dibuat dengan Ruby seperti Rails. Anda bisa
+  bergabung ke grup [Slack][6] Ruby Indonesia untuk saling berbagi
+  dengan komunitas.
 
 Informasi Umum Tentang Ruby
 : * [Ruby Central][3]
@@ -65,3 +67,4 @@ Informasi Umum Tentang Ruby
 [3]: http://rubycentral.org/
 [4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
 [5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[6]: http://ruby.id/slack/

--- a/id/community/index.md
+++ b/id/community/index.md
@@ -4,27 +4,25 @@ title: "Komunitas"
 lang: id
 ---
 
-Satu di antara faktor-faktor penting untuk sebuah bahasa pemrograman
-adalah bantuan dari komunitas di sekitar bahasa itu dalam perkembangan
-para anggotanya. Ruby mempunyai komunitas yang aktif, ramah dan
-berkembang untuk semua orang dari segala tingkatan, dari pemula sampai
-pakar.
+Komunitas yang menumbuhkan sebuah bahasa pemrograman merupakan salah satu
+kekuatan yang paling penting darinya. Ruby memiliki semangat dan komunitas
+yang bersahabat untuk semua orang dari segala tingkatan.
 {: .summary}
 
 Jika Anda tertarik untuk berpartisipasi, berikut adalah beberapa tempat
 untuk memulai petualangan Anda:
 
 [Kelompok Pengguna Ruby](user-groups/)
-: Kelompok Pengguna Ruby di sekitar tempat Anda adalah tempat yang baik
+: Kelompok Pengguna Ruby di sekitar Anda adalah tempat yang baik
   untuk bertemu dengan programmer Ruby lain. Kelompok-kelompok ini
   mempunyai otonomi sendiri-sendiri dan biasanya mempunyai pertemuan
-  bulanan, milis, web situs, dan beberapa grup juga mengadakan codefest
-  di mana beberapa anggota berkumpul untuk *coding* bersama-sama.
+  bulanan, milis, web situs, dan jika Anda beruntung, sering
+  diadakan *codefest*.
 
 [Milis Ruby dan Newsgroups](mailing-lists/)
-: Ada bermacam-macam milis untuk macam-macam topik di beberapa bahasa.
-  Para anggota milis tersebut akan dengan senang menjawab
-  pertanyaan-pertanyaan anda.
+: Ruby memiliki bermacam-macam milis untuk berbagai topik dan tersedia
+  di beberapa bahasa. Jika Anda memiliki pertanyaan terkait Ruby,
+  menanyakannya di milis adalah cara yang bagus untuk mendapatkan jawaban.
 
 **Ruby di IRC**
 : Anda bisa berbincang-bincang (*chatting*) dengan pengguna Ruby lainnya
@@ -34,21 +32,19 @@ untuk memulai petualangan Anda:
   [#ruby-id](irc://irc.freenode.net/ruby-id) untuk diskusi lokal.
 
 [Ruby Core](ruby-core/)
-: Selagi Ruby 2.0 sedang dikembangkan, sekarang adalah waktu yang tepat
-  untuk mengikuti perkembangan Ruby. Jika berminat untuk membantu,
-  mulailah dari sini
+: Sekarang adalah waktu yang tepat untuk mengikuti perkembangan Ruby.
+  Jika berminat untuk membantu, mulailah dari sini.
 
 [Blog tentang Ruby](weblogs/)
-: Hampir semua hal yang terjadi di dunia Ruby dikupas tuntas oleh para
-  blogger yang berdedikasi tinggi. Anda bisa memulai petualangan anda di
-  dunia Ruby blogging dari daftar ini.
+: Sangat jarang yang terjadi pada komunitas Ruby tidak dibicarakan dalam
+  *blog*. Kami memiliki sebuah daftar saran yang bagus untuk Anda agar
+  *up to date*.
 
 [Ruby Conferences](conferences/)
-: Semakin banyak pengguna Ruby di sekeliling dunia hadir di berbagai
-  konferensi Ruby. Mereka berkumpul dengan pengguna lainnya dan
-  berbagi-bagi pengalaman, cerita, dan membahas masa depan Ruby.
-  Pendatang baru di komunitas Ruby janganlah sungkan, Anda dijamin akan
-  disambut dengan ramah.
+: *Programmer* Ruby di seluruh dunia sedang terlibat dalam konferensi-
+  konferensi, di mana mereka bersama-sama berbagi laporan tentang
+  *work-in-progress*, diskusi masa depan Ruby, dan menyambut pendatang
+  baru di komunitas Ruby.
 
 [Komunitas Pengguna Ruby Indonesia][2]
 : Komunitas Pengguna Ruby Indonesia (mayoritas diikuti oleh orang

--- a/id/community/mailing-lists/manual-instructions/index.md
+++ b/id/community/mailing-lists/manual-instructions/index.md
@@ -25,9 +25,12 @@ apabila ada pertanyaan, saran, maupun komentar seputar milis.
 
 ### Milis Berbahasa Inggris
 
+CATATAN: Jika Anda tidak dapat berlangganan, mohon mengacu pada
+[lists.ruby-lang.org](http://lists.ruby-lang.org).
+
 Untuk berlangganan sebuah milis berbahasa Inggris, silakan kirim e-mail
-ke alamat *controller* milis yang Anda inginkan dengan isi pesan (bukan
-subjek/judul) sebagai berikut:
+ke alamat *controller* milis yang Anda inginkan berikut dengan isi pesan
+(bukan judul):
 
     subscribe
 {: .code}
@@ -71,6 +74,9 @@ isi pesan “unsubscribe” ke alamat *controller* milis yang Anda inginkan:
 
     unsubscribe
 {: .code}
+
+Pastikan untuk mengirim e-mail yang berisi teks biasa, e-mail yang berisi
+HTML mungkin tidak bekerja.
 
 ### Mencari Bantuan
 

--- a/id/community/ruby-core/index.md
+++ b/id/community/ruby-core/index.md
@@ -77,7 +77,7 @@ mengkonfirmasi terlebih dahulu apakah permintaan Anda akan diperhatikan atau
 tidak. Anda juga bisa mengirim *patch* langsung ke milis. Anda diharapkan
 untuk berpartisipasi aktif dalam diskusi tersebut.
 
-Mohon lihat [Patch Writer's Guide][writing patches] untuk beberapa tips,
+Mohon lihat [Patch Writer's Guide][writing-patches] untuk beberapa tips,
 langsung dari Matz, bagaimana *patch* Anda dipertimbangkan.
 
 Sebagai ringkasan, langkah-langkah mengirimkan *patch* adalah sebagai

--- a/id/community/ruby-core/index.md
+++ b/id/community/ruby-core/index.md
@@ -4,49 +4,55 @@ title: "Ruby Core"
 lang: id
 ---
 
-Sekarang saatnya untuk mengikuti pengembangan Ruby, di saat pengembangan
-Ruby terbaru versi 2.0. Dengan semakin banyaknya perhatian masyarakat
-informatika terhadap bahasa pemrograman Ruby, semakin dibutuhkan pula
-bakat-bakat dari komunitas untuk membantu pengembangan Ruby dan
-dokumentasinya. Silakan bergabung!
+Sekarang saatnya untuk mengikuti pengembangan Ruby. Dengan bertambahnya
+perhatian yang diterima oleh Ruby dalam beberapa tahun terakhir, maka
+dibutuhkan bakat yang baik untuk meningkatkan Ruby dan mendokumentasikannya.
+Sehingga, dari mana Anda memulai?
 {: .summary}
 
 Topik seputar pengembangan Ruby yang dibahas disini adalah:
 
 * [Menggunakan Subversion untuk Memonitor Pengembangan Ruby](#following-ruby)
-* [Menyempurnakan Ruby, dengan patch](#patching-ruby)
+* [Bagaimana Menggunakan Git pada Repository Utama Ruby](#git-ruby)
+* [Menyempurnakan Ruby, Patch by Patch](#patching-ruby)
 * [Peraturan untuk Developer Inti](#coding-standards)
 
 ### Menggunakan Subversion untuk Memonitor Pengembangan Ruby
 {: #following-ruby}
 
-Instalasi [Subversion][1] terlebih dahulu.
-
-Lakukan `svn checkout` *source code* Ruby dengan login sebagai anonim.
-Jadi di *console* Anda ketik:
+Mendapatkan kode sumber Ruby terbaru dengan melakukan *checkout* sebagai anonim
+pada repositori [Subversion][1]. Masukan perintah berikut pada *console* Anda:
 
 {% highlight sh %}
 $ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
 {% endhighlight %}
 
-Sekarang direktori `ruby` berisi *source code* Ruby 1.9 yang paling
-terbaru (trunk), yang merupakan versi development Ruby, yang akan
-dirilis sebagai 1.9.0 di akhir tahun 2007.
+Sekarang direktori `ruby` akan berisi kode sumber terbaru dari versi
+*development* Ruby (ruby-trunk). Saat ini *patch* yang digunakan oleh *trunk*
+di-*backport* ke *branch stable* {{ site.svn.stable.version }},
+{{ site.svn.previous.version }}, dan {{ site.svn.old.version }} (lihat bawah).
 
-Kalau Anda berminat mempatch Ruby 1.8, gunakan *branch* `ruby_1_8`
-ketika svn checkout:
+Jika Anda ingin *patching* Ruby {{ site.svn.stable.version }},
+gunakan *branch* {{ site.svn.stable.branch }} ketika sedang *checkout*:
 
 {% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8
+$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.stable.branch }}
 {% endhighlight %}
 
-Perintah tadi untuk *checkout* direktori pengembangan Ruby versi 1.8.
-Developer yang bekerja di Ruby 1.8 diharapkan melakukan migrasi
-perubahan mereka ke trunk Ruby, sangat sering dua branch kelihatan
-sangat mirip, dengan pengecualian adanya perbaikan yang dibuat oleh Matz
-dan Nobu untuk bahasa Ruby sendiri.
+Demikian pula untuk Ruby {{ site.svn.previous.version }}:
 
-Kalau Anda berminat *browsing*, Anda bisa *browse* [repository Ruby via
+{% highlight sh %}
+$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
+{% endhighlight %}
+
+Perintah di atas akan melakukan *checkout* masing-masing ke direktori
+`{{ site.svn.stable.branch }}` or `{{ site.svn.previous.branch }}`.
+Pekerjaan pengembang pada *maintenance branch* diharapkan untuk migrasi
+perubahannya ke Ruby *trunk*, seringkali *branch-branch* kelihatan sangat
+mirip, dengan pengecualian ada perbaikan yang dibuat oleh Matz dan Nobu untuk
+bahasa Ruby sendiri.
+
+Kalau Anda berminat *browsing*, Anda bisa *browse* [repository Ruby melalui
 web][2].
 
 Untuk informasi lebih lanjut tentang Subversion, silakan lihat [the
@@ -54,91 +60,112 @@ Subversion FAQ][3] dan [the Subversion book][4]. Sebagai alternatif,
 Anda bisa juga dapatkan buku [Pragmatic Version Control with Subversion][5]
 sebagai buku yang berguna untuk pengenalan svn.
 
+### Bagaimana Menggunakan Git pada Repositori Utama Ruby
+{: #git-ruby}
+
+Bagi mereka yang lebih memilih menggunakan [Git][6] dibanding Subversion dapat
+mengikuti instruksi di [mirror on GitHub][7], baik untuk [comitter][8]
+maupun [bukan commiter][9].
+
 ### Menyempurnakan Ruby, dengan Patch
 {: #patching-ruby}
 
-Rubyforge mempunyai [bug tracker][6] dengan submit patch dan bug report
-(laporan adanya bug) ke Matz dan rekan-rekan lainnya (Developer Ruby
-Core). Laporan-laporan ini juga di submit ke
-[milis Ruby-Core][mailing-lists] untuk didiskusikan,
-jadi Anda bisa mengkonfirmasi terlebih dahulu apakah permintaan Anda
-akan diperhatikan atau tidak. Anda juga bisa mengirim patch langsung ke
-milis. Anda diharapkan untuk berpartisipasi aktif dalam diskusi
-tersebut.
+Tim Ruby Core merawat [bug tracker][6] untuk memasukkan *patch* dan laporan
+*bug* ke Matz dan rekan-rekannya. Laporan-laporan ini juga dimasukkan ke
+[milis Ruby-Core][mailing-lists] untuk didiskusikan, jadi Anda bisa
+mengkonfirmasi terlebih dahulu apakah permintaan Anda akan diperhatikan atau
+tidak. Anda juga bisa mengirim *patch* langsung ke milis. Anda diharapkan
+untuk berpartisipasi aktif dalam diskusi tersebut.
 
-Sebagai ringkasan, jadi langkah-langkah mengirimkan patch adalah sebagai
+Mohon lihat [Patch Writer's Guide][writing patches] untuk beberapa tips,
+langsung dari Matz, bagaimana *patch* Anda dipertimbangkan.
+
+Sebagai ringkasan, langkah-langkah mengirimkan *patch* adalah sebagai
 berikut:
 
-1.  Jika Anda memperbaiki bug di Ruby 1.8, check out dulu copy dari Ruby
-    1.8 dengan svn pada branch `ruby_1_8`.
+1. *Checkout* salinan kode sumber Ruby dari Subversion.
+   Biasanya *patch* untuk *bugfix* atau fitur baru dimasukkan
+   untuk *trunk* dari kode sumber Ruby. Bahkan jika Anda ingin menambahkan
+   sebuah fitur ke Ruby {{ site.svn.previous.version }}, perubahan harus
+   disetujui terlebih dahulu di *trunk*.
 
-         $ svn co https://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8
+        $ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
 
-    Jika Anda ingin menambahkan fitur ke Ruby, lakukan check out dari
-    `trunk` Ruby source. Walaupun jika Anda ingin menambahkan fitur ke
-    Ruby 1.8, fitur tersebut harus disetujui dulu di trunk.
+   Jika Anda sedang memperbaiki sebuah *bug* yang khusus pada satu *branch
+   maintenance*, *checkout* salinan dari masing-masing *branch*,
+   Misal, `{{ site.svn.previous.branch }}`.
 
-         $ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+        $ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
 
 2.  Tambahkan perbaikan Anda ke *source code* Ruby.
-3.  Buat patch untuk perbaikan Anda.
 
-         $ svn diff > ruby-changes.patch
+3.  Buat sebuah *patch*.
 
-4.  Email patch Anda ke [milis Ruby-Core][mailing-lists] dengan entri
-    ChangeLog yang menjelaskan patch.
-5.  Jika tidak ada masalah dengan patch, maka para committer akan
-    melakukan patch tersebut.
+        $ svn diff > ruby-changes.patch
 
-**Perhatian:** patch harus dikirimkan dalam format [unified diff][7].
-Untuk mengetahui lebih lanjut tentang bagaimana patch digabungkan
-(*merge*), lihat [the diffutils reference][8].
+4.  Buat sebuah tiket di [issue tracker][10] atau kirim *patch* melalui e-mail
+    ke [Ruby-Core mailing list][mailing-lists] dengan entri ChangeLog yang
+    menjelaskan patch.
+
+5.  Jika tidak ada masalah dengan *patch* tersebut, maka para *committer* akan
+    memberikan persetujuan untuk menggunakannya.
+
+**Perhatian:** *patch* harus dikirimkan dalam format [unified diff][12].
+Untuk mengetahui lebih lanjut tentang bagaimana *patch* digabungkan
+(*merge*), lihat [the diffutils reference][13].
 
 Diskusi tentang pengembangan Ruby dibicarakan di
 [milis Ruby-Core][mailing-lists]. Jadi kalau Anda penasaran
 apakah patch Anda berguna atau tidak atau bila Anda ingin
 memulai diskusi tentang masa depan Ruby, jangan sungkan untuk datang
-kemari. Jangan mempost hal-hal di luar topik (OOT) karena milis ini
+kemari. Jangan mengirimkan hal-hal di luar topik (OOT) karena milis ini
 adalah milis serius. Mari kita menjaga sopan santun karena kita
 berkorespondensi dengan pembuat Ruby.
 
-Ingatlah Developer Ruby Core tinggal di Jepang dan walau banyak yang
-bisa berbicara bahasa Inggris dengan baik tetap ada perbedaan timezone
-yang jauh. Mereka juga punya milis development yang menggunakan bahasa
-Jepang selain dengan milis yang Bahasa Inggris. Jadi sabarlah jika tidak
-ada yang membalas posting anda; jangan menyerah dan coba lagi beberapa
+Ingatlah tim Ruby Core tinggal di Jepang dan walau banyak yang
+bisa berbicara bahasa Inggris dengan baik tetap ada perbedaan zona waktu
+yang jauh. Mereka juga punya milis pengembangan yang menggunakan bahasa
+Jepang selain dengan milis berbahasa Inggris. Jadi sabarlah, jika tidak
+ada yang membalas kiriman Anda; jangan menyerah dan coba lagi beberapa
 hari kemudian.
 
 ### Pedoman untuk Pengembang Inti
 {: #coding-standards}
 
-Secara umum developer Ruby harus sudah terbiasa dengan *source code* dan
-*style* pengembangan yang digunakan oleh tim Ruby Core. Supaya jelas,
+Secara umum developer Ruby harus sudah terbiasa dengan kode sumber dan
+gaya pengembangan yang digunakan oleh tim Ruby Core. Supaya jelas,
 pedoman berikut harus dipatuhi ketika *check-in* (*commit*) ke
 Subversion:
 
 * Semua check-ins harus dijelaskan di `ChangeLog`, yang mengikuti
-  [standar GNU][9]. (Banyak Developer Ruby Core menggunakan Emacs
+  [standar GNU][14]. (Banyak Developer Ruby Core menggunakan Emacs
   `add-log` mode, yang bisa diakses dengan perintah `C-x 4 a`.)
-* Tanggal check-in harus diberikan dalam format Time Standar Jepang
-  (UTC+9).
-* Poin-poin ChangeLog Anda harus ditaruh juga di pesan commit
-  Subversion. Pesan ini secara otomatis di email ke milis Ruby-CVS
-  setelah Anda commit.
-* Deklarasi function ANSI digunakan di seluruh *source code* Ruby dan
-  *packaged extension*.
-* Tolong jangan gunakan comment style C++ (`//`), maintainer Ruby
+* Tanggal *check-in* harus diberikan dalam format yang memenuhi standar
+  waktu Jepang (UTC+9).
+* Poin-poin ChangeLog Anda harus ditaruh juga di pesan *commit*
+  Subversion. Pesan ini secara otomatis di e-mail ke milis Ruby-CVS
+  setelah Anda *commit*.
+* *Function prototype* digunakan di seluruh kode sumber Ruby dan
+  *packaged extension*-nya.
+* Tolong jangan gunakan gaya komentar C++ (`//`), *maintainer* Ruby
   cenderung memakai komentar multibaris standar C (`/* .. */`).
 
+Lihat juga informasi di [Ruby’s issue tracker][10].
 
 
-[mailing-lists]: /id/community/mailing-lists/
+
+[mailing-lists]: /en/community/mailing-lists/
+[writing-patches]: /en/community/ruby-core/writing-patches/
 [1]: http://subversion.apache.org/
 [2]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/
 [3]: http://subversion.apache.org/faq.html
 [4]: http://svnbook.org
 [5]: http://www.pragmaticprogrammer.com/titles/svn/
-[6]: http://rubyforge.org/tracker/?func=browse&amp;group_id=426&amp;atid=1698
-[7]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
-[8]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
-[9]: http://www.gnu.org/prep/standards/standards.html#Change-Logs
+[6]: http://git-scm.com/
+[7]: https://github.com/ruby/ruby
+[8]: https://github.com/shyouhei/ruby/wiki/committerhowto
+[9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
+[10]: https://bugs.ruby-lang.org/
+[12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
+[13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
+[14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs


### PR DESCRIPTION
As mentioned on #157, I found that community page `id` is outdated. These changes contains translation improvements and updated contents. Updated contents mean the content synchronizes with `en` pages. Please, review this PR.

Thank you.