### PR TITLE
Remove RubyMonk and Hackety Hack links (translations)

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -33,14 +33,6 @@ ruby -v
 : Коаните помагат с научаването на синтаксиса и структурата на Ruby,
   както и със запознаването с някои основни функции и библиотеки.
 
-[RubyMonk][3]
-: Научи Ruby идиоми и уроци и решавай проблеми в твоят браузър!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">The little coder’s starter kit</q>.
-  Забавен и лесен начин да се учи програмиране с Ruby чрез използването
-  на Shoes GUI Toolkit.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Необичайна, но интересна книга, която ще ви научи на Ruby чрез
   истории, шеги и рисунки. Първоначално създадено от *why the lucky stiff*,
@@ -144,8 +136,6 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -16,10 +16,6 @@ Ruby-Programmieren sicher nützlich sein werden.
   15-minütige Tutorial erlaubt es, Ruby-Code direkt im Browser
   einzugeben! (englisch)
 
-[Hackety Hack][2]
-: Ein einfacher Weg, Programmieren in Ruby mithilfe des GUI-Toolkits
-  Shoes zu lernen. (englisch)
-
 [Why’s (Poignant) Guide to Ruby][3]
 : Ein unorthodoxes Buch um Ruby zu lernen.
 
@@ -83,7 +79,6 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 
 
 [1]: https://ruby.github.io/TryRuby/
-[2]: http://www.hackety.com/
 [3]: http://mislav.uniqpath.com/poignant-guide/
 [4]: http://www.moccasoft.de/papers/ruby_tutorial
 [5]: http://pine.fm/LearnToProgram/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -71,12 +71,6 @@ pour les nombreuses façons d'obtenir Ruby.
   vous n’avez aucunes notions de programmation, commencez par là. Une
   traduction française est [disponible en PDF][7]
 
-[Hackety Hack][8]
-: <q cite="http://www.hackety.com/">The little coder’s starter kit</q>.
-  Il s’agit d’un logiciel à vocation éducative, qui vous apprendra à
-  programmer en utilisant Ruby et le toolkit Shoes pour réaliser des
-  interfaces graphiques.
-
 [*Learning Ruby*][9]
 : Un ensemble cohérent de notes introductives sur la structure et la
   logique qui prévalent en Ruby. Tout à fait indiqué pour se
@@ -145,7 +139,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://pine.fm/LearnToProgram/
 [7]: http://www.ruby-doc.org/docs/ApprendreProgrammer/Apprendre_%E0_Programmer.pdf
-[8]: http://www.hackety.com/
 [9]: http://rubylearning.com/
 [10]: http://www.techotopia.com/index.php/Ruby_Essentials
 [11]: http://www.meshplex.org/wiki/Ruby/Ruby_on_Rails_programming_tutorials

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -35,15 +35,6 @@ mendapatkan Ruby.
   Ruby. Tujuannya adalah untuk belajar bahasa Ruby, sintaks, struktur, dan
   beberapa fungsi umum dan library. Kami juga mengajarkan budaya Ruby.
 
-[RubyMonk][3]
-: Temukan idiom Ruby, pelajari dan pecahkan masalah Ruby, semua dalam
-  browser Anda!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">Starter kit kecil untuk koder</q>.
-  Ini sebuah cara menyenangkan dan mudah untuk belajar tentang
-  pemrograman (melalui Ruby) menggunakan Shoes GUI Toolkit.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Ini sebuah buku tak konvensional tapi menarik yang akan mengajarkan Anda Ruby
   melalui cerita, humor cerdas, dan komik. Awalnya dibuat oleh *why the lucky
@@ -166,8 +157,6 @@ adalah tempat yang baik untuk memulai.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -21,14 +21,6 @@ potrà venire comodo quando vorrai programmare in Ruby.
   sua sintassi, struttura e qualche funzionalità e libreria comune. E
   anche un po’ di cultura.
 
