### PR TITLE
Move 2.3.7 to security maintenance in downloads.yml

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -10,11 +10,11 @@ stable:
 
   - 2.5.1
   - 2.4.4
-  - 2.3.7
 
 # optional
 security_maintenance:
 
+  - 2.3.7
   - 2.2.10
 
 # optional


### PR DESCRIPTION
Version 2.3.7 was moved to security maintenance in `branches.yml` with commit d2b4869282784c05c18983b79715bea16d10b362.

This PR moves 2.3.7 to security maintenance in `downloads.yml` too.