### PR TITLE
Reorganize release data

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -1,7 +1,12 @@
-# name:     branch name (MAJOR.MINOR since 2.1)
-# status:   normal maintenance | security maintenance | eol | preview
-# date:     date of first stable release (YYYY-MM-DD)
-# eol_date: date of EOL (YYYY-MM-DD)
+# This file provides details on the various Ruby branches
+# and their maintenance status.
+#
+# Each entry has the following form:
+#
+# - name:     branch name (MAJOR.MINOR since 2.1)
+#   status:   normal maintenance | security maintenance | eol | preview
+#   date:     date of first stable release (YYYY-MM-DD)
+#   eol_date: date of EOL (YYYY-MM-DD)
 
 - name: 2.4
   status: normal maintenance

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -1,3 +1,7 @@
+# This file specifies the Ruby releases
+# that will be listed on the downloads page.
+
+# optional
 preview:
 
 stable:
@@ -5,10 +9,12 @@ stable:
   - 2.4.2
   - 2.3.5
 
+# optional
 security_maintenance:
 
   - 2.2.8
 
+# optional
 eol:
 
   - 2.1.10

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -2,57 +2,16 @@ preview:
 
 stable:
 
-  - version: 2.4.2
-    url:
-      bz2: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2
-      gz: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.zip
-    sha256:
-      bz2: 08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc
-      gz: 93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c
-      xz: 748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
-      zip: 37d7cb27d8abd4b143556260506306659930548652343076f7f8470f07818824
-
-  - version: 2.3.5
-    url:
-      bz2: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2
-      gz: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip
-    sha256:
-      bz2: f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b
-      gz: 5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc
-      xz: 7d3a7dabb190c2da06c963063342ca9a214bcd26f2158e904f0ec059b065ffda
-      zip: c9971e1ccb6e2f1ab32b1fe05416fce0b19a1cd9ba8fa095c77c4bdf2058e514
+  - 2.4.2
+  - 2.3.5
 
 security_maintenance:
 
-  - version: 2.2.8
-    url:
-      bz2: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2
-      gz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip
-    sha256:
-      bz2: b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e
-      gz: 8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a
-      xz: 37eafc15037396c26870f6a6c5bcd0658d14b46cd5e191a3b56d89dd22d561b0
-      zip: 58bf98b62d21d6cc622e6ef5c7d024db0458c6860199ab4c1bf68cdc4b36fa9d
+  - 2.2.8
 
 eol:
 
-  - version: 2.1.10
-    url:
-      bz2: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2
-      gz: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip
-    sha256:
-      bz2: a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1
-      gz: fb2e454d7a5e5a39eb54db0ec666f53eeb6edc593d1d2b970ae4d150b831dd20
-      xz: 5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
-      zip: 21cf83156ec782d17827fb9c8a945626dfd68cf0d9eb5ca7a78b12eb91c6f1fb
+  - 2.1.10
 
 stable_snapshot:
 

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,3 +1,25 @@
+# This file provides details on the various Ruby releases.
+#
+# For a new release, add an entry of the following form:
+#
+# - version: Ruby version (MAJOR.MINOR.TEENY since 2.1.0)
+#   date: release date (YYYY-MM-DD)
+#   post: /en/news/YYYY/MM/DD/ruby-VERSION-released/
+#   url:
+#     bz2: download URL
+#     gz:  ...
+#     xz:  ...
+#     zip: ...
+#   sha256:
+#     bz2: checksum
+#     gz:  ...
+#     xz:  ...
+#     zip: ...
+#
+# In order to get the release listed on the downloads page,
+# you also need to add an entry to `_data/downloads.yml'.
+
+
 # 2.5 series
 
 - version: 2.5.0-preview1

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -9,6 +9,17 @@
 - version: 2.4.2
   date: 2017-09-14
   post: /en/news/2017/09/14/ruby-2-4-2-released/
+  url:
+    bz2: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2
+    gz:  https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz
+    xz:  https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.xz
+    zip: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.zip
+  sha256:
+    bz2: 08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc
+    gz:  93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c
+    xz:  748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
+    zip: 37d7cb27d8abd4b143556260506306659930548652343076f7f8470f07818824
+
 - version: 2.4.1
   date: 2017-03-22
   post: /en/news/2017/03/22/ruby-2-4-1-released/
