### PR TITLE
Podcast page tweaks (en)

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -43,9 +43,10 @@ to start:
   the Ruby community.
 
 [Podcasts](podcasts/)
-: If you like to hear about Ruby rather than read about you can listen
-  to podcasts which cover new Ruby or gem releases, interviews and
-  discussions between Ruby programmers, contributors, and maintainers.
+: If you prefer to listen to discussions about Ruby rather than read,
+  you can tune into one of these awesome Ruby podcasts. These Rubyists
+  use their podcasts to cover new releases, community news, and
+  interview their fellow Ruby developers.
 
 General Ruby Information
 : * [Ruby Central][ruby-central]

--- a/en/community/podcasts/index.md
+++ b/en/community/podcasts/index.md
@@ -14,5 +14,12 @@ Listen to news, interviews, and discussions about Ruby and its community.
 : The Ruby on Rails Podcast, a weekly conversation about Ruby on Rails,
   open source software, and the programming profession.
 
+### Getting Involved
+
+Podcast hosts are always looking for guests. If you have some Ruby
+wisdom to share, get in touch with the creators of these shows.
+
+You can also start your own Ruby podcast and get added to this list!
+
 [rorpodcast]: http://5by5.tv/rubyonrails
 [rogues]: https://devchat.tv/ruby-rogues


### PR DESCRIPTION
Following the changes from #1466, I wanted suggest a couple of tweaks.

Add a CTA to the podcasts page

I really like the "Spreading the Word" CTA on the Ruby blogs page and
wanted to add something similar to the podcasts page.

 Improve podcast section copy

The phrasing for this was a little confusing and there were one or two
grammar issues.