### PR TITLE
Update documentation page (id)

### DIFF
--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -4,31 +4,19 @@ title: "Dokumentasi"
 lang: id
 ---
 
-Di sini Anda akan menemukan petunjuk manual, tutorial, dan referensi yang
-akan berguna ketika Anda merasa seperti meng-*coding* di Ruby.
+Panduan, tutorial, dan materi referensi untuk membantu Anda mempelajari Ruby
+lebih lanjut
 {: .summary}
 
 ### Memasang Ruby
 
-Kecuali jika Anda hanya ingin mencoba Ruby di *browser* (lihat tautan di bawah ini)
-Anda perlu memasang Ruby di dalam komputer Anda.
-Anda dapat mengecek apakah Ruby telah tersedia dengan membuka *terminal*
-dan mengetik
+Meskipun Anda dapat dengan mudah [try Ruby pada browser Anda][1], Anda juga
+dapat membaca [panduan instalasi](installation/) untuk memasang Ruby.
 
-{% highlight sh %}
-ruby -v
-{% endhighlight %}
+### Mulai
 
-Ini seharusnya mengeluarkan informasi versi Ruby yang terpasang.
-Jika tidak, lihat [halaman instalasi](installation/) untuk berbagai pilihan
-mendapatkan Ruby.
-
-### Langkah Pertama
-
-[Try Ruby!][1]
-: Tutorial interaktif yang memungkinkan Anda mencoba Ruby tepat di browser
-  Anda. Tutorial 15 menit tersebut ditujukan pada pemula yang ingin
-  merasakan bahasanya.
+[Official FAQ](/en/documentation/faq/)
+: *Frequently asked questions* resmi.
 
 [Ruby Koans][2]
 : Ruby Koans memandu Anda sepanjang jalan menuju pencerahan untuk belajar
@@ -40,36 +28,28 @@ mendapatkan Ruby.
   melalui cerita, humor cerdas, dan komik. Awalnya dibuat oleh *why the lucky
   stiff*, panduan ini tetap klasik untuk pelajar Ruby.
 
-[Ruby dalam 20 Menit](/id/documentation/quickstart/)
-: Ini tutorial yang mencakup dasar-dasar Ruby. Dari awal sampai akhir, tutorial
-  tersebut tidak akan membawa Anda lebih dari 20 menit.
-
-[Ruby dari Bahasa Pemrograman Lain](/id/documentation/ruby-from-other-languages/)
-: Datang ke Ruby dari bahasa lain? Entah itu C, C + +, Java, Perl,
-  PHP, atau Python, artikel ini dapat menolong Anda!
-
 [Learning Ruby][6]
 : Sebuah koleksi menyeluruh dari catatan pelajaran Ruby bagi mereka yang baru ke
   bahasa Ruby dan sedang mencari pengenalan konsep dan konstruksi
   Ruby.
 
 [Ruby Essentials][7]
-: Ruby Essentials adalah buku online gratis yang dirancang untuk memberikan
+: Ruby Essentials adalah buku *online* gratis yang dirancang untuk memberikan
   panduan singkat dan mudah diikuti untuk belajar Ruby.
 
 [Learn to Program][8]
-: Tutorial kecil yang indah Chris Pine untuk pemula pemrograman. Jika
-  Anda tidak tahu bagaimana membuat program, mulai di sini.
+: Tutorial kecil yang indah oleh Chris Pine untuk pemula pemrograman. Jika
+  Anda tidak tahu bagaimana membuat program, mulai dari sini.
 
 [Learn Ruby the Hard Way][38]
-: Sebuah kumpulan latihan yang sangat baik dengan penjelasan yang memandu Anda dari
-  semua dasar Ruby hingga OOP dan pengembangan *web*.
+: Sebuah kumpulan latihan yang sangat baik dengan penjelasan yang memandu Anda
+  dari semua dasar Ruby hingga OOP dan pengembangan *web*.
 
 ### Manual
 
 [Programming Ruby][9]
 : Ini salah satu karya penting untuk pemrograman Ruby dalam Bahasa Inggris.
-  Edisi pertama [Pragmatic Programmers’ book][10] ini tersedia gratis online.
+  Edisi pertama [Pragmatic Programmers’ book][10] ini tersedia gratis *online*.
 
 [Ruby User’s Guide][11]
 : Diterjemahkan dari versi Jepang asli ditulis oleh Yukihiro
@@ -77,19 +57,23 @@ mendapatkan Ruby.
   Mark Slagell adalah gambaran baik dari banyak aspek dari bahasa Ruby.
 
 [The Ruby Programming Wikibook][12]
-: Manual online gratis dengan konten untuk pemula dan menengah ditambah
+: Manual *online* gratis dengan konten untuk pemula dan menengah ditambah
   referensi bahasa Ruby secara menyeluruh.
 
 ### Referensi
 
