### PR TITLE
Use Ruby 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-rvm: 2.5.1
+rvm: 2.6.1
 cache:
   bundler: true
 script: bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby ENV['CUSTOM_RUBY_VERSION'] || '~> 2.5.1'
+ruby ENV['CUSTOM_RUBY_VERSION'] || '~> 2.6.1'
 
 gem 'rake'
 gem 'jekyll', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ DEPENDENCIES
   validate-website (~> 1.6)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.1p33
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
@hsbt 

This updates the site to use Ruby 2.6.1. I do not merge myself since currently I can not test the deploy.

I confirmed that the generated `_site` did not change, using `diff -qr`.