### PR TITLE
Add link for Ruby Weekly

### DIFF
--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -42,6 +42,7 @@ out there, be sure to let them know!
 
 [rubyflow]: http://www.rubyflow.com/
 [rubyland]: http://rubyland.news/
+[ruby-weekly]: https://rubyweekly.com/
 [riding-rails]: http://weblog.rubyonrails.org/
 [reddit]: http://www.reddit.com/r/ruby
 [hn]: http://news.ycombinator.com/


### PR DESCRIPTION
Follow up: #1889 

There is no link for Ruby Weekly ;)
https://github.com/ruby/www.ruby-lang.org/blob/e72d59b11ef642478c3ceacc2b66490ee20262e5/en/community/weblogs/index.md#L25

Could you review this? @olivierlacan @JuanitoFatas 