### PR TITLE
Update all try_ruby links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -666,7 +666,7 @@ locales:
 
   sidebar:
     try_ruby: &try_ruby
-      url: http://tryruby.org/
+      url: https://easydatawarehousing.github.io/TryRuby/
     rubybib: &rubybib
       url: http://rubybib.org/
 

--- a/_config.yml
+++ b/_config.yml
@@ -666,7 +666,7 @@ locales:
 
   sidebar:
     try_ruby: &try_ruby
-      url: https://easydatawarehousing.github.io/TryRuby/
+      url: https://ruby.github.io/TryRuby/
     rubybib: &rubybib
       url: http://rubybib.org/
 

--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -142,7 +142,7 @@ ruby -v
 Ако имате въпроси относно Ruby, [пощенският списък](/bg/community/mailing-lists/)
 е чудесно място да ги зададете.
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -142,7 +142,7 @@ ruby -v
 Ако имате въпроси относно Ruby, [пощенският списък](/bg/community/mailing-lists/)
 е чудесно място да ги зададете.
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -82,7 +82,7 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 
 
 
-[1]: http://tryruby.org
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://www.hackety.com/
 [3]: http://mislav.uniqpath.com/poignant-guide/
 [4]: http://www.moccasoft.de/papers/ruby_tutorial

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -82,7 +82,7 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://www.hackety.com/
 [3]: http://mislav.uniqpath.com/poignant-guide/
 [4]: http://www.moccasoft.de/papers/ruby_tutorial

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -167,7 +167,7 @@ If you have questions about Ruby the
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -167,7 +167,7 @@ If you have questions about Ruby the
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -70,7 +70,7 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://pine.fm/LearnToProgram/
 [3]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [4]: http://pragmaticprogrammer.com/titles/ruby/index.html

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -70,7 +70,7 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://pine.fm/LearnToProgram/
 [3]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [4]: http://pragmaticprogrammer.com/titles/ruby/index.html

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -143,7 +143,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 
 
 [2]: http://jeveuxapprendreruby.fr/
-[3]: http://tryruby.org/
+[3]: https://easydatawarehousing.github.io/TryRuby/
 [4]: http://rubykoans.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://pine.fm/LearnToProgram/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -143,7 +143,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 
 
 [2]: http://jeveuxapprendreruby.fr/
-[3]: https://easydatawarehousing.github.io/TryRuby/
+[3]: https://ruby.github.io/TryRuby/
 [4]: http://rubykoans.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://pine.fm/LearnToProgram/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -164,7 +164,7 @@ adalah tempat yang baik untuk memulai.
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -164,7 +164,7 @@ adalah tempat yang baik untuk memulai.
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -143,7 +143,7 @@ iniziare.
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -143,7 +143,7 @@ iniziare.
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -156,7 +156,7 @@ ruby -v
 영어가 되신다면 [메일링 리스트](/ko/community/mailing-lists/)를 사용하실 수도
 있습니다.
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -156,7 +156,7 @@ ruby -v
 영어가 되신다면 [메일링 리스트](/ko/community/mailing-lists/)를 사용하실 수도
 있습니다.
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -146,7 +146,7 @@ angielskim).
 
 Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -146,7 +146,7 @@ angielskim).
 
 Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -160,7 +160,7 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -160,7 +160,7 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -149,7 +149,7 @@ ruby -v
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -149,7 +149,7 @@ ruby -v
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -109,7 +109,7 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://www.hackety.com/
 [4]: http://mislav.uniqpath.com/poignant-guide/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -109,7 +109,7 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://www.hackety.com/
 [4]: http://mislav.uniqpath.com/poignant-guide/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -159,7 +159,7 @@ là một nơi tuyệt vời.
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -159,7 +159,7 @@ là một nơi tuyệt vời.
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -121,7 +121,7 @@ ruby -v
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -121,7 +121,7 @@ ruby -v
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -112,7 +112,7 @@ lang: zh_tw
 
 
 
-[1]: http://tryruby.org/
+[1]: https://easydatawarehousing.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -112,7 +112,7 @@ lang: zh_tw
 
 
 
-[1]: https://easydatawarehousing.github.io/TryRuby/
+[1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
 [3]: http://rubymonk.com/
 [4]: http://www.hackety.com/


### PR DESCRIPTION
Fixes issue ruby/www.ruby-lang.org#1182 change all TryRuby links from http://tryruby.org/ to https://easydatawarehousing.github.io/TryRuby/