### PR TITLE
Fix typo and add mention about 2.5 series to en news

### DIFF
--- a/en/news/_posts/2018-02-17-multiple-vulnerabilities-in-rubygems.md
+++ b/en/news/_posts/2018-02-17-multiple-vulnerabilities-in-rubygems.md
@@ -30,6 +30,7 @@ It is strongly recommended for Ruby users to take one of the following workaroun
 * Ruby 2.2 series: 2.2.9 and earlier
 * Ruby 2.3 series: 2.3.6 and earlier
 * Ruby 2.4 series: 2.4.3 and earlier
+* Ruby 2.5 series: 2.5.0 and earlier
 * prior to trunk revision 62422
 
 ## Workarounds

--- a/ja/news/_posts/2018-02-17-multiple-vulnerabilities-in-rubygems.md
+++ b/ja/news/_posts/2018-02-17-multiple-vulnerabilities-in-rubygems.md
@@ -30,7 +30,7 @@ RubyGems の公式ブログにて[報告されています](http://blog.rubygems
 * Ruby 2.2.9 以前の全ての Ruby 2.2 系列
 * Ruby 2.3.6 以前の全ての Ruby 2.3 系列
 * Ruby 2.4.3 以前の全ての Ruby 2.4 系列
-* Ruby 2.5.0 以前の全ての Ruby 2.4 系列
+* Ruby 2.5.0 以前の全ての Ruby 2.5 系列
 * revision 62422 より前の開発版
 
 ## 回避策


### PR DESCRIPTION
I think that `Ruby 2.4 系列` is a typo. Together, add a mention about 2.5 series to en news. Thanks.