### PR TITLE
Add CODEOWNERS to enable auto review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# Order alphabetically.
+# Order is important. The last matching pattern takes the most precedence.
+
+# Default owners for everything in the repo.
+*      @ruby/www-ruby-lang-org-editorial
+
+bg/    @ruby/www-ruby-lang-org-i18n
+
+de/    @ruby/www-ruby-lang-org-i18n-de
+
+en/    @ruby/www-ruby-lang-org-editorial
+
+es/    @ruby/www-ruby-lang-org-i18n-es
+
+fr/    @ruby/www-ruby-lang-org-i18n-fr
+
+id/    @ruby/www-ruby-lang-org-i18n-id
+
+it/    @ruby/www-ruby-lang-org-i18n-it
+
+ja/    @ruby/www-ruby-lang-org-i18n-ja
+
+ko/    @ruby/www-ruby-lang-org-i18n-ko
+
+pl/    @ruby/www-ruby-lang-org-i18n
+
+pt/    @ruby/www-ruby-lang-org-i18n
+
+ru/    @ruby/www-ruby-lang-org-i18n
+
+tr/    @ruby/www-ruby-lang-org-i18n
+
+vi/    @ruby/www-ruby-lang-org-i18n
+
+zh_cn/ @ruby/www-ruby-lang-org-i18n-zh_cn
+
+zh_tw/ @ruby/www-ruby-lang-org-i18n-zh_tw


### PR DESCRIPTION
This PR adds [`CODEOWNERS` file to enable automatic request review to the right team](https://help.github.com/articles/about-codeowners) for changes in each language.

Existing teams:

* [www.ruby-lang.org-i18n](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n)
* [www-ruby-lang-org-i18n-de](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-de)
* [www-ruby-lang-org-i18n-es](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-es)
* [www-ruby-lang-org-i18n-fr](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-fr)
* [www-ruby-lang-org-i18n-zh_cn](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-zh_cn)
* [www-ruby-lang-org-i18n-zh_tw](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-zh_tw)
* [www.ruby-lang.org-i18n-it](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-it)
* [www.ruby-lang.org-i18n-ja](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-ja)
* [www.ruby-lang.org-i18n-ko](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-ko)
* [www.ruby-lang.org-i18n-id](https://github.com/orgs/ruby/teams/www-ruby-lang-org-i18n-id)

What do you think?