+[Official API Documentation][docs-rlo-en]
+: Dokumentasi API Ruby resmi untuk versi yang berbeda termasuk versi yang
+  belum rilis (*trunk*) saat ini.
+
 [Ruby Core Reference][13]
 : Diambil langsung dari source code Ruby menggunakan [RDoc][14],
-  referensi ini mendokumentasikan seluruh class dan module core
+  referensi ini mendokumentasikan seluruh *class* dan *module core*
   (seperti String, Array, Symbol, dll.).
 
 [Ruby Standard Library Reference][15]
 : Juga diambil langsung dari source code menggunakan RDoc, referensi ini
-  mendokumentasikan library standar.
+  mendokumentasikan *library* standar.
 
 [Ruby C API Reference][extensions]
 : Pengenalan Ruby C API.
@@ -97,8 +81,8 @@ mendapatkan Ruby.
   atau membantu pengembangan Ruby.
 
 [RubyDoc.info][16]
-: Situs web lengkap untuk dokumentasi referensi tentang gem Ruby dan
-  proyek Ruby yang di-host di GitHub.
+: Situs *web* lengkap untuk dokumentasi referensi tentang gem Ruby dan
+  proyek Ruby yang di-*host* di GitHub.
 
 [Ruby & Rails Searchable API Docs][17]
 : Dokumentasi Rails dan Ruby yang dilengkapi dengan pencarian cerdas.
@@ -108,21 +92,21 @@ mendapatkan Ruby.
 
 ### Editor dan IDE
 
-Untuk meng-*coding* Ruby, Anda dapat menggunakan *default editor* dari sistem operasi
-Anda. Supaya lebih efektif koding, alangkah sangat berguna untuk
-memilih editor dengan dukungan Ruby dasar (misalnya
+Untuk memprogram Ruby, Anda dapat menggunakan *default editor* dari sistem
+operasi Anda. Supaya lebih efektif, alangkah sangat berguna untuk memilih
+*editor* dengan dukungan Ruby dasar (misalnya
 *highlight* sintaks, *browsing file*) atau *integrated development environment*
 yang memiliki fitur canggih (misalnya *code completion*, *refactoring*,
 *testing support*).
 
-Berikut adalah daftar kakas populer yang digunakan oleh para pengguna Ruby.
+Berikut adalah daftar kakas populer yang digunakan oleh para pengguna Ruby:
 
-* Kakas pada Linux dan lintas platform:
+* Kakas pada Linux dan lintas *platform*:
   * [Aptana Studio][19]
-  * [Emacs][20] with [Ruby mode][21] and [Rsense][22]
+  * [Emacs][20] dengan [Ruby mode][21] dan [Rsense][22]
   * [Geany][23]
   * [gedit][24]
-  * [Vim][25] with [vim-ruby][26] plugin and [Rsense][22]
+  * [Vim][25] dengan *plugin* [vim-ruby][26] dan [Rsense][22]
   * [RubyMine][27]
   * [SciTe][28]
   * [NetBeans][36]
@@ -142,8 +126,8 @@ Berikut adalah daftar kakas populer yang digunakan oleh para pengguna Ruby.
 
 ### Bacaan selanjutnya
 
-[Ruby-Doc.org][34] me-maintain daftar lengkap dokumentasi bahasa Inggris.
-Ada juga banyak [buku tentang Ruby] [35]. Jika Anda memiliki pertanyaan
+[Ruby-Doc.org][34] merawat daftar lengkap dokumentasi Bahasa Inggris.
+Ada juga banyak [buku tentang Ruby][35]. Jika Anda memiliki pertanyaan
 tentang Ruby, [mailing list](/id/community/mailing-lists/)
 adalah tempat yang baik untuk memulai.
 
@@ -187,5 +171,6 @@ adalah tempat yang baik untuk memulai.
 [37]: http://www.sublimetext.com/
 [38]: http://ruby.learncodethehardway.org/
 [39]: http://kapeli.com/dash
+[docs-rlo-en]: https://docs.ruby-lang.org/en/
 [atom]: https://atom.io/
 [vscode]: https://code.visualstudio.com/


### PR DESCRIPTION
Changes:

* Simplify introductory copy for Documentation (see commit f971262255a484eddefe53bf545a7848d3939646)
* Add listing for the official API documentation (e01e69935f69250f279076b718eae5d9f71cf817)
* Remove redundant listing of Getting Started links (f3133b0d408a3ef6e040a0f485f34798245caae3)
* Don’t linger on installation in documentation (4d615d4670d78f9108fea1cd8e21c738ae8da365)
* Use named link reference for recently added link (379e180226bacd54ddeb6a4dafa56241382104ff)