### PR TITLE
Add a item to sync with English version announcement of Ruby 2.6.1 (ja)

### DIFF
--- a/ja/news/_posts/2019-01-30-ruby-2-6-1-released.md
+++ b/ja/news/_posts/2019-01-30-ruby-2-6-1-released.md
@@ -9,6 +9,8 @@ lang: ja
 
 Ruby 2.6.1 がリリースされました。
 
+* [大きな多バイト文字列を送ると Net::Protocol::BufferedIO#write で NoMethodError が発生する問題](https://bugs.ruby-lang.org/issues/15468) が修正されました。
+
 その他いくつかの不具合修正も含まれます。詳細は [commit log](https://github.com/ruby/ruby/compare/v2_6_0...v2_6_1) を参照してください。
 
 ## ダウンロード


### PR DESCRIPTION
[English announcement of Ruby 2.6.1 release announcement](https://github.com/ruby/www.ruby-lang.org/blob/8f0d8c2bd0/en/news/_posts/2019-01-30-ruby-2-6-1-released.md#changes) has a `Net::Protocol` thing, but current Japanese version doesn't.

This PR adds its translation of Japanese.