### PR TITLE
Drop parallel build jobs on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 rvm: 2.6.1
 cache: bundler
 env:
-  - TASK=build
-  - TASK=test
+  - TASK=ci
 script: bundle exec rake $TASK
 # Notifications, used by our Gitter channel.
 notifications:


### PR DESCRIPTION
For now it doesn't make sense, because build duration is not shortened
noticeably. The `test` task usually runs for only just under a second
(but as separate job adds about one minute of total runtime for setup).

Parallel builds had been introduced by #1993.