### PR TITLE
Fix code snippets in snap post

### DIFF
--- a/en/news/_posts/2018-11-08-snap.md
+++ b/en/news/_posts/2018-11-08-snap.md
@@ -16,7 +16,7 @@ Snap is a package system developed by Canonical. It allows you to distribute a s
 On Ubuntu 16.04 or later, you can use Ruby snap with the following command:
 
 ```
-sudo snap install ruby -classic
+sudo snap install ruby --classic
 ```
 
 (If you use other Linux distributions, please refer to https://docs.snapcraft.io/installing-snapd/6735)
@@ -40,7 +40,7 @@ Our snap set `$HOME/.gem` to `GEM_HOME` and `GEM_PATH` environment variable. So 
 eval `ruby.env`
 ```
 
-Since `$HOME/.gem` is shared by multiple versions, if you switch versions and use them, you will need to recompile C extensions using the `gem pristin --extensions` command.
+Since `$HOME/.gem` is shared by multiple versions, if you switch versions and use them, you will need to recompile C extensions using the `gem pristine --extensions` command.
 
 The initial version of official Ruby snap has released during Snapcraft summit held at Canonical office in London on Nov 6-8th, 2018. Any feedbacks are welcomed at https://github.com/ruby/snap.ruby.
 

--- a/en/news/_posts/2018-11-08-snap.md
+++ b/en/news/_posts/2018-11-08-snap.md
@@ -15,22 +15,30 @@ Snap is a package system developed by Canonical. It allows you to distribute a s
 
 On Ubuntu 16.04 or later, you can use Ruby snap with the following command:
 
-    sudo snap install ruby -classic
+```
+sudo snap install ruby -classic
+```
 
 (If you use other Linux distributions, please refer to https://docs.snapcraft.io/installing-snapd/6735)
 
 Our snap uses the "channel" feature to release multiple Ruby series concurrently. For example, without specifying a channel, 2.5.3 will be installed. But if you want to use Ruby 2.4, specify the 2.4 channel like the following:
 
-    sudo snap install ruby --classic --channel=2.4/stable
+```
+sudo snap install ruby --classic --channel=2.4/stable
+```
 
 You can also use multiple channels. The following commands switch to Ruby 2.3:
 
-    sudo snap switch ruby --channel=2.3/stable
-    sudo snap refresh
+```
+sudo snap switch ruby --channel=2.3/stable
+sudo snap refresh
+```
 
 Our snap set `$HOME/.gem` to `GEM_HOME` and `GEM_PATH` environment variable. So if you want to execute commands installed by rubygems such as rails and rspec without using bundle exec, you have to add the following line to your shell rc files (like .bashrc):
 
-    eval `ruby.env`
+```
+eval `ruby.env`
+```
 
 Since `$HOME/.gem` is shared by multiple versions, if you switch versions and use them, you will need to recompile C extensions using the `gem pristin --extensions` command.
 

--- a/ja/news/_posts/2018-11-08-snap.md
+++ b/ja/news/_posts/2018-11-08-snap.md
@@ -40,6 +40,6 @@ sudo snap refresh
 eval `ruby.env`
 ```
 
-`$HOME/.gem` は複数のバージョンで共有されるため、バージョンを切り替えて利用した場合、C 拡張などは `gem pristin --extensions` コマンドを用いて再コンパイルする必要があります。
+`$HOME/.gem` は複数のバージョンで共有されるため、バージョンを切り替えて利用した場合、C 拡張などは `gem pristine --extensions` コマンドを用いて再コンパイルする必要があります。
 
 この ruby snap は 11/6-8 にロンドンの canonical オフィスで開催された snapcraft summit で初めて公式バージョンをリリースしました。不具合やフィードバックは https://github.com/ruby/snap.ruby で受け付けています。お楽しみください。

--- a/ja/news/_posts/2018-11-08-snap.md
+++ b/ja/news/_posts/2018-11-08-snap.md
@@ -15,22 +15,30 @@ snap は canonical が開発している新しいパッケージシステムで�
 
 Ubuntu 16.04 以降のディストリビューションなら以下のコマンドで snap ruby を使うことができます。
 
-    sudo snap install ruby --classic
+```
+sudo snap install ruby --classic
+```
 
 Ubuntu 以外のディストリビューションで snap を利用する場合の準備については https://docs.snapcraft.io/installing-snapd/6735 を参照してください。
 
 Ruby の snap パッケージは channel と呼ばれる機能を用いて、現在メンテナンスしているバージョンを配信しています。例えば、2018/11 現在 channel を指定しない場合は 2.5.3 がインストールされますが、2.4 を利用したい場合は以下のように指定します。
 
-    sudo snap install ruby --classic --channel=2.4/stable
+```
+sudo snap install ruby --classic --channel=2.4/stable
+```
 
 snap の機能を使うと複数の Ruby のバージョンを利用することができます。例えば、Ruby 2.3 に切り替えるには以下のコマンドを実行します。
 
-    sudo snap switch ruby --channel=2.3/stable
-    sudo snap refresh
+```
+sudo snap switch ruby --channel=2.3/stable
+sudo snap refresh
+```
 
 また、snap の制限事項として、RubyGems は `$HOME/.gem` にインストールされるように GEM_HOME と GEM_PATH を設定しています。そのため、rails や rspec などのコマンドを `bundle exec` を用いずに実行したい場合は以下の行を `.bashrc` などに設定する必要があります。
 
-    eval `ruby.env`
+```
+eval `ruby.env`
+```
 
 `$HOME/.gem` は複数のバージョンで共有されるため、バージョンを切り替えて利用した場合、C 拡張などは `gem pristin --extensions` コマンドを用いて再コンパイルする必要があります。
 


### PR DESCRIPTION
This fixes the code snippets in #1888, since double-dashes were not appearing correctly.

Before:
```
sudo snap install ruby –classic –channel=2.4/stable
```

After:
```
sudo snap install ruby -–classic -–channel=2.4/stable
```