### PR TITLE
Update RubySpec URL

### DIFF
--- a/bg/news/_posts/2010-11-15-ruby-1-9-2-released.md
+++ b/bg/news/_posts/2010-11-15-ruby-1-9-2-released.md
@@ -104,7 +104,7 @@ It causes a LoadError
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/de/news/_posts/2010-08-24-ruby-1-9-2-verffentlicht.md
+++ b/de/news/_posts/2010-08-24-ruby-1-9-2-verffentlicht.md
@@ -134,7 +134,7 @@ sein.
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org/
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/en/news/_posts/2010-08-18-ruby-1-9-2-released.md
+++ b/en/news/_posts/2010-08-18-ruby-1-9-2-released.md
@@ -100,7 +100,7 @@ It causes a LoadError
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/es/news/_posts/2010-08-18-ruby-1-9-2-liberada.md
+++ b/es/news/_posts/2010-08-18-ruby-1-9-2-liberada.md
@@ -120,7 +120,7 @@ Causa LoadError
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/fr/news/_posts/2010-08-23-ruby-1-9-2-is-released.md
+++ b/fr/news/_posts/2010-08-23-ruby-1-9-2-is-released.md
@@ -114,7 +114,7 @@ J\'obtiens une erreur de type LoadError
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/it/news/_posts/2010-11-14-ruby-1-9-2-is-released.md
+++ b/it/news/_posts/2010-11-14-ruby-1-9-2-is-released.md
@@ -120,7 +120,7 @@ Causa un LoadError
 
 
 
-[1]: http://www.rubyspec.org
+[1]: https://github.com/ruby/spec
 [2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/ja/news/_posts/2008-06-01-ruby-1-8-7-has-been-released.md
+++ b/ja/news/_posts/2008-06-01-ruby-1-8-7-has-been-released.md
@@ -46,4 +46,4 @@ Ruby 1.8.7がリリースされました。 (リリースについてのアナ�
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.zip
 [5]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_7/NEWS
 [6]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_7/ChangeLog
-[7]: http://rubyspec.org/
+[7]: https://github.com/ruby/spec

--- a/ja/news/_posts/2010-08-18-ruby-1-9-2-is-released.md
+++ b/ja/news/_posts/2010-08-18-ruby-1-9-2-is-released.md
@@ -105,7 +105,7 @@ LoadErrorが発生する
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/tr/news/_posts/2011-01-17-ruby-1-9-2-is-released.md
+++ b/tr/news/_posts/2011-01-17-ruby-1-9-2-is-released.md
@@ -102,7 +102,7 @@ Bir LoadError kaynağı
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/zh_cn/news/_posts/2010-11-06-ruby-1-9-2.md
+++ b/zh_cn/news/_posts/2010-11-06-ruby-1-9-2.md
@@ -110,7 +110,7 @@ It causes a LoadError
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip

--- a/zh_tw/news/_posts/2010-08-18-ruby-1-9-2.md
+++ b/zh_tw/news/_posts/2010-08-18-ruby-1-9-2.md
@@ -104,7 +104,7 @@ LoadError 的原因 ?
 
 [1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/NEWS
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_0/ChangeLog
-[3]: http://www.rubyspec.org
+[3]: https://github.com/ruby/spec
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz
 [6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.zip


### PR DESCRIPTION
It seems `rubyspec.org` is expired and reused.