### PR TITLE
Revive YAML front matter

### DIFF
--- a/admin/translation-status/index.html
+++ b/admin/translation-status/index.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
to enable liquid tags again.
This partially reverts 2c8ff6b80a1d8fb2b8b86e38996fdd7e6b8c491d.