### PR TITLE
Validate with libtidy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ rvm: 2.6.2
 cache: bundler
 env:
   - TASK=ci
-before_install: gem install bundler:2.0.1
+before_install:
+  - gem install bundler:2.0.1
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/htacg/tidy-html5/releases/download/5.4.0/tidy-5.4.0-64bit.deb; sudo apt-get remove '^libtidy.*';  sudo dpkg -i tidy-5.4.0-64bit.deb; fi
 script: bundle exec rake $TASK
 # Notifications, used by our Gitter channel.
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,5 @@ end
 group :development do
   gem 'minitest'
   gem 'spidr', '~> 0.6'
-  gem 'validate-website', '~> 1.6'
+  gem 'validate-website', '~> 1.9'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,17 +77,17 @@ GEM
     sq_mini_racer (0.2.4.sqreen2)
     sqreen (1.17.0)
       sq_mini_racer (~> 0.2.4.sqreen2)
-    tidy_ffi (0.1.6)
+    tidy_ffi (1.0.0)
       ffi (~> 1.2)
     unicorn (5.5.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    validate-website (1.9.2)
+    validate-website (1.9.3)
       crass (~> 1)
       paint (~> 2)
       slop (~> 4.6)
       spidr (~> 0.6)
-      tidy_ffi (~> 0.1)
+      tidy_ffi (~> 1.0)
       w3c_validators (~> 1.3)
     w3c_validators (1.3.4)
       json (>= 1.8)
@@ -108,7 +108,7 @@ DEPENDENCIES
   spidr (~> 0.6)
   sqreen
   unicorn
-  validate-website (~> 1.6)
+  validate-website (~> 1.9)
 
 RUBY VERSION
    ruby 2.6.2p48

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tr vi zh_cn zh_tw]
 CONFIG = "_config.yml"
 
 task :default => [:build]
-task :ci      => [:test, :build]
+task :ci      => [:test, :build, 'check:markup']
 
 desc "Build the Jekyll site"
 task :build do


### PR DESCRIPTION
ref https://github.com/ruby/www.ruby-lang.org/pull/1420

Use libtidy https://github.com/htacg/tidy-html5 to check the build-ed `_site` generated on CI.
Also update validate-website gem.

Time ~ 10sec for `check:markup` cf https://travis-ci.org/ruby/www.ruby-lang.org/builds/504098647#L590

### Why?

Since #832 we can see that errors happen on markup even it we are using markdown on most of the pages (cf #1418, #1458, #1987 )

The main blocker before was that it increase build time but the complete website check take now ~10sec to ~12sec

cc @stomar @hsbt 