### PR TITLE
Support of Ruby 2.3 has ended

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -19,14 +19,14 @@
   eol_date:
 
 - name: 2.4
-  status: normal maintenance
+  status: security maintenance
   date: 2016-12-25
-  eol_date:
+  eol_date: scheduled for 2020-03-31
 
 - name: 2.3
-  status: security maintenance
+  status: eol
   date: 2015-12-25
-  eol_date: scheduled for 2019-03-31
+  eol_date: 2019-03-31
 
 - name: 2.2
   status: eol

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,17 +9,16 @@ stable:
 
   - 2.6.2
   - 2.5.5
-  - 2.4.6
 
 # optional
 security_maintenance:
 
-  - 2.3.8
+  - 2.4.6
 
 # optional
 eol:
 
-  - 2.2.10
+  - 2.3.8
 
 stable_snapshot:
 

--- a/en/news/_posts/2019-03-31-support-of-ruby-2-3-has-ended.md
+++ b/en/news/_posts/2019-03-31-support-of-ruby-2-3-has-ended.md
@@ -1,0 +1,43 @@
+---
+layout: news_post
+title: "Support of Ruby 2.3 has ended"
+author: "antonpaisov"
+translator:
+date: 2019-03-31 00:00:00 +0000
+lang: en
+---
+
+We announce that all support of the Ruby 2.3 series has ended.
+
+After the release of Ruby 2.3.7 on March 28, 2018,
+the support of the Ruby 2.3 series was in the security maintenance phase.
+Now, after one year has passed, this phase has ended.
+Therefore, on March 31, 2019, all support of the Ruby 2.3 series ends.
+Security and bug fixes from more recent Ruby versions will no longer be
+backported to 2.3. There won't be any patches of 2.3 either.
+We highly recommend that you upgrade to Ruby 2.6 or 2.5 as soon as possible.
+
+
+## About currently supported Ruby versions
+
+### Ruby 2.6 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+### Ruby 2.5 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+
+### Ruby 2.4 series
+
+Currently in security maintenance phase.
+We will never backport any bug fixes to 2.4 except security fixes.
+If a critical security issue is found, we will release an urgent fix for it.
+We are planning to end the support of the Ruby 2.4 series on March 31, 2020.


### PR DESCRIPTION
As Ruby 2.3 reaches its EOL on March 31, here's a post about it.
This PR should be merged on March 31.