### PR TITLE
Remove duplicate `status` and use expected `date` key for 2.6 branch

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -10,7 +10,7 @@
 
 - name: 2.6
   status: normal maintenance
-  status: 2018-12-25
+  date: 2018-12-25
   eol_date:
 
 - name: 2.5


### PR DESCRIPTION
Ruby 2.6 release date is listed with the `status` key instead of the `date` key in the branches page, with the result that the branch actual status is not shown and the release date is in the wrong position.

This PR fixes the issue, restoring the correct keys.