### PR TITLE
Fix the download section of 2.4.6 release (en)

### DIFF
--- a/en/news/_posts/2019-04-01-ruby-2-4-6-released.md
+++ b/en/news/_posts/2019-04-01-ruby-2-4-6-released.md
@@ -26,22 +26,29 @@ Therefore, we recommend that you start planning to upgrade to Ruby 2.6 or 2.5.
 
 ## Download
 
-* [https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2)
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2>
+
       SIZE:   12623913 bytes
       SHA1:   b44b5c6637a69b3b95971b1937ecb583dc1de568
       SHA256: 909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02
       SHA512: 292802984e5cff6d526d817bde08216fe801d255c4cede0646e450f22d4a3a81ae612ec5d193dcc2a888e3e98b2531af845b6b863a2952bcf3fb863f95368bcf
-* [https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz)
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz>
+
       SIZE:   15880585 bytes
       SHA1:   3bc2d9ab3381887c57e0fb7937dc14e9f419f06c
       SHA256: de0dc8097023716099f7c8a6ffc751511b90de7f5694f401b59f2d071db910be
       SHA512: 7eb7720961e98e22e4335c38eeead9db96d049ef3ac1da437769b98fee7a10feb092643ce75822a2fe3bd5fd94938417ab5c2de7c6056afe0abf6e4cf03ca282
-* [https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.xz)
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.xz>
+
       SIZE:   10005544 bytes
       SHA1:   86a4fa22cb3547005ec4bfcf77489a4254226187
       SHA256: 25da31b9815bfa9bba9f9b793c055a40a35c43c6adfb1fdbd81a09099f9b529c
       SHA512: eafb2257747f99e2ed262af142e71175b70f7cceaa4d1253b92c8337f075a9a58a2d93b029d75e11a9b124f112a8f0983273b2b30afc147b5cf71a8dbb5fa0ba
-* [https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.zip](https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.zip)
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.zip>
+
       SIZE:   17469891 bytes
       SHA1:   0e55d231c0e119304e077e42923ce6a1c3daa1d1
       SHA256: c5de9f11d4b7608d57139b96f7bc94899bb2fc9dee2e192c8951f6647a9d60f7


### PR DESCRIPTION
Current

<img width="983" alt="Screenshot 2019-04-04 20 03 51" src="https://user-images.githubusercontent.com/1000669/55551116-f2718880-5714-11e9-9b1d-96ea8d94385a.png">

After

<img width="734" alt="Screenshot 2019-04-04 20 03 40" src="https://user-images.githubusercontent.com/1000669/55551117-f2718880-5714-11e9-9672-41f87b672a83.png">
