### PR TITLE
Translate CVE-2018-8778: Buffer under-read in String#unpack news (id)

### DIFF
--- a/id/news/_posts/2018-03-28-buffer-under-read-unpack-cve-2018-8778.md
+++ b/id/news/_posts/2018-03-28-buffer-under-read-unpack-cve-2018-8778.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "CVE-2018-8778: Buffer under-read pada String#unpack"
+author: "usa"
+translator: "meisyal"
+date: 2018-03-28 14:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan *buffer under-read* pada *method* `String#unpack`.
+Kerentanan ini telah ditetapkan sebagai penanda CVE [CVE-2018-8778](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8778).
+
+## Detail
+
+`String#unpack` menerima penentu format sebagai parameternya, dan dapat
+dispesifikasikan posisi dari data yang di-*parsing* oleh penentu `@`.
+Jika sebuah angka yang sangat besar di-*parsing* dengan `@`, angka tersebut
+dianggap sebagai nilai negatif, dan pembacaan *out-of-buffer* terjadi.
+Sehingga, jika sebuah skrip menerima sebuah masukan dari luar sebagai *argument*
+dari `String#unpack`, penyerang dapat membaca data di *heap*.
+
+Semua pengguna yang terimbas dengan rilis ini seharusnya memperbarui segera.
+
+## Versi Terimbas
+
+* Rangkaian Ruby 2.2: 2.2.9 dan sebelumnya
+* Rangkaian Ruby 2.3: 2.3.6 dan sebelumnya
+* Rangkaian Ruby 2.4: 2.4.3 dan sebelumnya
+* Rangkaian Ruby 2.5: 2.5.0 dan sebelumnya
+* Rangkaian Ruby 2.6: 2.6.0-preview1
+* Sebelum revisi *trunk* r62992
+
+## Rujukan
+
+Terima kasih kepada [aerodudrizzt](https://hackerone.com/aerodudrizzt) telah
+melaporkan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2018-03-28 14:00:00 (UTC)


### PR DESCRIPTION
As titled. Help me to review this translation @gozali.

Thanks.