### PR TITLE
Translate 2018 Fukuoka Ruby Award Competition (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -1,0 +1,65 @@
+---
+layout: news_post
+title: "2018 福岡 Ruby 大賽 ─ Matz 親自審視參賽作品！"
+author: "Fukuoka Ruby"
+translator: "Vincent Lin"
+date: 2017-12-27 00:00:00 +0000
+lang: zh_tw
+---
+
+親愛的 Ruby 愛好者，
+
+日本福岡市政府與松本行弘（“Matz”）先生誠摯邀您一起來參加 Ruby 大賽。有開發出什麼有趣的 Ruby 應用嗎？歡迎參賽。
+
+2018 福岡 Ruby 大賽──最大獎──壹百萬日圓！
+
+截止日期：2018 年 1 月 31 日。
+
+![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz 與評審委員小組會選出本次大賽的優勝者。福岡 Ruby 大賽的最大獎是壹百萬日圓。過去的優勝者有來自美國的 Rhomobile 公司以及韓國釜山的亞太經貿氣候中心。
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+參賽的作品不需要完全是用 Ruby 寫的，但需要用到 Ruby 獨一無二的特色。
+
+必須是過去一年內所開發的作品才有效，進一步了解請造訪下列福岡市政府網站：
+
+[http://www.digitalfukuoka.jp/events/152](http://www.digitalfukuoka.jp/events/152)
+
+或參考
+
+[http://myfukuoka.com/events/2018-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2018-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/393/RubyAward_ApplicationForm_2018.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/393/RubyAward_ApplicationForm_2018.doc)
+
+請將報名表 Email 至 award@f-ruby.com。
+
+今年我們有以下特別獎：
+
+AWS 特賞得獎者將獲得：
+
+* Amazon Fire Tablet（可能會修改）
+* 免費 AWS 架構技術諮詢服務
+
+GMO Pepabo 特賞將獲得：
+
+* Lolipop! 共享主機服務的標準方案十年免費，或是 Managed Cloud 的流量方案價值日幣十萬元的折價券
+* Muumuu Domain DNS 註冊服務：十年免費域名一個（限每年費用低於一萬日圓的域名）
+
+IIJ GIO 特賞將獲得：
+
+* 更多細節將在稍後公佈
+
+Money Forward 特賞將獲得：
+
+* 與 Money Forward 的 Ruby 提交者共享晚餐
+* 個人金融管理系統 "Money Forward" 的高級服務十年免費優待券一張
+
+Salesforce 特賞將獲得：
+
+* salesforce.com 的新奇禮品
+
+“Matz 會仔細審閱、測試作品的原始碼，參加的意義非凡啊！大賽免費參加！”
+
+謝謝！


### PR DESCRIPTION
zh_tw Translation for 2018 Fukuoka Ruby Award Competition post

- zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md

Thank you.