### PR TITLE
Translation of 2018-06-20-support-of-ruby-2-2-has-ended (es)

### DIFF
--- a/es/news/_posts/2018-06-20-support-of-ruby-2-2-has-ended.md
+++ b/es/news/_posts/2018-06-20-support-of-ruby-2-2-has-ended.md
@@ -1,0 +1,48 @@
+---
+layout: news_post
+title: "Support of Ruby 2.2 has ended"
+author: "antonpaisov"
+translator: "vtamara"
+date: 2018-06-20 00:00:00 +0000
+lang: es
+---
+
+Anunciamos la terminación de todo soporte a la serie Ruby 2.2.
+
+Después de la publicación de Ruby 2.2.7 el 28 de Marzo de 2017,
+el soporte para la serie Ruby 2.2 estaba en la fase de mantenimiento de
+seguridad.
+Ahora, tras un año, esa fase ha terminado.
+Por lo tanto, el 31 de marzo de 2018, terminó todo soporte a la serie Ruby 2.2.
+Los arreglos de seguridad y a fallas de versiones más reciente de Ruby
+no se portaran a la serie 2.2, y no se publicarán más parches para la versión
+2.2.
+Recomendamos que actualice a Ruby 2.5 o 2.4 tan pronto como le sea posible.
+
+
+## Sobre las versiones de ruby que son soportadas en la actualidad
+
+### Serie Ruby 2.5
+
+Actualmente está en fase de mantenimiento normal.
+Retro-portaremos los arreglos a fallas y publicaremos nuevas versiones con las
+soluciones cuando sea necesario.
+Y si se encuentra un problema de seguridad crítico, publicaremos
+una solución urgente para el mismo.
+
+### Serie Ruby 2.4
+
+Actualmente está en fase de mantenimiento normal.
+Portaremos los arreglos a fallas y publicaremos nuevas versiones con las
+soluciones cuando sea necesario.
+Y si se encuentra un problema de seguridad crítico, publicaremos
+una solución urgente para el mismo.
+
+### Serie Ruby 2.3
+
+Actualmente está en fase de mantenimiento de seguridad.
+No portaremos soluciones a fallas a 2.3 excepto las relacionadas con
+seguridad.
+Si se encuentra un problema de seguridad crítico, publicaremos
+una solución urgente para el mismo.
+Planeamos terminar el soporte para la serie Ruby 2.3 al final de Marzo de 2019.


### PR DESCRIPTION
Helping #1606