### PR TITLE
Note ruby/ruby#2058 as a known issue in 2.6.0 release announcement

### DIFF
--- a/en/news/_posts/2018-12-25-ruby-2-6-0-released.md
+++ b/en/news/_posts/2018-12-25-ruby-2-6-0-released.md
@@ -113,6 +113,12 @@ With those changes, [6437 files changed, 231471 insertions(+), 98498 deletions(-
 
 Merry Christmas, Happy Holidays, and enjoy programming with Ruby 2.6!
 
+## Known Problem
+
+_(This section was added at January 28, 2019.)_
+
+* [Net::Protocol::BufferedIO#write raises NoMethodError when sending large multi-byte string](https://github.com/ruby/ruby/pull/2058)
+
 ## Download
 
 * <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz>


### PR DESCRIPTION
This [included a known issue from ruby 2.6.0](https://github.com/ruby/ruby/pull/2058).

https://github.com/ruby/ruby/pull/2058#issuecomment-458005198