### PR TITLE
Fix broken link to MORPHA on Success Stories (en)

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -62,7 +62,7 @@ lang: bg
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -77,7 +77,7 @@ you’ll find a small sample of real world usage of Ruby.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -66,7 +66,7 @@ témoignages du « monde réel. »
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
 [5]: http://www.torontorehab.com
-[6]: http://www.morpha.de/php_e/index.php3
+[6]: http://www.morpha.de/
 [7]: http://ods.org/
 [8]: http://www.lucent.com/
 [9]: http://www.level3.com/

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -87,7 +87,7 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 [11]: http://www.larc.nasa.gov/
 [12]: http://www.motorola.com
 [13]: http://www.torontorehab.com
-[14]: http://www.morpha.de/php_e/index.php3
+[14]: http://www.morpha.de/
 [15]: http://ods.org/
 [16]: http://www.lucent.com/
 [17]: http://www.level3.com/

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -75,7 +75,7 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/ko/documentation/success-stories/index.md
+++ b/ko/documentation/success-stories/index.md
@@ -72,7 +72,7 @@ lang: ko
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -83,7 +83,7 @@ Rubiego w rzeczywistości.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -76,7 +76,7 @@ Aqui você encontrará uma pequena amostra do uso de Ruby no mundo real.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/ru/documentation/success-stories/index.md
+++ b/ru/documentation/success-stories/index.md
@@ -79,7 +79,7 @@ lang: ru
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com/
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -76,7 +76,7 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.sketchup.com/
 [3]: http://www.torontorehab.com
-[4]: http://www.morpha.de/php_e/index.php3
+[4]: http://www.morpha.de/
 [5]: http://ods.org/
 [6]: http://www.lucent.com/
 [7]: http://www.level3.com/

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -71,7 +71,7 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/zh_cn/documentation/success-stories/index.md
+++ b/zh_cn/documentation/success-stories/index.md
@@ -57,7 +57,7 @@ lang: zh_cn
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -52,7 +52,7 @@ lang: zh_tw
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: http://www.torontorehab.com
-[5]: http://www.morpha.de/php_e/index.php3
+[5]: http://www.morpha.de/
 [6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/


### PR DESCRIPTION
The link was broken and going to a 404 page, so changing to point to the
root of the domain.

[Success Stories](https://www.ruby-lang.org/en/documentation/success-stories/)