### PR TITLE
Add TruffleRuby to the list of Ruby implementations

### DIFF
--- a/en/about/index.md
+++ b/en/about/index.md
@@ -193,18 +193,22 @@ Here’s a list:
 * [Rubinius][rubinius] is ‘Ruby written in Ruby’. Built on top of LLVM,
   Rubinius sports a nifty virtual machine that other languages are being
   built on top of, too.
-* [MacRuby][macruby] is a Ruby that’s tightly integrated with Apple’s Cocoa
-  libraries for Mac OS X, allowing you to write desktop applications
-  with ease.
+* [TruffleRuby][truffleruby] is a high performance Ruby implementation on top of
+  GraalVM.
 * [mruby][mruby] is a lightweight implementation of the Ruby language
   that can be linked and embedded within an application.
   Its development is led by Ruby’s creator Yukihiro “Matz” Matsumoto.
+* [MacRuby][macruby] is a Ruby that’s tightly integrated with Apple’s Cocoa
+  libraries for Mac OS X, allowing you to write desktop applications
+  with ease.
 * [IronRuby][ironruby] is an implementation “tightly integrated with the .NET
   Framework”.
 * [MagLev][maglev] is “a fast, stable, Ruby implementation with integrated
   object persistence and distributed shared cache”.
 * [Cardinal][cardinal] is a “Ruby compiler for [Parrot][parrot] Virtual Machine”
   (Perl 6).
+
+For a more complete list, see [Awesome Rubies][awesome-rubies].
 
 ### References
 
@@ -230,9 +234,11 @@ Here’s a list:
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
 [rubinius]: http://rubini.us
+[truffleruby]: https://github.com/oracle/truffleruby
 [macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io
 [cardinal]: https://github.com/parrot/cardinal
 [parrot]: http://parrot.org
+[awesome-rubies]: https://github.com/planetruby/awesome-rubies


### PR DESCRIPTION
* Move MacRuby below mruby since it is not actively developed.
* Add a link to Awesome Rubies for a more exhaustive list.