### PR TITLE
Fix typo in variable assignment demonstration :)

### DIFF
--- a/en/documentation/quickstart/index.md
+++ b/en/documentation/quickstart/index.md
@@ -133,7 +133,7 @@ irb(main):007:0> a = 3 ** 2
 => 9
 irb(main):008:0> b = 4 ** 2
 => 16
-irb(main):009:0> Math.sqrt(a+b)
+irb(main):009:0> c = Math.sqrt(a+b)
 => 5.0
 {% endhighlight %}
 


### PR DESCRIPTION
I spot this inconsistency while learning ruby via `Ruby in 20 Minutes` finally I got the source which I suspect it is only a static site and it is open source 😄 