@@ -33,6 +44,17 @@
 - version: 2.3.5
   date: 2017-09-14
   post: /en/news/2017/09/14/ruby-2-3-5-released/
+  url:
+    bz2: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2
+    gz:  https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz
+    xz:  https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz
+    zip: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip
+  sha256:
+    bz2: f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b
+    gz:  5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc
+    xz:  7d3a7dabb190c2da06c963063342ca9a214bcd26f2158e904f0ec059b065ffda
+    zip: c9971e1ccb6e2f1ab32b1fe05416fce0b19a1cd9ba8fa095c77c4bdf2058e514
+
 - version: 2.3.4
   date: 2017-03-30
   post: /en/news/2017/03/30/ruby-2-3-4-released/
@@ -60,6 +82,17 @@
 - version: 2.2.8
   date: 2017-09-14
   post: /en/news/2017/09/14/ruby-2-2-8-released/
+  url:
+    bz2: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2
+    gz:  https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz
+    xz:  https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz
+    zip: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip
+  sha256:
+    bz2: b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e
+    gz:  8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a
+    xz:  37eafc15037396c26870f6a6c5bcd0658d14b46cd5e191a3b56d89dd22d561b0
+    zip: 58bf98b62d21d6cc622e6ef5c7d024db0458c6860199ab4c1bf68cdc4b36fa9d
+
 - version: 2.2.7
   date: 2017-03-28
   post: /en/news/2017/03/28/ruby-2-2-7-released/
@@ -99,6 +132,17 @@
 - version: 2.1.10
   date: 2016-04-01
   post: /en/news/2016/04/01/ruby-2-1-10-released/
+  url:
+    bz2: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2
+    gz:  https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz
+    xz:  https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz
+    zip: https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip
+  sha256:
+    bz2: a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1
+    gz:  fb2e454d7a5e5a39eb54db0ec666f53eeb6edc593d1d2b970ae4d150b831dd20
+    xz:  5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
+    zip: 21cf83156ec782d17827fb9c8a945626dfd68cf0d9eb5ca7a78b12eb91c6f1fb
+
 - version: 2.1.9
   date: 2016-03-30
   post: /en/news/2016/03/30/ruby-2-1-9-released/

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -5,7 +5,7 @@ lang: bg
 ---
 
 Това е мястото, от където можете да свалите последната версия на Ruby.
-Наличната стабилна версия е {{ site.data.downloads.stable[0].version }}.
+Наличната стабилна версия е {{ site.data.downloads.stable[0] }}.
 Препоръчително е да прочете [Лиценз на Ruby][license].
 {: .summary}
 
@@ -37,18 +37,18 @@ Ruby може да бъде инсталиран и от изходен код �
 може да използвате някое от приложенията за управление на Ruby версии,
 споменати по-горе. Те могат да ви помогнат.
 
