### PR TITLE
Translate missing parts in code examples (tr)

### DIFF
--- a/tr/examples/cities.md
+++ b/tr/examples/cities.md
@@ -4,19 +4,19 @@ layout: null
 
 {% highlight ruby %}
 # Tüm bir Array üzerinde
-# matematik işlem yapmak
+# matematik işlemi yapmak
 # isteseniz dahi
 # Ruby ne istediğinizi
 # hemen anlar
-cities  = %w[ London
-              Oslo
-              Paris
-              Amsterdam
-              Berlin ]
-visited = %w[Berlin Oslo]
+şehirler = %w[ İstanbul
+               Tokyo
+               Londra
+               Paris
+               Berlin ]
+gidilen  = %w[Berlin İstanbul]
 
 puts "Halihazırda " +
      "şu şehirleri " +
      "ziyaret etmedim:",
-     cities - visited
+     şehirler - gidilen
 {% endhighlight %}

--- a/tr/examples/cities.md
+++ b/tr/examples/cities.md
@@ -8,15 +8,15 @@ layout: null
 # isteseniz dahi
 # Ruby ne istediğinizi
 # hemen anlar
-şehirler = %w[ İstanbul
-               Tokyo
-               Londra
-               Paris
-               Berlin ]
-gidilen  = %w[Berlin İstanbul]
+cities = %w[ London
+             Oslo
+             Paris
+             Amsterdam
+             Berlin ]
+visited  = %w[Berlin Oslo]
 
-puts "Halihazırda " +
-     "şu şehirleri " +
-     "ziyaret etmedim:",
-     şehirler - gidilen
+puts "I still need " +
+     "to visit the " +
+     "following cities:",
+     cities - visited
 {% endhighlight %}

--- a/tr/examples/cities.md
+++ b/tr/examples/cities.md
@@ -13,7 +13,7 @@ cities = %w[ London
              Paris
              Amsterdam
              Berlin ]
-visited  = %w[Berlin Oslo]
+visited = %w[Berlin Oslo]
 
 puts "I still need " +
      "to visit the " +

--- a/tr/examples/greeter.md
+++ b/tr/examples/greeter.md
@@ -3,20 +3,20 @@ layout: null
 ---
 
 {% highlight ruby %}
-# Selamlama sınıfı
-class Selamlama
-  def initialize(isim)
-    @isim = isim.capitalize
+# Greeter sınıfı
+class Greeter
+  def initialize(name)
+    @name = name.capitalize
   end
 
-  def selamla
-    puts "Merhaba #{@isim}!"
+  def salute
+    puts "Hello #{@name}!"
   end
 end
 
 # Yeni bir nesne üret
-s = Selamlama.new("Dünya")
+g = Greeter.new("world")
 
-# Çıktı "Merhaba Dünya!"
-s.selamla
+# Çıktı "Hello World!"
+g.salute
 {% endhighlight %}

--- a/tr/examples/greeter.md
+++ b/tr/examples/greeter.md
@@ -4,19 +4,19 @@ layout: null
 
 {% highlight ruby %}
 # Selamlama sınıfı
-class Greeter
+class Selamlama
   def initialize(isim)
     @isim = isim.capitalize
   end
 
-  def salute
+  def selamla
     puts "Merhaba #{@isim}!"
   end
 end
 
-# Yeni bir obje üretin
-g = Greeter.new("Dünya!")
+# Yeni bir nesne üret
+s = Selamlama.new("Dünya")
 
 # Çıktı "Merhaba Dünya!"
-g.salute
+s.selamla
 {% endhighlight %}

--- a/tr/examples/hello_world.md
+++ b/tr/examples/hello_world.md
@@ -3,7 +3,7 @@ layout: null
 ---
 
 {% highlight ruby %}
-# Meşhur Merhaba Dünya
+# Meşhur Hello World
 # programı Ruby'de çok
 # basit. Şunlar gereksiz:
 #
@@ -13,5 +13,5 @@ layout: null
 #
 # İşte kodumuz:
 
-puts "Merhaba Dünya!"
+puts "Hello World!"
 {% endhighlight %}

--- a/tr/examples/hello_world.md
+++ b/tr/examples/hello_world.md
@@ -3,15 +3,15 @@ layout: null
 ---
 
 {% highlight ruby %}
-# Meşhur Hello World
+# Meşhur Merhaba Dünya
 # programı Ruby'de çok
 # basit. Şunlar gereksiz:
 #
-# * bir "main" metodu
-# * yeni satır bildirimi
-# * noktalı virgüller
+# * Bir "main" metodu
+# * Yeni satır
+# * Noktalı virgüller
 #
 # İşte kodumuz:
 
-puts "Hello World!"
+puts "Merhaba Dünya!"
 {% endhighlight %}

--- a/tr/examples/i_love_ruby.md
+++ b/tr/examples/i_love_ruby.md
@@ -4,14 +4,14 @@ layout: null
 
 {% highlight ruby %}
 # Çıktı "I love Ruby"
-say = "I love Ruby"
-puts say
+söz = "I love Ruby"
+puts söz
 
 # Çıktı "I *LOVE* RUBY"
-say['love'] = "*love*"
-puts say.upcase
+söz['love'] = "*love*"
+puts söz.upcase
 
 # Çıktı "I *love* Ruby"
 # ama 5 kere
-5.times { puts say }
+5.times { puts söz }
 {% endhighlight %}

--- a/tr/examples/i_love_ruby.md
+++ b/tr/examples/i_love_ruby.md
@@ -4,14 +4,14 @@ layout: null
 
 {% highlight ruby %}
 # Çıktı "I love Ruby"
-söz = "I love Ruby"
-puts söz
+say = "I love Ruby"
+puts say
 
 # Çıktı "I *LOVE* RUBY"
-söz['love'] = "*love*"
-puts söz.upcase
+say['love'] = "*love*"
+puts say.upcase
 
 # Çıktı "I *love* Ruby"
 # ama 5 kere
-5.times { puts söz }
+5.times { puts say }
 {% endhighlight %}


### PR DESCRIPTION
Here specifies that code examples shouldn't be translated  with an exception of comment lines: https://github.com/ruby/www.ruby-lang.org/wiki#notes-for-translators
But just translating comments, explaining code to a native and newby person is not possible; translating strings, variables and other names is also necessary.

I am not opening an issue for this because as I have seen, some changes had already been made to these examples, which violates this rule. But if it is necessary, I can open an issue and we can continue discussing the issue there. If my proposal OK, then the line in the wiki I mentioned should be edited (or deleted). I can do that, too.