### PR TITLE
Fix dmoz.org links

### DIFF
--- a/bg/community/index.md
+++ b/bg/community/index.md
@@ -47,5 +47,5 @@ Oбщността, която се образува около един език
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/de/community/index.md
+++ b/de/community/index.md
@@ -81,5 +81,5 @@ Allgemeine Information zu Ruby
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/es/community/index.md
+++ b/es/community/index.md
@@ -52,5 +52,5 @@ Información general sobre Ruby
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/fr/community/index.md
+++ b/fr/community/index.md
@@ -53,5 +53,5 @@ Informations générales
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/id/community/index.md
+++ b/id/community/index.md
@@ -65,6 +65,6 @@ Informasi Umum Tentang Ruby
 
 [2]: http://tech.groups.yahoo.com/group/id-ruby/
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/
 [6]: http://ruby.id/slack/

--- a/it/community/index.md
+++ b/it/community/index.md
@@ -52,5 +52,5 @@ Informazioni generali su Ruby
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/ko/community/index.md
+++ b/ko/community/index.md
@@ -49,5 +49,5 @@ lang: ko
   * [Rails at Open Directory Project][5]
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/pl/community/index.md
+++ b/pl/community/index.md
@@ -54,6 +54,6 @@ Ogólne informacje o Rubim
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/
 [6]: http://forum.rubyonrails.pl/

--- a/pt/community/index.md
+++ b/pt/community/index.md
@@ -49,5 +49,5 @@ Informação gerais sobre o Ruby
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/ru/community/index.md
+++ b/ru/community/index.md
@@ -49,5 +49,5 @@ lang: ru
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/tr/community/index.md
+++ b/tr/community/index.md
@@ -60,5 +60,5 @@ Genel Ruby Kaynakları
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/vi/community/index.md
+++ b/vi/community/index.md
@@ -50,5 +50,5 @@ Thông tin chung về Ruby
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/zh_cn/community/index.md
+++ b/zh_cn/community/index.md
@@ -39,6 +39,6 @@ Ruby 的一般信息
 
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/
 [ruby-china]: https://ruby-china.org

--- a/zh_tw/community/index.md
+++ b/zh_tw/community/index.md
@@ -44,5 +44,5 @@ Ruby 的一般消息
 [railsfun]: http://railsfun.tw/index.php
 
 [3]: http://rubycentral.org/
-[4]: http://dmoz.org/Computers/Programming/Languages/Ruby/
-[5]: http://dmoz.org/Computers/Programming/Languages/Ruby/Software/Rails/
+[4]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[5]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/


### PR DESCRIPTION
dmoz.org is no longer active. dmoztools.net still hosts a lot of the
same content. This commit updates those links.

This is a continuation of #1966 per @JuanitoFatas.