### PR TITLE
Fix redirect from http to https on rubybib.org link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -670,7 +670,7 @@ locales:
     try_ruby: &try_ruby
       url: https://ruby.github.io/TryRuby/
     rubybib: &rubybib
-      url: http://rubybib.org/
+      url: https://rubybib.org/
 
     bg:
       get_started:


### PR DESCRIPTION
This was redirecting from the http to https version of the website, it is generally best practice to avoid redirects for the user.