-[RubyMonk][3]
-: Impara il lessico Ruby risolvendo problemi nel tuo browser!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">Lo starter kit del piccolo
-  programmatore</q>. Un modo facile e divertente per imparare a
-  programmare (attraverso Ruby) usando il toolkit GUI *Shoes*.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Un libro poco convenzionale ma interessante che ti insegna ad usare
   Ruby attraverso storie, battute argute e fumetti. Originariamente
@@ -145,8 +137,6 @@ iniziare.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -37,14 +37,6 @@ ruby -v
   루비 언어, 문법, 구조, 일반적인 함수들과 라이브러리를 배우는 것입니다.
   Koans에서는 문화도 가르칩니다.
 
-[RubyMonk][3] (영문)
-: 브라우저에서 루비의 관용적인 코드를 발견하거나 수업을 듣고 문제를 풀
-  수 있습니다.
-
-[Hackety Hack][4] (영문)
-: <q cite="http://www.hackety.com/">꼬꼬마 코더의 스타터 킷</q>.
-  Shoes GUI 개발환경을 사용해 루비를 통해 쉽고 재미있게 프로그래밍을 배웁니다.
-
 [Why’s (Poignant) Guide to Ruby][5] (영문)
 : 이야기, 재치, 만화를 통해 루비를 가르쳐주는 틀에 얽매이지 않는 재미있는
   책입니다. *Why the Lucky Stiff*의 저작물로 루비를 배우는 사람을 위한
@@ -158,8 +150,6 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -20,15 +20,6 @@ Znajdziesz tutaj odnośniki do podręczników, tutoriali i materiałów
   Celem jest nauczenie się języka Ruby, składni, struktury i
    pewnych popularnych funkcji i bibliotek. Nauczenie również kultury.
 
-[RubyMonk][3]
-: Odkryj dialekt Rubiego, weź lekcje i rozwiązuj problemy, a to wszystko
-  w twojej przeglądarce!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">Zestaw startowy młodego kodera</q>.
-  Zabawny i prosty sposób na naukę programowania (poprzez Rubiego) przy
-  użyciu Shoes GUI Toolkit.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Niekonwencjonalna ale interesująca książka, która nauczy cię Rubiego
   poprzez historyjki, dowcipy i komiks. Oryginalnie stworzona przez
@@ -148,8 +139,6 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -35,15 +35,6 @@ diversas maneiras de obter o Ruby.
   O objetivo é aprender a linguagem, sintaxe, estrutura algumas funções e
   bibliotecas comuns do Ruby. Também ensinamos cultura.
 
-[RubyMonk][3]
-: Descubra idiomas Ruby, aprenda lições e resolva problemas, tudo
-  no seu browser!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">O kit de iniciante do programadorzinho</q>.
-  Um jeito fácil e divertido de aprender sobre programação (com Ruby)
-  usando o Shoes GUI Toolkit.
-
 [O Guia (Comovente) de Ruby do Why][5]
 : UM livro inconveniente, porém interessante, que te ensinará Ruby através
   de histórias, humor e quadrinhos. Originalmente criado por *why the lucky
@@ -162,8 +153,6 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://why.carlosbrando.com/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -34,15 +34,6 @@ ruby -v
   ресурса – изучить язык Ruby, его синтаксис, структуру и несколько
   стандартных функций и библиотек. Так же он обучит вас культуре.
 
-[RubyMonk][3]
-: Откройте для себя идиомы Ruby, пройдите урок и решите проблемы, все в
-  вашем браузере!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">Стартовый набор маленького
-  программиста</q>. Веселый и легкий путь обучения программированию (при
-  помощи Ruby), использует графическую среду разработки Shoes.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Необычная, но интересная книга, которая научит вас Ruby посредством
   историй, шуток и комиксов. Созданное программистом *why the lucky stiff*,
@@ -151,8 +142,6 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -21,11 +21,6 @@ referanslar ve diğer belgeleri bulacaksınız.
   kullanılan yapılarını öğrenmek ama bununla beraber size kültürünü de
   öğretiyor.
 
