### PR TITLE
Remove del.icio.us links as website is no longer

### DIFF
--- a/bg/community/weblogs/index.md
+++ b/bg/community/weblogs/index.md
@@ -19,8 +19,7 @@ lang: bg
 
 ### Популявизиране на Ruby
 
-Ако поддържате Ruby блог Ви препоръчваме да го добавите в
-[del.icio.us][12] с *ruby* таг. Също така можете да се свържете с
+Също така можете да се свържете с
 гореспоменатите блогове ако имате интересни статии върху общи теми.
 
 Ruby е популярна тема в [Digg][13], [Slashdot][14], [reddit][15],
@@ -32,7 +31,6 @@ Ruby е популярна тема в [Digg][13], [Slashdot][14], [reddit][15],
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/de/community/weblogs/index.md
+++ b/de/community/weblogs/index.md
@@ -39,8 +39,7 @@ empfehlen:
 
 ### Weitersagen
 
-Wer ein eigenes Blog zum Thema Ruby hat, sollte es auf [del.icio.us][12]
-mit dem Tag *ruby* versehen. Die oben genannten Blogs sind ebenfalls
+Die oben genannten Blogs sind ebenfalls
 gute Anlaufstellen, um dort eigene Themen anderen bereitzustellen. (Wenn
 es offensichtlich nichts mit Rails zu tun hat, wird das *Riding Rails*
 Team eventuell nicht daran interessiert sein, aber man weiß ja nie).
@@ -56,6 +55,5 @@ Thema. Wer interessanten Code findet, sollte sich dort melden.
 [9]: http://www.rubyinside.com/
 [10]: http://oreillynet.com/ruby/
 [11]: http://weblog.rubyonrails.org/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/

--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -35,8 +35,7 @@ updates.
 
 ### Spreading the Word
 
-If you’ve got a Ruby blog you’ve started, it’s wise to link the blog on
-[del.icio.us][12] with the *ruby* tag. You might also contact the
+You might also contact the
 weblogs above, if you are covering a topic they’d be interested in.
 (Obviously, if it’s not Rails-related, then the *Riding Rails* crew may
 not be as interested—but you never know.)
@@ -53,7 +52,6 @@ some brilliant code out there, be sure to let them know!
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/fr/community/weblogs/index.md
+++ b/fr/community/weblogs/index.md
@@ -34,9 +34,7 @@ Quelques blogs se démarquent par la fréquence de leur mise-à-jour.
 
 ### Participer
 
-Si vous venez de lancer votre propre blog sur Ruby, il serait
-intéressant de vous inscrire sur [del.icio.us][13] avec le *tag*
-**ruby**. Vous pourriez aussi contacter les blogs mentionnés ci-dessus,
+Vous pourriez aussi contacter les blogs mentionnés ci-dessus,
 si vous parlez d’un sujet susceptible de les intéresser.
 
 Ruby est également un sujet récurrent sur [Digg][14] et [Slashdot][15].
@@ -48,7 +46,6 @@ Ruby est également un sujet récurrent sur [Digg][14] et [Slashdot][15].
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
 [12]: http://newsforwhatyoudo.com/groups/643ddee01cd911deaef1001aa018681c/news
-[13]: http://del.icio.us
 [14]: http://digg.com/programming
 [15]: http://developers.slashdot.org/
 [16]: http://news.humancoders.com/t/ruby

--- a/id/community/weblogs/index.md
+++ b/id/community/weblogs/index.md
@@ -34,9 +34,7 @@ signifikan.
 
 ### Dari Mulut ke Mulut
 
-Apabila Anda mempunyai Ruby blog atau baru saja memulainya, Anda
-disarankan untuk memasukkan *link*-nya ke [del.icio.us][15] dengan tag
-*ruby*. Anda bisa juga menghubungi blog-blog yang disebutkan di atas,
+Anda bisa juga menghubungi blog-blog yang disebutkan di atas,
 apabila blog Anda mencakup topik yang relevan. (Tentu saja, apabila blog
 Anda tidak berhubungan dengan Rails, maka tim *Riding Rails* tidak akan
 tertarik—tapi mungkin saja sebaliknya.)
@@ -54,6 +52,5 @@ tersebut!
 [12]: http://weblog.rubyonrails.org/
 [13]: http://www.rubyinside.com/
 [14]: http://www.rubyist.net/~matz/
-[15]: http://del.icio.us
 [16]: http://digg.com/programming
 [17]: http://developers.slashdot.org/

