### PR TITLE
Paralleling Travis jobs to shorten build duration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ sudo: false
 rvm: 2.6.1
 cache:
   bundler: true
-script: bundle exec rake ci
+env:
+  matrix:
+    - SCRIPT="bundle exec rake build"
+    - SCRIPT="bundle exec rake test"
+script: $SCRIPT
 # Notifications, used by our Gitter channel.
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 sudo: false
 rvm: 2.6.1
-cache:
-  bundler: true
+cache: bundler
 env:
   matrix:
     - SCRIPT="bundle exec rake build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ sudo: false
 rvm: 2.6.1
 cache: bundler
 env:
-  matrix:
-    - SCRIPT="bundle exec rake build"
-    - SCRIPT="bundle exec rake test"
-script: $SCRIPT
+  - TASK=build
+  - TASK=test
+script: bundle exec rake $TASK
 # Notifications, used by our Gitter channel.
 notifications:
   webhooks:


### PR DESCRIPTION
Fixed the in-between travis build caching problem and makes the jobs parallel making easier to identify an eventual issue.