### PR TITLE
Remove useless backspace in posts (zh_tw, zh_cn)

### DIFF
--- a/zh_cn/news/_posts/2018-11-06-ruby-2-6-0-preview3-released.md
+++ b/zh_cn/news/_posts/2018-11-06-ruby-2-6-0-preview3-released.md
@@ -55,7 +55,7 @@ Ruby 2.6 引入了 `RubyVM::AST` 模块。
 * 增加 `:exception` 选项，以让 `Kernel.#system` 抛出错误而不是返回 `false`。[[功能 #14386]](https://bugs.ruby-lang.org/issues/14386)
 
 * 新增 oneshot 模式 [[功能 #15022]](https://bugs.ruby-lang.org/issues/15022)
-  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
+  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
   * 为 `Coverage.start` 方法新增 `:oneshot_lines` 关键字参数。
   * 为 `Coverage.result` 方法新增 `:stop` 和 `:clear` 关键字参数。如果 `clear` 被设置为 true，它会清空计数器。如果 `stop` 被设置为 true，它会禁用覆盖测量。
   * 新增 `Coverage.line_stub`，其为从源代码新建代码覆盖存根（stub）提供了一个简单的帮助函数。

--- a/zh_cn/news/_posts/2018-12-06-ruby-2-6-0-rc1-released.md
+++ b/zh_cn/news/_posts/2018-12-06-ruby-2-6-0-rc1-released.md
@@ -56,7 +56,7 @@ Ruby 2.6 引入了 `RubyVM::AbstractSyntaxTree` 模块。
 * 增加 `:exception` 选项，以让 `Kernel.#system` 抛出错误而不是返回 `false`。[[功能 #14386]](https://bugs.ruby-lang.org/issues/14386)
 
 * 新增 oneshot 模式 [[功能 #15022]](https://bugs.ruby-lang.org/issues/15022)
-  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
+  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
   * 为 `Coverage.start` 方法新增 `:oneshot_lines` 关键字参数。
   * 为 `Coverage.result` 方法新增 `:stop` 和 `:clear` 关键字参数。如果 `clear` 被设置为 true，它会清空计数器。如果 `stop` 被设置为 true，它会禁用覆盖测量。
   * 新增 `Coverage.line_stub`，其为从源代码新建代码覆盖存根（stub）提供了一个简单的帮助函数。

--- a/zh_cn/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md
+++ b/zh_cn/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md
@@ -56,7 +56,7 @@ Ruby 2.6 引入了 `RubyVM::AbstractSyntaxTree` 模块。
 * 增加 `:exception` 选项，以让 `Kernel.#system` 抛出错误而不是返回 `false`。[[功能 #14386]](https://bugs.ruby-lang.org/issues/14386)
 
 * 新增 oneshot 模式 [[功能 #15022]](https://bugs.ruby-lang.org/issues/15022)
-  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
+  * 此模式检查「每一行代码是否都至少被执行一次」，而不是「每行代码被执行了几次」。每行代码的 hook 至多被调用一次，并会在调用后将 hook 标识移除。换句话说，移除后的代码运行将没有额外的性能开销。
   * 为 `Coverage.start` 方法新增 `:oneshot_lines` 关键字参数。
   * 为 `Coverage.result` 方法新增 `:stop` 和 `:clear` 关键字参数。如果 `clear` 被设置为 true，它会清空计数器。如果 `stop` 被设置为 true，它会禁用覆盖测量。
   * 新增 `Coverage.line_stub`，其为从源代码新建代码覆盖存根（stub）提供了一个简单的帮助函数。

--- a/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -45,7 +45,7 @@ AWS 特賞得獎者將獲得：
 GMO Pepabo 特賞將獲得：
 
 * Lolipop! 共享主機服務的標準方案十年免費，或是 Managed Cloud 的流量方案價值日幣十萬元的折價券
-* Muumuu Domain DNS 註冊服務：十年免費域名一個（限每年費用低於一萬日圓的域名）
+* Muumuu Domain DNS 註冊服務：十年免費域名一個（限每年費用低於一萬日圓的域名）
 
 IIJ GIO 特賞將獲得：
 

--- a/zh_tw/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/zh_tw/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -45,7 +45,7 @@ AWS 特賞得獎者將獲得：
 GMO Pepabo 特賞將獲得：
 
 * Lolipop! 共享主機服務的標準方案十年免費，或是 Managed Cloud 的流量方案價值日幣十萬元的折價券
-* Muumuu Domain DNS 註冊服務：十年免費域名一個（限每年費用低於一萬日圓的域名）
+* Muumuu Domain DNS 註冊服務：十年免費域名一個（限每年費用低於一萬日圓的域名）
 
 IIJ GIO 特賞將獲得：
 


### PR DESCRIPTION
Remove useless and invisible backspace(U+0008) from #1983 and #1982 

- zh_cn/news/_posts/2018-11-06-ruby-2-6-0-preview3-released.md
- zh_cn/news/_posts/2018-12-06-ruby-2-6-0-rc1-released.md
- zh_cn/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md
- zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
- zh_tw/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md

Thank you.😀
