### PR TITLE
Disable redirect to outdated translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,27 +1,12 @@
+---
+---
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     <title>Ruby Programming Language</title>
     <script type="text/javascript">
-      var languages = {
-        "bg":    "bg",
-        "de":    "de",
-        "es":    "es",
-        "fr":    "fr",
-        "id":    "id",
-        "it":    "it",
-        "ja":    "ja",
-        "ko":    "ko",
-        "pl":    "pl",
-        "pt":    "pt",
-        "ru":    "ru",
-        "tr":    "tr",
-        "vi":    "vi",
-        "zh-CN": "zh_cn",
-        "zh-TW": "zh_tw"
-      };
-
+      var languages = {% languages_json %};
       var code = window.navigator.language || window.navigator.userLanguage || "en";
       if (code.substr(0,2) !== "zh") { code = code.substr(0,2); }
 


### PR DESCRIPTION
I think redirecting to outdated translations is not good.
And I do not want to maintain languages map manually.
So I think it should stop to redirect automatically.
Some languages are commented out in `LANGS_MAP`, because original LANGS does not include them.
Magic number `about_6_months_ago` is to stop redirecting to `pt` which is not included in original LANGS and latest posts are 2017-12-14.

ref  #1827