### PR TITLE
Update RDoc URL for RDoc itself

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -145,7 +145,7 @@ ruby -v
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -164,7 +164,7 @@ If you have questions about Ruby the
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [16]: http://www.rubydoc.info/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -77,7 +77,7 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 [5]: http://mislav.uniqpath.com/poignant-guide/
 [6]: http://www.rubyist.net/~slagell/ruby/
 [7]: http://www.ruby-doc.org/core
-[8]: http://docs.seattlerb.org/rdoc/
+[8]: https://ruby.github.io/rdoc
 [9]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [11]: http://ruby-doc.org

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -147,7 +147,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [14]: http://www.rubyist.net/~slagell/ruby/
 [15]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [16]: http://www.ruby-doc.org/core
-[17]: http://docs.seattlerb.org/rdoc/
+[17]: https://ruby.github.io/rdoc
 [18]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [20]: http://rubydoc.info/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -161,7 +161,7 @@ adalah tempat yang baik untuk memulai.
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [16]: http://www.rubydoc.info/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -146,7 +146,7 @@ iniziare.
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -44,7 +44,7 @@ Rubyでプログラミングする際に役立つドキュメントを紹介し�
 ### リファレンス
 
 [Ruby コアリファレンス (英語)](http://www.ruby-doc.org/core/)
-: [RDoc](http://docs.seattlerb.org/rdoc/)を用いてRubyのソースコードから直接生成したものです。
+: [RDoc](https://ruby.github.io/rdoc)を用いてRubyのソースコードから直接生成したものです。
   String, ArrayやSymbol等のコアクラスやモジュールのリファレンスがあります。
 
 [Ruby 標準ライブラリリファレンス (英語)](http://www.ruby-doc.org/stdlib/)

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -155,7 +155,7 @@ ruby -v
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -148,7 +148,7 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -157,7 +157,7 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -151,7 +151,7 @@ ruby -v
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -116,7 +116,7 @@ listeleri](/en/community/mailing-lists/) iyi bir başlangıç olacaktır.
 [13]: http://www.belgeler.org/uygulamalar/ruby/ruby-ug.html
 [14]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [15]: http://www.ruby-doc.org/core
-[16]: http://docs.seattlerb.org/rdoc/
+[16]: https://ruby.github.io/rdoc
 [17]: http://www.ruby-doc.org/stdlib
 [19]: http://www.rubydoc.info/
 [20]: http://rubydocs.org/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -156,7 +156,7 @@ là một nơi tuyệt vời.
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [16]: http://www.rubydoc.info/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -122,7 +122,7 @@ ruby -v
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -113,7 +113,7 @@ lang: zh_tw
 [11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
-[14]: http://docs.seattlerb.org/rdoc/
+[14]: https://ruby.github.io/rdoc
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/


### PR DESCRIPTION
I found that RDoc URL of RDoc itself is too old in many pages.
http://docs.seattlerb.org/rdoc/ uses RDoc 4.1.1, but latest version https://rubygems.org/gems/rdoc is 6.0.4.

I heard current canonical URL https://ruby.github.io/rdoc from @aycabta, a maintainer of RDoc, so I substituted with it using `sed -i`.