### PR TITLE
Add a link to rurema for Ruby 2.5.0 (ja)

### DIFF
--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -22,6 +22,7 @@ Rubyでプログラミングする際に役立つドキュメントを紹介し�
 * [Rubyリファレンスマニュアル Ruby 2.2.0版][man-220]
 * [Rubyリファレンスマニュアル Ruby 2.3.0版][man-230]
 * [Rubyリファレンスマニュアル Ruby 2.4.0版][man-240]
+* [Rubyリファレンスマニュアル Ruby 2.5.0版][man-250]
 * [るりまサーチ][man-search]
 
 またこのリファレンスマニュアルをまとめてダウンロードすることもできます。
@@ -116,6 +117,7 @@ Posted by Shugo Maeda on 26 May 2006
 [man-220]: https://docs.ruby-lang.org/ja/2.2.0/doc/index.html
 [man-230]: https://docs.ruby-lang.org/ja/2.3.0/doc/index.html
 [man-240]: https://docs.ruby-lang.org/ja/2.4.0/doc/index.html
+[man-250]: https://docs.ruby-lang.org/ja/2.5.0/doc/index.html
 [man-search]: https://docs.ruby-lang.org/ja/search/
 [man-xz]: https://cache.ruby-lang.org/pub/ruby/doc/ruby-refm-1.9.3-dynamic-20120829.tar.xz
 [man-gz]: https://cache.ruby-lang.org/pub/ruby/doc/ruby-refm-1.9.3-dynamic-20120829.tar.gz


### PR DESCRIPTION
The following Ruby 2.5.0 manual (japanese) URL is available.
https://docs.ruby-lang.org/ja/2.5.0/doc/index.html