### PR TITLE
Drop mention of old OS X versions (id)

### DIFF
--- a/id/documentation/installation/index.md
+++ b/id/documentation/installation/index.md
@@ -122,8 +122,7 @@ Ini semestinya memasang versi Ruby terbaru.
 ### Homebrew (OS X)
 {: #homebrew}
 
-Pada OS X Yosemite dan Mavericks, Ruby 2.0 sudah tersedia.
-OS X Mountain Lion, Lion, dan Snow Leopard terisi dengan Ruby 1.8.7.
+Ruby 2.0 sudah dimasukkan pada macOS (High) Sierra dan OS X El Capitan.
 
 Banyak pengguna OS X menggunakan [Homebrew][homebrew] sebagai *package manager*.
 Hal ini sangat mudah untuk mendapatkan versi terbaru menggunakan Homebrew:


### PR DESCRIPTION
As mentioned on 9e7c14d6ae66a2abc55e8fcc56449edad2cc3a2a, the old version of OS X should not be mentioned.