### PR TITLE
Translate CVE-2017-17742: HTTP response splitting in WEBrick news (id)

### DIFF
--- a/id/news/_posts/2018-03-28-http-response-splitting-in-webrick-cve-2017-17742.md
+++ b/id/news/_posts/2018-03-28-http-response-splitting-in-webrick-cve-2017-17742.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "CVE-2017-17742: Pemisahan respons HTTP pada WEBrick"
+author: "usa"
+"translator": "meisyal"
+date: 2018-03-28 14:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan pemisahan respons HTTP pada WEBrick yang di-*bundle*
+dengan Ruby. Kerentanan ini telah ditetapkan sebagai penanda CVE
+[CVE-2017-17742](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17742).
+
+## Detail
+
+Jika sebuah skrip menerima sebuah masukan dari luar dan mengeluarkan hasilnya
+tanpa ada modifikasi bagian dari respons HTTP, seorang penyerang dapat
+menggunakan karakter *newline* untuk mengelabui *client* bahwa respons *header*
+berhenti di sana, dan dapat menginjeksi respons HTTP palsu setelah karakter
+*newline* untuk menampilkan informasi berbahaya kepada *client*.
+
+Semua pengguna yang terkena imbas ini seharusnya memperbarui segera.
+
+## Versi Terimbas
+
+* Rangkaian Ruby 2.2: 2.2.9 dan sebelumnya
+* Rangkaian Ruby 2.3: 2.3.6 dan sebelumnya
+* Rangkaian Ruby 2.4: 2.4.3 dan sebelumnya
+* Rangkaian Ruby 2.5: 2.5.0 dan sebelumnya
+* Rangkaian Ruby 2.6: 2.6.0-preview1
+* Sebelum revisi *trunk* r62968
+
+## Rujukan
+
+Terima kasih kepada Aaron Patterson <tenderlove@ruby-lang.org> yang telah
+melaporkan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2018-03-28 14:00:00 (UTC)


### PR DESCRIPTION
Another translation that needs to be reviewed by @gozali.