### PR TITLE
Add 2.4.3 release announce and CVE-2017-17405 announce.

### DIFF
--- a/en/news/_posts/2017-12-14-net-ftp-command-injection-cve-2017-17405.md
+++ b/en/news/_posts/2017-12-14-net-ftp-command-injection-cve-2017-17405.md
@@ -1,0 +1,30 @@
+---
+layout: news_post
+title: "Command injection vulnerability in Net::FTP"
+author: "nagachika"
+translator:
+date: 2017-12-14 00:00:00 +0000
+lang: en
+---
+
+There is a command injection vulnerability in Net::FTP bundled with Ruby.
+This vulnerability has been assigned the CVE identifier CVE-2017-17405.
+
+## Details
+
+Net::FTP#get, getbinaryfile, gettextfile, put, putbinaryfile, and puttextfile use Kernel#open to open a local file.  If the `localfile` argument starts with the pipe character `"|"`, the command following the pipe character is executed.  The default value of `localfile` is `File.basename(remotefile)`, so malicious FTP servers could cause arbitrary command execution.
+
+All users running an affected release should upgrade immediately.
+
+## Affected Versions
+Ruby 2.2 series: 2.2.8 and earlier
+Ruby 2.3 series: 2.3.5 and earlier
+Ruby 2.4 series: 2.4.2 and earlier
+Ruby 2.5 series: 2.5.0-preview1
+prior to trunk revision r61242
+
+## Credit
+Thanks to Etienne Stalmans from the Heroku product security team for reporting the issue.
+
+## History
+* Originally published at 2017-12-14 00:00:00 (UTC)

--- a/en/news/_posts/2017-12-14-ruby-2-4-3-released.md
+++ b/en/news/_posts/2017-12-14-ruby-2-4-3-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.4.3 Released"
+author: "nagachika"
+translator:
+date: 2017-12-14 00:00:00 +0000
+lang: en
+---
+
+Ruby 2.4.3 has been released.
+
+This release includes some bug fixes and a security fix.
+
+* [CVE-2017-17405: Command injection vulnerability in Net::FTP](/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/)
+
+There are also som bug fixes.
+See [commit logs](https://github.com/ruby/ruby/compare/v2_4_2...v2_4_3) for more details.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2>
+
+      SIZE:   12615068 bytes
+      SHA1:   3ca96536320b915762d57fe1ee540df6810bf631
+      SHA256: 0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30
+      SHA512: fb4339e30c04d03b1422b6c32ede45902e072cd26325b36f3fc05c341d42eea6431d88718242dcc9ce24d9cad26f3d26772f2e806bd7d93f40be50268c318409
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz>
+
+      SIZE:   14178729 bytes
+      SHA1:   787b7f4e90fb4b39a61bc1a31eb7765f875a590c
+      SHA256: fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98
+      SHA512: e6859cee49f74bbfbcfc9dd583aa0f1af007354f9b56ec09959d24764e69ed6ea3d1d59a229ad25b451161a1ea2ac60e0621dbbcc484ad219eed9e55f3825e05
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.xz>
+
+      SIZE:   10040072 bytes
+      SHA1:   f0a49dddb4e7903a11a80554fd7a317a854cd365
+      SHA256: 23677d40bf3b7621ba64593c978df40b1e026d8653c74a0599f0ead78ed92b51
+      SHA512: 8bcf60c994a96787da5d743c66f5609a5a6d834d6d61243cdea7fd059197c3b10da43c99e5649be85e2f2329eedcbb1dd76e89ce3ac586be9056348f7449ed09
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.zip>
+
+      SIZE:   15649173 bytes
+      SHA1:   19744d7673914804b46f75b374faee87b2ea18d9
+      SHA256: a4cd07af2cef121582b8bf7ec57fb9a916d99556c713538bc4469be68bfc1961
+      SHA512: 5e51b4337ee12041925dd6b91df6d0c7fc5bf19846c1c8d5aa43823f5410d1291cd428bdb5245f08a399051d06c2cb59fde73a7d3da379cbbd24f9c2b60fcc8c
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped
+us to make this release.
+Thanks for their contributions.

--- a/ja/news/_posts/2017-12-14-ruby-2-4-3-released.md
+++ b/ja/news/_posts/2017-12-14-ruby-2-4-3-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 2.4.3 リリース"
+author: "nagachika"
+translator:
+date: 2017-12-14 00:00:00 +0000
+lang: ja
+---
+
+Ruby 2.4.3 がリリースされました。
+このリリースには以下の脆弱性修正が含まれています。
+
+* [CVE-2017-17405: Command injection vulnerability in Net::FTP](/en/news/2017/12/14/xxx-cve-2017-17405/)
+
+その他いくつかの不具合修正も含まれます。詳細は [commit log](https://github.com/ruby/ruby/compare/v2_4_2...v2_4_3) を参照してください。
+
+
+## ダウンロード
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2>
+
+      SIZE:   12615068 bytes
+      SHA1:   3ca96536320b915762d57fe1ee540df6810bf631
+      SHA256: 0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30
+      SHA512: fb4339e30c04d03b1422b6c32ede45902e072cd26325b36f3fc05c341d42eea6431d88718242dcc9ce24d9cad26f3d26772f2e806bd7d93f40be50268c318409
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz>
+
+      SIZE:   14178729 bytes
+      SHA1:   787b7f4e90fb4b39a61bc1a31eb7765f875a590c
+      SHA256: fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98
+      SHA512: e6859cee49f74bbfbcfc9dd583aa0f1af007354f9b56ec09959d24764e69ed6ea3d1d59a229ad25b451161a1ea2ac60e0621dbbcc484ad219eed9e55f3825e05
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.xz>
+
+      SIZE:   10040072 bytes
+      SHA1:   f0a49dddb4e7903a11a80554fd7a317a854cd365
+      SHA256: 23677d40bf3b7621ba64593c978df40b1e026d8653c74a0599f0ead78ed92b51
+      SHA512: 8bcf60c994a96787da5d743c66f5609a5a6d834d6d61243cdea7fd059197c3b10da43c99e5649be85e2f2329eedcbb1dd76e89ce3ac586be9056348f7449ed09
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.zip>
+
+      SIZE:   15649173 bytes
+      SHA1:   19744d7673914804b46f75b374faee87b2ea18d9
+      SHA256: a4cd07af2cef121582b8bf7ec57fb9a916d99556c713538bc4469be68bfc1961
+      SHA512: 5e51b4337ee12041925dd6b91df6d0c7fc5bf19846c1c8d5aa43823f5410d1291cd428bdb5245f08a399051d06c2cb59fde73a7d3da379cbbd24f9c2b60fcc8c
+
+## リリースコメント
+
+このリリースにあたり、多くのコミッター、開発者、バグ報告をしてくれたユーザーの皆様に感謝を申し上げます。


### PR DESCRIPTION
Ruby 2.4.3 release announce (en, ja) and CVE-2017-17405 announce (en only).
