### PR TITLE
absent operator → absence operator

### DIFF
--- a/en/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
+++ b/en/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
@@ -26,7 +26,7 @@ It introduces some new features and performance improvements, for example:
 ## Other notable changes since 2.4
 
 * Merge Onigmo to 6.1.1.
-  It adds [absent operator](https://github.com/k-takata/Onigmo/issues/87)
+  It adds [absence operator](https://github.com/k-takata/Onigmo/issues/87)
   Note that Ruby 2.4.1 also includes this change.
 * Merge bundler to standard libraries.
 * Merge rubygems-2.6.13.

--- a/en/news/_posts/2017-12-14-ruby-2-5-0-rc1-released.md
+++ b/en/news/_posts/2017-12-14-ruby-2-5-0-rc1-released.md
@@ -38,7 +38,7 @@ It introduces some new features and performance improvements, for example:
 ## Other notable changes since 2.4
 
 * Update to Onigmo 6.1.3.
-  It adds the [absent operator](https://github.com/k-takata/Onigmo/issues/87).
+  It adds the [absence operator](https://github.com/k-takata/Onigmo/issues/87).
   Note that Ruby 2.4.1 also includes this change.
 * Add Bundler to standard libraries.
 * Update to RubyGems 2.7.0.

--- a/id/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
+++ b/id/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
@@ -27,7 +27,7 @@ contoh:
 ## Beberapa perubahan penting lainnya sejak versi 2.4
 
 * Menggabungkan Onigmo ke 6.1.1.
-  Ini menambahkan [absent operator](https://github.com/k-takata/Onigmo/issues/87)
+  Ini menambahkan [absence operator](https://github.com/k-takata/Onigmo/issues/87)
   Perhatikan Ruby 2.4.1 juga berisi perubahan ini.
 * Menggabungkan bundler ke pustaka standar.
 * Menggabungkan rubygems-2.6.13.

--- a/ko/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
+++ b/ko/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
@@ -26,7 +26,7 @@ lang: ko
 ## 2.4 이후 주목할 만한 변경
 
 * Onigmo를 6.1.1로 병합했습니다.
-  [absent operator](https://github.com/k-takata/Onigmo/issues/87)를 추가했습니다.
+  [absence operator](https://github.com/k-takata/Onigmo/issues/87)를 추가했습니다.
   루비 2.4.1은 이미 이 사항을 포함하였습니다.
 * 번들러를 표준 라이브러리로 병합했습니다.
 * rubygems-2.6.13 병합했습니다.

--- a/zh_tw/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
+++ b/zh_tw/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
@@ -26,7 +26,7 @@ lang: zh_tw
 ## 自 2.4 起重要的變化
 
 * 合併 Onigmo 至 6.1.1 版本。
-  新增了 [absent operator](https://github.com/k-takata/Onigmo/issues/87)
+  新增了 [absence operator](https://github.com/k-takata/Onigmo/issues/87)
   Ruby 2.4.1 也同樣包含此變更.
 * 合併 bundler 至標準函式庫。
 * 合併 rubygems-2.6.13 。


### PR DESCRIPTION
Onigmo use `absence operator` instead of `absent operator` as the name of operator now.