### PR TITLE
Replace "..." with "and so on" in FAQ 1

### DIFF
--- a/en/documentation/faq/1/index.md
+++ b/en/documentation/faq/1/index.md
@@ -55,7 +55,7 @@ Ruby features:
 
 * Simple syntax,
 * Basic OO features (classes, methods, objects, and so on),
-* Special OO features (mixins, singleton methods, renaming, ...),
+* Special OO features (mixins, singleton methods, renaming, and so on),
 * Operator overloading,
 * Exception handling,
 * Iterators and closures,


### PR DESCRIPTION
This pull request replaces the text "..." with "and so on" so the two sentences about OO features are consistent with one another. Thoughts?