### PR TITLE
Make font size of code the same as of parent element

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -135,8 +135,6 @@ code {
   border: 1px solid #ddd;
   background-color: #f8f8f8;
   font-family: Consolas, "Liberation Mono", Courier, monospace;
-  font-size: 14px;
-  line-height: 16px;
   text-shadow: 0 1px 0 #fff;
   -webkit-border-radius: 3px;
      -moz-border-radius: 3px;

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -46,6 +46,7 @@ a:hover { color: #0086b3; }
 
 p {
   margin: 20px 0;
+  line-height: 1.4rem;
   text-rendering: optimizeLegibility;
 }
 


### PR DESCRIPTION
Let code be same size as parent containing element. Someone should check this before deploying to production.