### PR TITLE
remove rubydox.net

### DIFF
--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -127,15 +127,12 @@ pour les nombreuses façons d'obtenir Ruby.
 : Documentation sur les API Ruby et Ruby On Rails, proposant un système
   de recherche poussé.
 
-[RubyDox][22]
-: Documentation pour Ruby, Rails, gems et plugin Rails.
-
 ### Lectures additionnelles
 
-[Ruby-Doc.org][23] maintient à jour une liste presque exhaustive de la
+[Ruby-Doc.org][22] maintient à jour une liste presque exhaustive de la
 documentation disponible en anglais. Il existe également de nombreux
-ouvrages à propos de Ruby : [une liste de livres en anglais][24]
-(relativement exhaustive) et [une liste de livres en français][25]
+ouvrages à propos de Ruby : [une liste de livres en anglais][23]
+(relativement exhaustive) et [une liste de livres en français][24]
 (incomplète). Par ailleurs, si vous avez des questions à poser sur Ruby,
 la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 à explorer.
@@ -162,7 +159,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [20]: http://rubydoc.info/
 [21]: http://rubydocs.org/
-[22]: http://www.rubydox.net/
-[23]: http://ruby-doc.org
-[24]: http://www.ruby-doc.org/bookstore
-[25]: http://rubyfrance.org/liens/livres/
+[22]: http://ruby-doc.org
+[23]: http://www.ruby-doc.org/bookstore
+[24]: http://rubyfrance.org/liens/livres/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -95,13 +95,11 @@ referanslar ve diğer belgeleri bulacaksınız.
 [Ruby & Rails Searchable API Docs][20]
 : Akıllı arama özellikleri olan Rails ve Ruby dökümantasyonu.
 
-[RubyDox][21]
-: Ruby, Rails, Gem ve Plugin Belgeleri.
 
 ### Diğer Belgeler
 
-[Ruby-Doc.org][22] Ruby hakkındaki İngilizce belgeleri bir araya
-toplamayı amaçlayan bir site. [Ruby hakkında yazılmış kitaplar][23] da
+[Ruby-Doc.org][21] Ruby hakkındaki İngilizce belgeleri bir araya
+toplamayı amaçlayan bir site. [Ruby hakkında yazılmış kitaplar][22] da
 bakılacak diğer kaynaklardan. [Ruby Garden Wiki][9] adresinde
 kullanıcıların oluşturduğu geniş bir içerik mevcut. Ayrıca Ruby hakkında
 aklınıza takılan herhangi bir soru için [e-posta
@@ -128,6 +126,5 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 [17]: http://www.ruby-doc.org/stdlib
 [19]: http://www.rubydoc.info/
 [20]: http://rubydocs.org/
-[21]: http://www.rubydox.net/
-[22]: http://ruby-doc.org
-[23]: http://www.ruby-doc.org/bookstore
+[21]: http://ruby-doc.org
+[22]: http://www.ruby-doc.org/bookstore


### PR DESCRIPTION
rubydox.net is dead and no longer about ruby.
It appears it is now a website promoting an online casino (and potential scam) and should be removed.