### PR TITLE
Russian version of rubyinstaller.org website link

### DIFF
--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -73,4 +73,4 @@ lang: ru
 [mirrors]: /en/downloads/mirrors/
 [rvm]: http://rvm.io/
 [rbenv]: https://github.com/rbenv/rbenv
-[rubyinstaller]: https://rubyinstaller.org/
+[rubyinstaller]: https://rubyinstaller.ru/


### PR DESCRIPTION
It's reasonable and natural to see links to localized russian version of RubyInstaller website on russian pages of ruby-lang.org

