### PR TITLE
Remove MacRuby from about page

### DIFF
--- a/en/about/index.md
+++ b/en/about/index.md
@@ -198,9 +198,6 @@ Here’s a list:
 * [mruby][mruby] is a lightweight implementation of the Ruby language
   that can be linked and embedded within an application.
   Its development is led by Ruby’s creator Yukihiro “Matz” Matsumoto.
-* [MacRuby][macruby] is a Ruby that’s tightly integrated with Apple’s Cocoa
-  libraries for Mac OS X, allowing you to write desktop applications
-  with ease.
 * [IronRuby][ironruby] is an implementation “tightly integrated with the .NET
   Framework”.
 * [MagLev][maglev] is “a fast, stable, Ruby implementation with integrated
@@ -235,7 +232,6 @@ For a more complete list, see [Awesome Rubies][awesome-rubies].
 [jruby]: http://jruby.org
 [rubinius]: http://rubini.us
 [truffleruby]: https://github.com/oracle/truffleruby
-[macruby]: http://www.macruby.org
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io


### PR DESCRIPTION
[MacRuby](https://github.com/MacRuby/MacRuby) hasn’t seen a release since 2012 and has been put “on an indefinite hiatus” in 2015. Therefore, I’d suggest removing it from the about page.

If you’re fine with this change, I can update the translated pages as well.