-* **Стабилни версии:**{% for release in site.data.downloads.stable %}
+* **Стабилни версии:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **Получават security ъпдейти (скоро ще бъдат преустановени!):**{% for release in site.data.downloads.security_maintenance %}
+* **Получават security ъпдейти (скоро ще бъдат преустановени!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Преустановена поддръжка (EOL):**{% for release in site.data.downloads.eol %}
+* **Преустановена поддръжка (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -5,7 +5,7 @@ lang: de
 ---
 
 Hier kannst Du die aktuellen Ruby-Distributionen herunterladen.
-Die stabile Version ist derzeit {{ site.data.downloads.stable[0].version }}.
+Die stabile Version ist derzeit {{ site.data.downloads.stable[0] }}.
 Bitte nimm auch [Rubys Lizenz][license] zur Kenntnis.
 {: .summary}
 
@@ -36,18 +36,18 @@ Siehe die [Installationsanleitung][installation] für Details.
 Falls es Schwierigkeiten beim Kompilieren geben sollte, solltest Du
 vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
 
-* **Stabile Versionen:**{% for release in site.data.downloads.stable %}
+* **Stabile Versionen:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **In der Phase der Sicherheits-Maintenance (Unterstützung endet bald!):**{% for release in site.data.downloads.security_maintenance %}
+* **In der Phase der Sicherheits-Maintenance (Unterstützung endet bald!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Nicht mehr unterstützt (EOL):**{% for release in site.data.downloads.eol %}
+* **Nicht mehr unterstützt (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -5,7 +5,7 @@ lang: en
 ---
 
 Here you can get the latest Ruby distributions in your favorite flavor.
-The current stable version is {{ site.data.downloads.stable[0].version }}.
+The current stable version is {{ site.data.downloads.stable[0] }}.
 Please be sure to read [Ruby’s License][license].
 {: .summary}
 
@@ -34,24 +34,24 @@ See the [Installation][installation] page for details on building
 Ruby from source. If you have an issue compiling Ruby, consider using
 one of the third party tools mentioned above. They may help you.
 
-* **Stable releases:**{% for release in site.data.downloads.stable %}
+* **Stable releases:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.preview %}
-* **Preview releases:**{% for release in site.data.downloads.preview %}
+* **Preview releases:**{% for version in site.data.downloads.preview %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.security_maintenance %}
-* **In security maintenance phase (will EOL soon!):**{% for release in site.data.downloads.security_maintenance %}
+* **In security maintenance phase (will EOL soon!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Not maintained anymore (EOL):**{% for release in site.data.downloads.eol %}
+* **Not maintained anymore (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -4,6 +4,8 @@ title: "Descarga Ruby"
 lang: es
 ---
 
+{% include out-of-date.html %}
+
 Aquí puedes obtener las últimas distribuciones de Ruby en tu sabor
 favorito. La versión estable actual es {{ site.data.downloads.stable[0].version }}.
 Por favor asegúrate de leer la [licencia de Ruby][license].
@@ -34,16 +36,7 @@ usar una de las herramientas de terceros en la siguiente sección. Pueden servir
 de ayuda.
 
 * **Estable actual:**
-  [Ruby {{ site.data.downloads.stable[0].version }}]({{ site.data.downloads.stable[0].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[0].sha256.gz }}
-
-* **Estable previo:**
-  [Ruby {{ site.data.downloads.stable[1].version }}]({{ site.data.downloads.stable[1].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[1].sha256.gz }}
-
-* **Estable viejo:**
-  [Ruby {{ site.data.downloads.stable[2].version }}]({{ site.data.downloads.stable[2].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[2].sha256.gz }}
+  Ruby {{ site.data.downloads.stable[0].version }}
 
 * **Snapshots:**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -7,7 +7,7 @@ lang: es
 {% include out-of-date.html %}
 
 Aquí puedes obtener las últimas distribuciones de Ruby en tu sabor
-favorito. La versión estable actual es {{ site.data.downloads.stable[0].version }}.
+favorito. La versión estable actual es {{ site.data.downloads.stable[0] }}.
 Por favor asegúrate de leer la [licencia de Ruby][license].
 {: .summary}
 
@@ -36,7 +36,7 @@ usar una de las herramientas de terceros en la siguiente sección. Pueden servir
 de ayuda.
 
 * **Estable actual:**
-  Ruby {{ site.data.downloads.stable[0].version }}
+  Ruby {{ site.data.downloads.stable[0] }}
 
 * **Snapshots:**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -7,7 +7,7 @@ lang: fr
 {% include out-of-date.html %}
 
 Vous pouvez obtenir sur cette page les dernières versions de Ruby. La
-version stable actuelle est la {{ site.data.downloads.stable[0].version }}.
+version stable actuelle est la {{ site.data.downloads.stable[0] }}.
 N’oubliez pas de consulter la [licence Ruby][license].
 {: .summary}
 
@@ -41,7 +41,7 @@ envisagez d'utiliser l'un des outils tiers mentionnés plus haut. Ils pourront
 peut-être vous aider.
 
 * **Dernière version stable :**
-  Ruby {{ site.data.downloads.stable[0].version }}
+  Ruby {{ site.data.downloads.stable[0] }}
 
 * **Snapshots :**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -4,6 +4,8 @@ title: "Télécharger Ruby"
 lang: fr
 ---
 
+{% include out-of-date.html %}
+
 Vous pouvez obtenir sur cette page les dernières versions de Ruby. La
 version stable actuelle est la {{ site.data.downloads.stable[0].version }}.
 N’oubliez pas de consulter la [licence Ruby][license].
@@ -39,16 +41,7 @@ envisagez d'utiliser l'un des outils tiers mentionnés plus haut. Ils pourront
 peut-être vous aider.
 
 * **Dernière version stable :**
-  [Ruby {{ site.data.downloads.stable[0].version }}]({{ site.data.downloads.stable[0].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[0].sha256.gz }}
-
-* **Version stable précédente :**
-  [Ruby {{ site.data.downloads.stable[1].version }}]({{ site.data.downloads.stable[1].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[1].sha256.gz }}
-
-* **Anciennes versions stables:**
-  [Ruby {{ site.data.downloads.stable[2].version }}]({{ site.data.downloads.stable[2].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[2].sha256.gz }}
+  Ruby {{ site.data.downloads.stable[0].version }}
 
 * **Snapshots :**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/id/downloads/index.md
+++ b/id/downloads/index.md
@@ -5,7 +5,7 @@ lang: id
 ---
 
 Di sini Anda bisa mendapatkan distribusi Ruby terbaru sesuai pilihan Anda.
-Versi stabil saat ini adalah {{ site.data.downloads.stable[0].version }}.
+Versi stabil saat ini adalah {{ site.data.downloads.stable[0] }}.
 Pastikan Anda membaca [Lisensi Ruby][license] terlebih dahulu.
 {: .summary}
 
@@ -34,18 +34,18 @@ Lihat halaman [Instalasi][installation] untuk detail membangun
 Ruby dari kode sumbernya. Jika Anda memiliki masalah kompilasi Ruby, pertimbangkan menggunakan
 salah satu kakas bantu pihak ketiga yang telah disebutkan sebelumnya. Itu mungkin membantu Anda.
 
-* **Stable releases:**{% for release in site.data.downloads.stable %}
+* **Stable releases:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **Pada fase perawatan keamanan (akan EOL segera!):**{% for release in site.data.downloads.security_maintenance %}
+* **Pada fase perawatan keamanan (akan EOL segera!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Tidak dirawat sama sekali (EOL):**{% for release in site.data.downloads.eol %}
+* **Tidak dirawat sama sekali (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -4,6 +4,8 @@ title: "Scarica Ruby"
 lang: it
 ---
 
+{% include out-of-date.html %}
+
 Tramite questa pagina è possibile scaricare le distribuzioni di Ruby più
 recenti nel tuo formato preferito. La versione stabile corrente è la
 {{ site.data.downloads.stable[0].version }}. Assicurati di aver letto
@@ -41,16 +43,7 @@ degli strumenti di terze parti presenti nella sezione successiva. Potrebbero
 esserti di aiuto.
 
 * **Stabile Corrente:**
-  [Ruby {{ site.data.downloads.stable[0].version }}]({{ site.data.downloads.stable[0].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[0].sha256.gz }}
-
-* **Stabile Precedente:**
-  [Ruby {{ site.data.downloads.stable[1].version }}]({{ site.data.downloads.stable[1].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[1].sha256.gz }}
-
-* **Stabile Vecchia:**
-  [Ruby {{ site.data.downloads.stable[2].version }}]({{ site.data.downloads.stable[2].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[2].sha256.gz }}
+  Ruby {{ site.data.downloads.stable[0].version }}
 
 * **Snapshots:**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -8,7 +8,7 @@ lang: it
 
 Tramite questa pagina è possibile scaricare le distribuzioni di Ruby più
 recenti nel tuo formato preferito. La versione stabile corrente è la
-{{ site.data.downloads.stable[0].version }}. Assicurati di aver letto
+{{ site.data.downloads.stable[0] }}. Assicurati di aver letto
 la [Licenza di Ruby][license].
 {: .summary}
 
@@ -43,7 +43,7 @@ degli strumenti di terze parti presenti nella sezione successiva. Potrebbero
 esserti di aiuto.
 
 * **Stabile Corrente:**
-  Ruby {{ site.data.downloads.stable[0].version }}
+  Ruby {{ site.data.downloads.stable[0] }}
 
 * **Snapshots:**
   * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -5,7 +5,7 @@ lang: ja
 ---
 
 ここでは、Rubyインタプリタの代表的な入手方法を説明します。
-現在の安定版は {{ site.data.downloads.stable[0].version }}です。
+現在の安定版は {{ site.data.downloads.stable[0] }}です。
 [Ruby’sライセンス][license]を必ずお読み下さい。
 {: .summary}
 
@@ -28,18 +28,18 @@ lang: ja
 
 もしコンパイルで問題がある場合、[インストールガイド][installation] ページで解説しているサードパーティーツールの利用が助けになるかもしれません。
 
-* **安定版:**{% for release in site.data.downloads.stable %}
+* **安定版:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **セキュリティ修正のみの安定版 (まもなく EOL):**{% for release in site.data.downloads.security_maintenance %}
+* **セキュリティ修正のみの安定版 (まもなく EOL):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **メンテナンス終了 (EOL):**{% for release in site.data.downloads.eol %}
+* **メンテナンス終了 (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -5,7 +5,7 @@ lang: ko
 ---
 
 자신이 선호하는 방식으로 최신 루비 배포판을 설치할 수 있습니다.
-현재 안정 버전은 {{ site.data.downloads.stable[0].version }}입니다.
+현재 안정 버전은 {{ site.data.downloads.stable[0] }}입니다.
 [루비 라이센스][license]를 읽어 보십시오.
 {: .summary}
 
@@ -35,18 +35,18 @@ lang: ko
 밑에서 소개하는 서드파티 도구 중 하나를 이용해볼 것을 고려해 보십시오.
 도움이 될 것입니다.
 
-* **안정 릴리스:**{% for release in site.data.downloads.stable %}
+* **안정 릴리스:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [루비 {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **보안 유지보수 단계(곧 EOL 예정!):**{% for release in site.data.downloads.security_maintenance %}
+* **보안 유지보수 단계(곧 EOL 예정!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [루비 {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **더 이상 유지보수 없음(EOL):**{% for release in site.data.downloads.eol %}
+* **더 이상 유지보수 없음(EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [루비 {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -4,6 +4,8 @@ title: "Pobierz Rubiego"
 lang: pl
 ---
 
+{% include out-of-date.html %}
+
 Tutaj znajdziesz najnowsze dystrybucje języka Ruby. Aktualna stabilna
 wersja to {{ site.data.downloads.stable[0].version }}. Pamiętaj aby przeczytać
 [licencję Rubiego][license].
@@ -37,16 +39,7 @@ budowania Rubiego ze źródeł. Jeśli masz problem z kompilacją Rubiego rozwa�
 skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
 
 * **Obecny stabilny:**
-  [Ruby {{ site.data.downloads.stable[0].version }}]({{ site.data.downloads.stable[0].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[0].sha256.gz }}
-
-* **Poprzedni stabilny:**
-  [Ruby {{ site.data.downloads.stable[1].version }}]({{ site.data.downloads.stable[1].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[1].sha256.gz }}
-
-* **Stary stabilny:**
-  [Ruby {{ site.data.downloads.stable[2].version }}]({{ site.data.downloads.stable[2].url.gz }})<br>
-  sha256: {{ site.data.downloads.stable[2].sha256.gz }}
+  Ruby {{ site.data.downloads.stable[0].version }}
 
 * **Migawki:**
   * [Stabilna migawka]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -7,7 +7,7 @@ lang: pl
 {% include out-of-date.html %}
 
 Tutaj znajdziesz najnowsze dystrybucje języka Ruby. Aktualna stabilna
-wersja to {{ site.data.downloads.stable[0].version }}. Pamiętaj aby przeczytać
+wersja to {{ site.data.downloads.stable[0] }}. Pamiętaj aby przeczytać
 [licencję Rubiego][license].
 {: .summary}
 
@@ -39,7 +39,7 @@ budowania Rubiego ze źródeł. Jeśli masz problem z kompilacją Rubiego rozwa�
 skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
 
 * **Obecny stabilny:**
-  Ruby {{ site.data.downloads.stable[0].version }}
+  Ruby {{ site.data.downloads.stable[0] }}
 
 * **Migawki:**
   * [Stabilna migawka]({{ site.data.downloads.stable_snapshot.url.gz }}):

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -5,7 +5,7 @@ lang: pt
 ---
 
 Aqui você poderá obter as distribuições mais recentes de Ruby em seus sabores
-preferidos. A versão estável atual é a {{ site.data.downloads.stable[0].version }}.
+preferidos. A versão estável atual é a {{ site.data.downloads.stable[0] }}.
 Por favor certifique-se de ter lido a [Licença do Ruby][license].
 {: .summary}
 
@@ -36,18 +36,18 @@ como compilar Ruby a partir dos fontes. Se você tiver algum problema
 compilando Ruby, considere utilizar uma das ferramentas de terceiros
 mencionadas acima. Elas podem te ajudar.
 
-* **Versões estáveis:**{% for release in site.data.downloads.stable %}
+* **Versões estáveis:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **Com suporte a atualizações de segurança (EOL em breve!):**{% for release in site.data.downloads.security_maintenance %}
+* **Com suporte a atualizações de segurança (EOL em breve!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Sem suporte a atualizações (EOL):**{% for release in site.data.downloads.eol %}
+* **Sem suporte a atualizações (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -5,7 +5,7 @@ lang: ru
 ---
 
 Здесь вы найдете последние дистрибутивы Ruby на любой вкус. Текущая
-стабильная версия {{ site.data.downloads.stable[0].version }}.
+стабильная версия {{ site.data.downloads.stable[0] }}.
 Пожалуйста, ознакомьтесь с [лицензией Ruby][license].
 {: .summary}
 
@@ -35,18 +35,18 @@ lang: ru
 из исходников. Если у вас возникла сложность с компиляцией Ruby, попробуйте один из
 сторонних инструментов из следующей секции. Они могут помочь вам.
 
-* **Стабильные релизы:**{% for release in site.data.downloads.stable %}
+* **Стабильные релизы:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **На стадии поддержки безопасности (скоро будет остановлена):**{% for release in site.data.downloads.security_maintenance %}
+* **На стадии поддержки безопасности (скоро будет остановлена):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Больше не поддерживается (EOL):**{% for release in site.data.downloads.eol %}
+* **Больше не поддерживается (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/tr/downloads/index.md
+++ b/tr/downloads/index.md
@@ -7,7 +7,7 @@ lang: tr
 {% include out-of-date.html %}
 
 Burada en son Ruby dağıtımlarını işinize gelen şekliyle bulabilirsiniz.
-En son kararlı sürüm {{ site.data.downloads.stable[0].version }},
+En son kararlı sürüm {{ site.data.downloads.stable[0] }},
 lütfen önce [Ruby lisansını][license] okuyun.
 {: .summary}
 
@@ -17,7 +17,7 @@ Kaynak kodundan kurmak, platformunuza yeterince hakimseniz ve
 ortamınızda özel ayarlar gerekiyorsa uygun çözümdür. Eğer platformunuza
 hazır paket bulunmazsa da uygun olacaktır.
 
-* Ruby {{ site.data.downloads.stable[0].version }}
+* Ruby {{ site.data.downloads.stable[0] }}
   Kararlı Versiyon (*tavsiye edilir*)
 * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }})
   Bu son kararlı SVN’nin tar gzip hali. Son kararlı

--- a/tr/downloads/index.md
+++ b/tr/downloads/index.md
@@ -17,8 +17,7 @@ Kaynak kodundan kurmak, platformunuza yeterince hakimseniz ve
 ortamınızda özel ayarlar gerekiyorsa uygun çözümdür. Eğer platformunuza
 hazır paket bulunmazsa da uygun olacaktır.
 
-* [Ruby {{ site.data.downloads.stable[0].version }}]({{ site.data.downloads.stable[0].url.gz }})
-  (sha256:&nbsp;{{ site.data.downloads.stable[0].sha256.gz }})
+* Ruby {{ site.data.downloads.stable[0].version }}
   Kararlı Versiyon (*tavsiye edilir*)
 * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }})
   Bu son kararlı SVN’nin tar gzip hali. Son kararlı

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -6,7 +6,7 @@ lang: vi
 
 Bạn có thể lấy về bản phân phối Ruby mới nhất cho hầu hết các nền tảng
 tại đây.
-Bản ổn định mới nhất là {{ site.data.downloads.stable[0].version }}.
+Bản ổn định mới nhất là {{ site.data.downloads.stable[0] }}.
 Xin tham khảo [giấy phép][license] trước khi dùng.
 {: .summary}
 
@@ -35,18 +35,18 @@ Xem trang [Cài đặt][installation] để biết thêm chi tiết cách biên 
 Ruby từ nguồn. Nếu bạn gặp vấn đề biên dịch Ruby, xin hãy xem xét sử
 dụng một trong những công cụ của bên thứ ba đã được đề cập ở trên.
 
-* **Bản ổn định:**{% for release in site.data.downloads.stable %}
+* **Bản ổn định:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **Trong giai đoạn duy trì bảo mật (sẽ sớm EOL!):**{% for release in site.data.downloads.security_maintenance %}
+* **Trong giai đoạn duy trì bảo mật (sẽ sớm EOL!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **Không còn duy trì nữa (EOL):**{% for release in site.data.downloads.eol %}
+* **Không còn duy trì nữa (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -5,7 +5,7 @@ lang: zh_cn
 ---
 
 您可以在这里下载最新的 Ruby 发行版。目前最新的稳定版本是
-{{ site.data.downloads.stable[0].version }}。另外，请先阅读 [Ruby 版权说明][license]。
+{{ site.data.downloads.stable[0] }}。另外，请先阅读 [Ruby 版权说明][license]。
 {: .summary}
 
 ### 安装 Ruby 的方法
@@ -26,18 +26,18 @@ lang: zh_cn
 
 从源代码编译 Ruby 的详细说明，参见[安装页面][installation]。若编译 Ruby 时遇到问题，请参考安装页面罗列的第三方工具，可能会有帮助。
 
-* **稳定版:**{% for release in site.data.downloads.stable %}
+* **稳定版:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **在做安全性维护的版本（很快 EOL！）:**{% for release in site.data.downloads.security_maintenance %}
+* **在做安全性维护的版本（很快 EOL！）:**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **不再维护的版本（EOL）:**{% for release in site.data.downloads.eol %}
+* **不再维护的版本（EOL）:**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -5,7 +5,7 @@ lang: zh_tw
 ---
 
 您可以在這裡下載最適合的 Ruby 發行版。目前最新的穩定版本是
-{{ site.data.downloads.stable[0].version }}。請記得詳閱 [Ruby 版權說明][license]。
+{{ site.data.downloads.stable[0] }}。請記得詳閱 [Ruby 版權說明][license]。
 {: .summary}
 
 ### 安裝 Ruby 的方法
@@ -26,18 +26,18 @@ lang: zh_tw
 
 進一步關於從原始碼編譯 Ruby 的資訊，請參考[安裝][installation]頁面。若編譯 Ruby 時遇到任何問題，請參考安裝頁面羅列的第三方工具，可能會有幫助。
 
-* **穩定版本：**{% for release in site.data.downloads.stable %}
+* **穩定版本：**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 
 {% if site.data.downloads.security_maintenance %}
-* **處於安全維護週期（即將停止維護！）：**{% for release in site.data.downloads.security_maintenance %}
+* **處於安全維護週期（即將停止維護！）：**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
 {% if site.data.downloads.eol %}
-* **不再維護（停止維護）：**{% for release in site.data.downloads.eol %}
+* **不再維護（停止維護）：**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}


### PR DESCRIPTION
**[WIP]**

Currently, data on Ruby releases is split into two files: `_data/downloads.yml` provides detailed data for the few Rubies that are currently "featured" on the downloads page, like download URLs and checksums, while `_data/releaes.yml` is a more extensive list of Ruby versions with data for the releases page, like release dates and links to the release announcements.

Duplicating/splitting the data in this way seems clumsy.

Proposed new organization of the data:

* all data is gathered in `releases.yml`, both for the releases and the downloads page
* `downloads.yml` now only defines (by specifying the version number) _which_ Rubies will be listed on the downloads page, the relevant data is taken from `releases.yml`

So, when publishing a new release, the relevant data should be added to `releases.yml`, and the release version added to `downloads.yml`.

One benefit: it seems very unlikely that one of the necessary changes is forgotten, because then the new release would not appear on the downloads page; the releases page would therefore always be up-to-date, other than e.g. reported in #1637 and others.

<del>One downside: the Liquid tags on the downloads page get somewhat complicated, it's not a very elegant solution. (But that might get improved after having a closer look at the Liquid docs.)</del>
_Update: Jekyll provides the `where` Liquid filter, which let's one find items in an array without a loop with condition, so the code is now much clearer._

Acceptable?

@hsbt, @nurse, @unak, @nagachika

**Not ready for merging, because I didn't yet adapt the download pages of the translated sites; they will break.**