### PR TITLE
Update link to Toronto Rehab (translations)

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -61,7 +61,7 @@ lang: bg
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/de/documentation/success-stories/index.md
+++ b/de/documentation/success-stories/index.md
@@ -56,7 +56,7 @@ Projekten, die Ruby nutzen.
 
 
 [1]: http://www.motorola.com
-[2]: http://www.torontorehab.com
+[2]: https://www.uhn.ca/TorontoRehab
 [3]: http://www.morpha.de/php_d/index.php3
 [4]: http://ods.org/
 [5]: http://www.lucent.com/

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -76,7 +76,7 @@ you’ll find a small sample of real world usage of Ruby.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -65,7 +65,7 @@ témoignages du « monde réel. »
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
-[5]: http://www.torontorehab.com
+[5]: https://www.uhn.ca/TorontoRehab
 [6]: http://www.morpha.de/php_e/index.php3
 [7]: http://ods.org/
 [8]: http://www.lucent.com/

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -86,7 +86,7 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 [10]: http://wiki.rubyonrails.com/rails/pages/RealWorldUsage
 [11]: http://www.larc.nasa.gov/
 [12]: http://www.motorola.com
-[13]: http://www.torontorehab.com
+[13]: https://www.uhn.ca/TorontoRehab
 [14]: http://www.morpha.de/php_e/index.php3
 [15]: http://ods.org/
 [16]: http://www.lucent.com/

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -74,7 +74,7 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/ko/documentation/success-stories/index.md
+++ b/ko/documentation/success-stories/index.md
@@ -71,7 +71,7 @@ lang: ko
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -82,7 +82,7 @@ Rubiego w rzeczywistości.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -75,7 +75,7 @@ Aqui você encontrará uma pequena amostra do uso de Ruby no mundo real.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/ru/documentation/success-stories/index.md
+++ b/ru/documentation/success-stories/index.md
@@ -78,7 +78,7 @@ lang: ru
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com/
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -75,7 +75,7 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.sketchup.com/
-[3]: http://www.torontorehab.com
+[3]: https://www.uhn.ca/TorontoRehab
 [4]: http://www.morpha.de/php_e/index.php3
 [5]: http://ods.org/
 [6]: http://www.lucent.com/

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -70,7 +70,7 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/zh_cn/documentation/success-stories/index.md
+++ b/zh_cn/documentation/success-stories/index.md
@@ -56,7 +56,7 @@ lang: zh_cn
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -51,7 +51,7 @@ lang: zh_tw
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
-[4]: http://www.torontorehab.com
+[4]: https://www.uhn.ca/TorontoRehab
 [5]: http://www.morpha.de/php_e/index.php3
 [6]: http://ods.org/
 [7]: http://www.lucent.com/


### PR DESCRIPTION
I updated Toronto Rehab's link from http://www.torontorehab.com to https://www.uhn.ca/TorontoRehab because the previous one is no longer available. cc: @stomar @hsbt 