### PR TITLE
Translate Ruby 2.6.1 Released (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2019-01-30-ruby-2-6-1-released.md
+++ b/zh_tw/news/_posts/2019-01-30-ruby-2-6-1-released.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "Ruby 2.6.1 發佈"
+author: "naruse"
+translator: Vincent Lin
+date: 2019-01-30 00:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.6.1 發佈了。
+
+## 變化
+
+* 修復了[當傳送巨大多位元字串時 Net::Protocol::BufferedIO#write 會引發 NoMethodError](https://bugs.ruby-lang.org/issues/15468)。
+
+此次發佈包含了許多錯誤修正，請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v2_6_0...v2_6_1)進一步了解。
+
+## 下載
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz>
+
+      SIZE:   16742207 bytes
+      SHA1:   416842bb5b4ca655610df1f0389b6e21d25154f8
+      SHA256: 17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8
+      SHA512: 89e016e60f107fa40da251bc9659584ee3191caee726b5c6818ecbe109f825c553041a5dfda7e6d2889fcf587e63fb5d9fbe6cbdbdc4572e1123c302f0f1b881
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.zip>
+
+      SIZE:   20595342 bytes
+      SHA1:   6fd14990dc411eb58852324d45b29f84d580644d
+      SHA256: ed1537f49d333a809900c1f49ad16c4c06224ebbf5c744cb7b9104ab2a385366
+      SHA512: 8a092486ecefac5bd734897562257a576112e59d90026d0b2ada10aa0b7e0fa86ed1cd803c6254eaa21b19ba36502d9ac268eae6f5714a6eca01904117ab0da6
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2>
+
+      SIZE:   14561930 bytes
+      SHA1:   d4c92d9b0057473238df2fd4792454b43976fda3
+      SHA256: 82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099
+      SHA512: fc41429491935b89532733b95476ab9f8a4efc310aad8f4c2bd3b68fba08fd7b6e9ac84c6c88ca892022d1ba76435295f3299ea466f9b5453c07d41cb539af59
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.xz>
+
+      SIZE:   11872964 bytes
+      SHA1:   ba5f4338bb642e3836dd80b73a9df0d1b6e079ae
+      SHA256: 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+      SHA512: fb36289a955f0596c683cdadf1e4a9a9fd35222b1e1c6160c2e7cd82e5befd40a7aa4361e55f7a8f83c06ee899ec493821c7db34a60c4ac3bca0e874d33ef1a9
+
+## 發佈記
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發佈，在此感謝他們。


### PR DESCRIPTION
Translate Ruby 2.6.1 Released post (zh_tw)

- zh_tw/news/_posts/2019-01-30-ruby-2-6-1-released.md

Thank you.