### PR TITLE
Update dmoz.org to dmoztools.net (en)

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -50,5 +50,5 @@ General Ruby Information
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoztools.net/Computers/Programming/Languages/Ruby/
-[5]: http://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/en/community/index.md
+++ b/en/community/index.md
@@ -50,5 +50,5 @@ General Ruby Information
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: http://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: http://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Rails/


### PR DESCRIPTION
dmoz.org is no longer operating, but the information is still available
on dmoztools.net. I think it's worth considering changing these
resources out for more modern ones.

Again, this is a change I can make across more translations if it's
considered valuable.