### PR TITLE
Translate 2018-10-17-not-propagated... (es)

### DIFF
--- a/es/news/_posts/2018-10-17-not-propagated-taint-flag-in-some-formats-of-pack-cve-2018-16396.md
+++ b/es/news/_posts/2018-10-17-not-propagated-taint-flag-in-some-formats-of-pack-cve-2018-16396.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "CVE-2018-16396: Banderas de contaminación no propagadas en Array#pack y String#unpack con algunas directivas"
+author: "usa"
+translator: "vtamara"
+date: 2018-10-17 14:00:00 +0000
+tags: security
+lang: es
+---
+
+Con algunos formatos de `Array#pack` y `String#unpack`, las banderas de
+contaminación (tainted) de los datos originales no se propagan a la
+cadena/arreglo que se retorna.
+A esta vulnerabilidad se le ha asignado el identificador CVS
+[CVE-2018-16396](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16396).
+
+## Detalles
+
+El método `Array#pack` convierte el arreglo que recibe en una cadena
+con un formato especificado.  Si el arreglo recibido contiene objetos
+contaminados, la cadena retornada también debe marcarse como
+contaminada.
+El método `String#unpack` que convierte una cadena en un arreglo
+también debería propagar la bandera de contaminación a los objetos
+del arreglo que se retorna.
+Pero, con las directivas `B`, `b`, `H` y `h`, las banderas
+de contaminación no se propagan.
+Asi, que si un script procesa una entrada no confiable con `Array#pack`
+y/o `String#unpack` y chequea su confiabilidad con las banderas de
+contaminación, el chequeo podría resultar errado.
+
+Todos los usuarios que corran una versión afectada deberían actualizar
+de inmediato.
+
+## Versiones afectadas
+
+* Serie Ruby 2.3: 2.3.7 y anteriores
+* Serie Ruby 2.4: 2.4.4 y anteriores
+* Serie Ruby 2.5: 2.5.1 y anteriores
+* Serie Ruby 2.6: 2.6.0-preview2 y anteriores
+* Anteriores la revisión r65125 del trunk
+
+## Credito
+
+Agradecimientos a [Chris Seaton](https://hackerone.com/chrisseaton)
+por reportar este problema.
+
+## Historia
+
+* Publicado originalmente el 2018-10-17 14:00:00 (UTC)


### PR DESCRIPTION
Translate 2018-10-17-not-propagated-taint-flag-in-some-formats-of-pack-cve-2018-16396.md (es)