### PR TITLE
Update about/website/index.md with supporting orgs (pt)

### DIFF
--- a/pt/about/website/index.md
+++ b/pt/about/website/index.md
@@ -34,12 +34,15 @@ e outros colaboradores deste website.
 
 Também agradecemos a todas as organizações que nos dão suporte:
 
- * [NaCl][nacl] (hospedagem)
+ * [Ruby Association][rubyassociation] (hospedagem)
  * [Heroku][heroku] (hospedagem)
  * [IIJ][iij] (hospedagem)
  * [GlobalSign][globalsign] (certificação SSL)
  * [Fastly][fastly] (CDN)
-
+ * [Hatena][hatena] ([mackerel][mackerel], monitoramento do servidor)
+ * [![CloudCore][cloudcore-logo] CloudCore][cloudcore] (servidor de build)
+ * [Ruby no Kai][rubynokai] (servidor de build)
+ 
 
 [logo]: /pt/about/logo/
 [webmaster]: mailto:webmaster@ruby-lang.org
@@ -53,3 +56,9 @@ Também agradecemos a todas as organizações que nos dão suporte:
 [iij]: http://www.iij.ad.jp
 [globalsign]: https://www.globalsign.com
 [fastly]: http://www.fastly.com
+[rubyassociation]: http://www.ruby.or.jp
+[hatena]: http://hatenacorp.jp/
+[mackerel]: https://mackerel.io/
+[cloudcore]: http://www.cloudcore.jp/?utm_source=ad&utm_medium=ad&utm_content=dev&utm_campaign=vps
+[cloudcore-logo]: http://www.cloudcore.jp/develop/links/images/74x36_white.gif
+[rubynokai]: http://ruby-no-kai.org/

--- a/pt/about/website/index.md
+++ b/pt/about/website/index.md
@@ -51,12 +51,11 @@ Também agradecemos a todas as organizações que nos dão suporte:
 [github-repo]: https://github.com/ruby/www.ruby-lang.org/
 [github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
 [github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki
-[nacl]: http://www.netlab.jp
+[rubyassociation]: http://www.ruby.or.jp
 [heroku]: https://www.heroku.com/
 [iij]: http://www.iij.ad.jp
 [globalsign]: https://www.globalsign.com
 [fastly]: http://www.fastly.com
-[rubyassociation]: http://www.ruby.or.jp
 [hatena]: http://hatenacorp.jp/
 [mackerel]: https://mackerel.io/
 [cloudcore]: http://www.cloudcore.jp/?utm_source=ad&utm_medium=ad&utm_content=dev&utm_campaign=vps

--- a/pt/about/website/index.md
+++ b/pt/about/website/index.md
@@ -42,7 +42,7 @@ Também agradecemos a todas as organizações que nos dão suporte:
  * [Hatena][hatena] ([mackerel][mackerel], monitoramento do servidor)
  * [![CloudCore][cloudcore-logo] CloudCore][cloudcore] (servidor de build)
  * [Ruby no Kai][rubynokai] (servidor de build)
- 
+
 
 [logo]: /pt/about/logo/
 [webmaster]: mailto:webmaster@ruby-lang.org


### PR DESCRIPTION
This PR updates the list of supporting organizations for the Portuguese i18n file, based on the English one