-[Hackety Hack][3]
-: <q cite="http://www.hackety.com/">Küçük programcının başlangıç
-  kiti</q>. Shoes GUI Toolkit kullanarak Ruby programlamayı öğrenmek
-  için eğlenceli ve koly bir yol.
-
 [Why’s (Poignant) Guide to Ruby][4]
 : Ruby’nin hikayelerle, nüktelerle ve karikatürlerle anlatıldığı
   sıradışı ama ilginç bir kitap. Orjinali *why the lucky stiff*
@@ -109,7 +104,6 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://www.hackety.com/
 [4]: http://mislav.uniqpath.com/poignant-guide/
 [5]: http://pine.fm/LearnToProgram/
 [6]: http://rubylearning.com/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -34,15 +34,6 @@ việc cài đặt Ruby.
   bạn kiến thức về ngôn ngữ, cú pháp, cấu trúc và một số hàm và thư viện phổ
   dụng của Ruby.
 
-[RubyMonk][3]
-: Khám phá các thành ngữ của Ruby, học các bài học và giải quyết những bài tập,
-  tất cả trên trình duyệt của bạn!
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">Nhập môn Ruby cho người không có kinh
-  nghiệm lập trình</q>.  Một cách thích thú và dễ dàng để học về lập trình
-  (thông qua Ruby) sử dụng bộ công cụ Shoes GUI.
-
 [Why’s (Poignant) Guide to Ruby][5]
 : Một cuốn sách thú vị và độc đáo, dạy bạn Ruby qua các mẩu truyện tranh vui
   nhộn. Ban đầu được tạo ra bởi *why the lucky stiff*. Sách này được xem là
@@ -161,8 +152,6 @@ là một nơi tuyệt vời.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -25,12 +25,6 @@ ruby -v
 [Ruby Koans][2]
 : Ruby Koans 可以指引你走过学习 Ruby 的启蒙之路。在这里可以学到 Ruby 语言的语法、结构、常用函数和库。当然，还有 Ruby 文化。
 
-[RubyMonk][3]
-: 探索 Ruby 的习惯用法，学习课程，解决问题，只需要浏览器就可完成！
-
-[Hackety Hack][4]
-: “小小程序员的入门工具。”使用 Shoes GUI 工具包趣学（Ruby）编程。
-
 [Why’s (Poignant) Guide to Ruby][5]
 : 一本不同寻常但是非常有趣的书，通过故事、幽默和漫画教你 Ruby。由 *why the luckystiff* 创作, 本书始终是学习 Ruby 的经典之作。
 
@@ -123,8 +117,6 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -16,13 +16,6 @@ lang: zh_tw
 : Ruby Koans 導引你走上學習 Ruby 的啟蒙之路。可以學到 Ruby 語言、語法、結構、常用函數與函式庫。
   當然也少不了 Ruby 的文化。
 
-[RubyMonk][3] （monk：修行的僧侣）
-: 探索 Ruby 的慣用法、學習課程，解決問題，在瀏覽器內便可完成！
-
-[Hackety Hack][4]
-: <q cite="http://www.hackety.com/">程式設計師的新手包</q>.
-  一種使用叫做 Shoes 的 GUI 工具，來學習如何用 Ruby 寫程式，有趣又簡單。
-
 [Why’s (Poignant) Guide to Ruby][5]
 : 非比尋常但玩味無窮的書，透過故事、幽默與漫畫來教會你 Ruby。由 *why the lucky
   stiff* 創作，本書是學習 Ruby 的經典大作。
@@ -114,8 +107,6 @@ lang: zh_tw
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[3]: http://rubymonk.com/
-[4]: http://www.hackety.com/
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials


### PR DESCRIPTION
As mentioned on #1831, Ruby Monk and Hackety links are broken. I removed that links not only for Bahasa Indonesia but also other languages.
cc: @stomar @hsbt 