### PR TITLE
Update Blog section

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -31,7 +31,7 @@ to start:
 : Now is a fantastic time to follow Ruby’s development.
   If you are interested in helping with Ruby, start here.
 
-[Weblogs About Ruby](weblogs/)
+[Ruby Blogs](weblogs/)
 : Very little happens in the Ruby community that is not talked about on
   the blogs. We’ve got a nice list of suggestions for you here for
   getting plugged in.

--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Weblogs"
+title: "Blogs"
 lang: en
 ---
 
@@ -22,36 +22,26 @@ describing new techniques, or speculating on Ruby’s future.
 A few notable blogs stand out for the frequency and immediacy of their
 updates.
 
-* [**O’Reilly Ruby**][8] is a group blog with pertinent Ruby tutorials
-  and interviews with interesting folks from around the community.
-* [**Riding Rails**][9] is the official group blog of the Ruby on Rails
-  team. If you are running Rails, this blog is essential for
-  notification of security updates and an overall view of the wide Rails
-  community.
-* [**Ruby Inside**][10] announces interesting applications and libraries
-  from throughout the world, both Ruby and Rails.
-* [**Matz’ Blog**][11] is a Japanese blog written by Ruby’s creator.
-  Even if you can’t read all of it, it’s good to know he’s right there!
+* [**Ruby Weekly**][ruby-weekly] Although more of a newsletter than a
+  blog, Ruby Weekly is a distillation of the most interesting Ruby
+  articles and news each week.
+* [**Riding Rails**][riding-rails] is the official group blog of the
+  Ruby on Rails team. If you are running Rails, this blog is essential
+  for notification of security updates and an overall view of the wide
+  Rails community.
 
 ### Spreading the Word
 
-You might also contact the
-weblogs above, if you are covering a topic they’d be interested in.
-(Obviously, if it’s not Rails-related, then the *Riding Rails* crew may
-not be as interested—but you never know.)
+You can contact the authors of the above blogs, if you are covering a
+topic they’d be interested in.
 
-Ruby is also a common topic on [Slashdot][14], [reddit][15],
-and [Hacker News][16], in their respective programming news. If you find
-some brilliant code out there, be sure to let them know!
-
+Ruby is also a common topic on [reddit][reddit], and [Hacker News][hn],
+in their respective programming news. If you find some brilliant code
+out there, be sure to let them know!
 
 
 [rubyflow]: http://www.rubyflow.com/
 [rubyland]: http://rubyland.news/
-[8]: http://oreillynet.com/ruby/
-[9]: http://weblog.rubyonrails.org/
-[10]: http://www.rubyinside.com/
-[11]: http://www.rubyist.net/~matz/
-[14]: http://developers.slashdot.org/
-[15]: http://www.reddit.com/r/ruby
-[16]: http://news.ycombinator.com/
+[riding-rails]: http://weblog.rubyonrails.org/
+[reddit]: http://www.reddit.com/r/ruby
+[hn]: http://news.ycombinator.com/


### PR DESCRIPTION
Removed several defunct blogs:
- Ruby Inside: last updated in 2014 (4 years ago)
- O'Reilly Ruby: doesn't exist anymore
- Matz' Blog: not updated since 2014
- Slashdot link, since https://slashdot.org/index2.pl?fhfilter=Ruby
reveals almost no recent mentions of Ruby, Reddit and HN are far more
active these days.

Added:
- RubyFlow: replacement for Ruby Inside as community-submitted news
- Ruby Weekly: although not a blog, arguably the most popular news
source and since #1465 was a tough sell for a single Newsletter, I
believe it belongs on this list

Changed:
- the title was "Weblogs" even though the body uses "Blogs", let's be
consistent as "weblog" has fallen out of fashion, or rather has never
been in fashion to begin with:
https://trends.google.com/trends/explore?date=all&geo=US&q=weblog,blog

Also took the opportunity to replace number-based reference links to
make @stomar happy. Even though he hates my verbose commit messages. <3