### PR TITLE
Update ruby to 2.6.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-rvm: 2.6.2
+rvm: 2.6.3
 cache: bundler
 env:
   - TASK=ci


### PR DESCRIPTION
Fix travis build failure introduced by 2bfdc390f34e26805947b7172c4ce0466407eceb 