### PR TITLE
Add posts about Rubima 0058 published (ja)

### DIFF
--- a/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
+++ b/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
@@ -6,7 +6,7 @@ translator:
 date: 2018-08-28 21:30:00 +0000
 lang: ja
 ---
-[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0058号][3]がリリースされました([\[ruby-list:50654\]][4])。
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0058号][3]がリリースされました([\[ruby-list:50698\]][4])。
 今号は、
 
 * [巻頭言](https://magazine.rubyist.net/articles/0058/0058-ForeWord.html)

--- a/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
+++ b/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
@@ -1,0 +1,23 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0058号 発行"
+author: "miyohide"
+date: 2018-08-28 21:30:00 +0000
+lang: ja
+---
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0058号][3]がリリースされました([\[ruby-list:50654\]][4])。
+今号は、
+
+* [巻頭言](https://magazine.rubyist.net/articles/0058/0058-ForeWord.html)
+* [Rubyist Hotlinks 【第 37 回】村田賢太さん](https://magazine.rubyist.net/articles/0058/0058-Hotlinks.html)
+* [RegionalRubyKaigi レポート (68) 松江 Ruby 会議 09](https://magazine.rubyist.net/articles/0058/0058-MatsueRubyKaigi09Report.html)
+* [RegionalRubyKaigi レポート (69) 大阪 Ruby 会議 01](https://magazine.rubyist.net/articles/0058/0058-OsakaRubyKaigi01Report.html)
+* [るびまバージョンアップの裏側](https://magazine.rubyist.net/articles/0058/0058-MigrateRubima.html)
+
+ という構成となっています。
+ お楽しみください。
+
+[1]: https://ruby-no-kai.org/
+[2]: https://magazine.rubyist.net/
+[3]: https://magazine.rubyist.net/articles/0058/0058-index.html
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50698

--- a/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
+++ b/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
@@ -2,6 +2,7 @@
 layout: news_post
 title: "Rubyist Magazine 0058号 発行"
 author: "miyohide"
+translator:
 date: 2018-08-28 21:30:00 +0000
 lang: ja
 ---


### PR DESCRIPTION
@ruby/www-ruby-lang-org-i18n-ja RubiMa Editors have released Rubyist Magazine 0058 (in japanese).