### PR TITLE
Translate CVE-2018-8779: Unintentional socket creation by poisoned NUL byte in UNIXServer and UNIXSocket (id)

### DIFF
--- a/id/news/_posts/2018-03-28-poisoned-nul-byte-unixsocket-cve-2018-8779.md
+++ b/id/news/_posts/2018-03-28-poisoned-nul-byte-unixsocket-cve-2018-8779.md
@@ -1,0 +1,46 @@
+---
+layout: news_post
+title: "CVE-2018-8779: Pembuatan socket yang tidak disengaja karena poisoned NUL byte pada UNIXServer dan UNIXSocket"
+author: "usa"
+translator: "meisyal"
+date: 2018-03-28 14:00:00 +0000
+tags: security
+lang: id
+---
+
+Ada sebuah kerentanan pembuatan *socket* yang tidak disengaja pada *method*
+`UNIXServer.open` dari pustaka *socket* yang dikemas dengan Ruby. Dan ada juga
+kerentanan akses *socket* yang tidak disengaja pada *method* `UNIXSocket.open`.
+Kerentanan ini telah ditetapkan sebagai penanda CVE [CVE-2018-8779](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8779).
+
+## Detail
+
+`UNIXServer.open` menerima *path* dari *socket* yang akan dibuat pada parameter
+pertamanya. Jika *path* mengandung NUL (`\0`) *bytes*, *method* ini mengenali
+*path* tersebut lengkap sebelum NUL *bytes*. Jika sebuah skrip menerima sebuah
+masukan dari luar sebagai argumen dari *method* ini, penyerang dapat membuat
+berkas *socket* pada *path* yang tidak diinginkan. Dan, `UNIXSocket.open` juga
+menerima *path* dari *socket* yang akan dibuat pada parameter pertamanya tanpa
+mengecek NUL *bytes* seperti `UNIXServer.open`. Sehingga, jika sebuah skrip
+menerima masukan dari luar sebagai argumen *method* ini, penyerang dapat
+menerima berkas *socket* pada *path* yang tidak diinginkan.
+
+Semua pengguna yang terimbas dengan rilis ini seharusnya segera memperbarui.
+
+## Versi Terimbas
+
+* Rangkaian Ruby 2.2: 2.2.9 dan sebelumnya
+* Rangkaian Ruby 2.3: 2.3.6 dan sebelumnya
+* Rangkaian Ruby 2.4: 2.4.3 dan sebelumnya
+* Rangkaian Ruby 2.5: 2.5.0 dan sebelumnya
+* Rangkaian Ruby 2.6: 2.6.0-preview1
+* Sebelum revisi *trunk* r62991
+
+## Rujukan
+
+Terima kasih kepada [ooooooo_q](https://hackerone.com/ooooooo_q) atas laporan
+masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2018-03-28 14:00:00 (UTC)


### PR DESCRIPTION
As usual, please help me to review this translation @gozali. Thank you.