### PR TITLE
Support of Ruby 2.2 has ended

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -29,9 +29,9 @@
   eol_date: scheduled for 2019-03-31
 
 - name: 2.2
-  status: security maintenance
+  status: eol
   date: 2014-12-25
-  eol_date: scheduled for 2018-03-31
+  eol_date: 2018-03-31
 
 - name: 2.1
   status: eol

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -15,12 +15,11 @@ stable:
 security_maintenance:
 
   - 2.3.7
-  - 2.2.10
 
 # optional
 eol:
 
-  - 2.1.10
+  - 2.2.10
 
 stable_snapshot:
 

--- a/en/news/_posts/2018-04-17-support-of-ruby-2-2-has-ended.md
+++ b/en/news/_posts/2018-04-17-support-of-ruby-2-2-has-ended.md
@@ -1,0 +1,43 @@
+---
+layout: news_post
+title: "Support of Ruby 2.2 has ended"
+author: "antonpaisov"
+translator:
+date: 2018-04-17 00:00:00 +0000
+lang: en
+---
+
+We announce that all support of the Ruby 2.2 series has ended.
+
+After the release of Ruby 2.2.7 on March 28, 2017,
+the support of the Ruby 2.2 series was in the security maintenance phase.
+Now, after one year has passed, this phase has ended.
+Therefore, on March 31, 2018, all support of the Ruby 2.2 series has ended.
+Bug and security fixes from more recent Ruby versions will no longer be
+backported to 2.2, and no further patch release of 2.2 will be released.
+We highly recommend that you upgrade to Ruby 2.5 or 2.4 as soon as possible.
+
+
+## About currently supported Ruby versions
+
+### Ruby 2.5 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+### Ruby 2.4 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+### Ruby 2.3 series
+
+Currently in security maintenance phase.
+We will never backport any bug fixes to 2.3 except security fixes.
+If a critical security issue is found, we will release an urgent fix for it.
+We are planning to end the support of the Ruby 2.3 series at the end of
+March 2019.


### PR DESCRIPTION
Replaces #1777 (without merge commit, rebased).

See discussions there.

Also fixes #1774.