--- a/it/community/weblogs/index.md
+++ b/it/community/weblogs/index.md
@@ -28,8 +28,7 @@ aggiornamenti.
 
 ### Partecipa e fatti conoscere
 
-Se hai iniziato un blog su Ruby, puoi linkare il tuo blog su
-[del.icio.us][12] con la tag *ruby*. Puoi anche contattare i blog di cui
+Puoi anche contattare i blog di cui
 sopra, se stai coprendo un soggetto nel quale sono interessati.
 (Ovviamente, se non è in relazione con Rails, allora la gente di *Riding
 Rails* può non essere interessata—ma non si sa mai).
@@ -45,7 +44,6 @@ di codice particolarmente brillanti, assicurati di farglielo sapere!
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/ko/community/weblogs/index.md
+++ b/ko/community/weblogs/index.md
@@ -26,8 +26,7 @@ lang: ko
 
 ### 널리 알리기
 
-직접 루비 블로그를 하고 있다면, [del.icio.us][12]에 *ruby* 태그를 붙여서
-링크하시는 것이 좋습니다. 위의 웹로그들이 관심을 가질 만한 주제를 다루고
+위의 웹로그들이 관심을 가질 만한 주제를 다루고
 계신다면 그들과 접촉하는 것도 방법입니다. (레일즈에 관련된 정보가 아니라면
 당신은 모르겠지만 아마 *Riding Rails*에서는 관심없을 것입니다.)
 
@@ -40,7 +39,6 @@ lang: ko
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/pt/community/weblogs/index.md
+++ b/pt/community/weblogs/index.md
@@ -29,8 +29,7 @@ atualizações.
 
 ### Divulgando a Palavra
 
-Se você iniciou um blog sobre Ruby, é inteligente criar um link para o blog
-no [del.icio.us][12] com a tag *ruby*. Você também poderá contatar os blogs
+Você também poderá contatar os blogs
 acima, se você estiver cobrindo um tópico no qual eles possam se interessar.
 (Obviamente, se não é um blog relacionado a Rails, a equipe do *Riding Rails*
 pode não estar interessada – mas nunca se sabe.)
@@ -45,7 +44,6 @@ Se encontrar algum código brilhante, lembre-se de avisá-los!
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/ru/community/weblogs/index.md
+++ b/ru/community/weblogs/index.md
@@ -28,8 +28,7 @@ lang: ru
 
 ### Распространение в мире
 
-Если вы ведете свой Ruby блог, полезным будет поделиться ссылкой на него
-на [del.icio.us][12] с тегом *ruby*. Вы можете также связаться с
+Вы можете также связаться с
 администраторами блогов выше, если вы освещаете интересную им тему.
 (очевидно, что если это не относится к Rails, то команда *Riding Rails*
 может быть не особо заинтересована – но кто знает)
@@ -45,7 +44,6 @@ Ruby также довольно частая тема на [Digg][13], [Slashdo
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby

--- a/vi/community/weblogs/index.md
+++ b/vi/community/weblogs/index.md
@@ -25,8 +25,7 @@ Một vài trang blog nổi bật về sự nhanh chóng và tần số cập nh
 
 ### Phổ biến từ khóa
 
-Nếu như bạn đã bắt đầu với một blog nào đó trước đây, hãy liên kết blog đó với trang
-[del.icio.us][12] bằng từ khóa *ruby*. Ngoài ra bạn cũng có thể liên hệ với
+Ngoài ra bạn cũng có thể liên hệ với
 các blog trên nếu bạn đang theo dõi một chủ đề nào đó mà họ cũng đang quan tâm.
 (Tất nhiên, nếu chủ đề đó không liên quan đến Rails thì nhóm *Riding Rails*
 có lẽ sẽ không quan tâm lắm —nhưng biết đâu đấy.)
@@ -41,7 +40,6 @@ Nếu như bạn tìm được một số đoạn mã hay trên mạng, hãy nó
 [9]: http://weblog.rubyonrails.org/
 [10]: http://www.rubyinside.com/
 [11]: http://www.rubyist.net/~matz/
-[12]: http://del.icio.us
 [13]: http://digg.com/programming
 [14]: http://developers.slashdot.org/
 [15]: http://www.reddit.com/r/ruby


### PR DESCRIPTION
The website claims to come back in July, but it seems like that was in
2017. This happened after pinboard wanted users to use its own service
after acquiring the website.