### PR TITLE
Fix url of maglev

### DIFF
--- a/bg/about/index.md
+++ b/bg/about/index.md
@@ -214,6 +214,6 @@ Ruby притежава множество други черти, като ня�
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/de/about/index.md
+++ b/de/about/index.md
@@ -249,6 +249,6 @@ November 2001.
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/en/about/index.md
+++ b/en/about/index.md
@@ -233,6 +233,6 @@ Here’s a list:
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/id/about/index.md
+++ b/id/about/index.md
@@ -251,6 +251,6 @@ di Ruby, dalam Bahasa Inggris), 22 Desember 2003.
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/ja/about/index.md
+++ b/ja/about/index.md
@@ -201,6 +201,6 @@ MRI以外のRuby処理系には以下のようなものがあります。
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/ko/about/index.md
+++ b/ko/about/index.md
@@ -186,6 +186,6 @@ MRI가 지원하지 않는 특별한 기능을 가지거나 합니다.
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/pl/about/index.md
+++ b/pl/about/index.md
@@ -237,6 +237,6 @@ Tu jest lista:
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/pt/about/index.md
+++ b/pt/about/index.md
@@ -249,6 +249,6 @@ Nov. 2001.
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/ru/about/index.md
+++ b/ru/about/index.md
@@ -245,6 +245,6 @@ Ruby как язык имеет несколько разных имплемен
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org

--- a/zh_cn/about/index.md
+++ b/zh_cn/about/index.md
@@ -152,6 +152,6 @@ Ruby 还有其他众多特性，下面列举一些：
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
-[maglev]: http://ruby.gemstone.com
+[maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org


### PR DESCRIPTION
it seems to be changed to github pages. I can't access the old one.