### PR TITLE
Now the primary repository is Git

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,14 +28,14 @@ license:
 
 svn:
   stable:
+    version: 2.6
+    branch:  ruby_2_6
+  previous:
     version: 2.5
     branch:  ruby_2_5
-  previous:
+  old:
     version: 2.4
     branch:  ruby_2_4
-  old:
-    version: 2.3
-    branch:  ruby_2_3
 
 locales:
   sitelinks:

--- a/en/community/ruby-core/index.md
+++ b/en/community/ruby-core/index.md
@@ -17,54 +17,30 @@ The topics related to Ruby development covered here are:
 * [Improving Ruby, Patch by Patch](#patching-ruby)
 * [Rules for Core Developers](#coding-standards)
 
-### Using Subversion to Track Ruby Development
-{: #following-ruby}
+### Using Git to Track Ruby Development
 
-Getting the latest Ruby source code is a matter of an anonymous checkout
-from the [Subversion][1] repository. From your command line:
+The current primary repository of the latest Ruby source code is
+[git.ruby-lang.org/ruby.git][gitrlo].
+There is also a [mirror on GitHub][7].  Usually, please use this mirror.
+
+You can get the latest Ruby source code by using Git.
+From your command line:
 
 {% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+$ git clone https://github.com/ruby/ruby.git
 {% endhighlight %}
 
 The `ruby` directory will now contain the latest source code
 for the development version of Ruby (ruby-trunk).
-Currently patches applied to the trunk are backported to the stable
-{{ site.svn.stable.version }}, {{ site.svn.previous.version }},
-and {{ site.svn.old.version }} branches (see below).
 
-If you’d like to follow patching of Ruby {{ site.svn.stable.version }},
-you should use the `{{ site.svn.stable.branch }}` branch when checking out:
+See also [Non-committer’s HOWTO to join our development][noncommitterhowto].
 
-{% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.stable.branch }}
-{% endhighlight %}
-
-Similarly for Ruby {{ site.svn.previous.version }}:
+If you have commit access, and if you want to push something,
+you should use the primary repository.
 
 {% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
+$ git clone git@git.ruby-lang.org:ruby/ruby.git
 {% endhighlight %}
-
-This will check out the respective development tree into a
-`{{ site.svn.stable.branch }}` or `{{ site.svn.previous.branch }}` directory.
-Developers working on the maintenance branches are expected to migrate
-their changes to Ruby’s trunk, so often the branches are very similar,
-with the exception of improvements made by Matz and Nobu to the language
-itself.
-
-If you prefer, you may browse [Ruby’s Subversion repository via the web][2].
-
-For information about Subversion, please see the [Subversion FAQ][3]
-and the [Subversion book][4]. Alternatively, you may find
-[Pragmatic Version Control with Subversion][5] to be a useful introductory book.
-
-### How to Use Git With the Main Ruby Repository
-{: #git-ruby}
-
-Those who prefer to use [Git][6] over Subversion can find instructions
-with the [mirror on GitHub][7], both for [those with commit access][8]
-and [everybody else][9].
 
 ### Improving Ruby, Patch by Patch
 {: #patching-ruby}
@@ -81,25 +57,24 @@ straight from Matz, on how to get your patches considered.
 
 To summarize, the steps for building a patch are:
 
-1.  Check out a copy of the Ruby source code from Subversion.
+1.  Check out a copy of the Ruby source code from GitHub.
     Usually patches for bugfixes or new features should be submitted
-    for the trunk of Ruby’s source. Even if you wish to add a feature
-    to Ruby {{ site.svn.previous.version }}, it has to be proven in
-    the trunk first.
+    for the trunk of Ruby’s source.
 
-        $ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+        $ git clone https://github.com/ruby/ruby.git
 
     If you are fixing a bug that is specific to only one maintenance branch,
-    check out a copy of the respective branch,
-    e.g. `{{ site.svn.previous.branch }}`.
+    check out a copy of the respective branch.
 
-        $ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
+        $ git checkout ruby_X_X
+
+    X_X should be replaced with a version that you want to check out.
 
 2.  Add your improvements to the code.
 
 3.  Create a patch.
 
-        $ svn diff > ruby-changes.patch
+        $ git diff > ruby-changes.patch
 
 4.  Create a ticket in the [issue tracker][10] or email your patch to
     the [Ruby-Core mailing list][mailing-lists] with a ChangeLog entry
@@ -120,47 +95,40 @@ should be very low, topics should be pointed, well-conceived and
 well-written. Since we’re addressing Ruby’s creator, let’s have some
 reverence.
 
-Keep in mind that Ruby’s core developers live in Japan and, while many
+Keep in mind that many Ruby’s core developers live in Japan and, while many
 speak very good English, there is a significant timezone difference.
 They also have an entire body of Japanese development lists happening
 alongside the English counterparts. Be patient, if your claim isn’t
 resolved, be persistent—give it another shot a few days later.
 
-### Rules for Core Developers
-{: #coding-standards}
 
-Generally, the developers of Ruby should be familiar with the source
-code and the style of development used by the team. To be clear, the
-following guidelines should be honored when checking into Subversion:
+### Note about branches
 
-* All check-ins should be described in the `ChangeLog`, following the
-  [GNU conventions][14]. (Many Ruby core developers use Emacs `add-log`
-  mode, which can be accessed with the command `C-x 4 a`.)
-* Check-in dates should be given in Japan Standard Time (UTC+9).
-* The bulleted points from your ChangeLog should also be placed in the
-  Subversion commit message. This message will be automatically mailed
-  to the Ruby-CVS list after you commit.
-* Function prototypes are used throughout Ruby’s source code and its
-  packaged extensions.
-* Please, do not use C++-style comments (`//`), Ruby’s maintainers
-  instead prefer the standard C multi-line comment (`/* .. */`).
+The source code of Ruby had been managed under Subversion repository until 22rd April 2019.
+Thus, some branches may be still managed under Subversion.
+You can view the SVN repository.
 
-See also the information in [Ruby’s issue tracker][10].
+* [&lt;URL:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby&gt;][svn-viewvc]
 
+However, you don't have to care about it (unless you are a branch maintainer).
+You can check out the branches in your Git working copy.
+For example, run the following command.
 
+{% highlight sh %}
+$ git checkout ruby_X_X
+{% endhighlight %}
 
+X_X should be replaced with a version that you want to check out.
+
+If you want to modify the branches, please open an issue in our [issue tracker][10].
+See also the following section.
+
+[gitrlo]: https://git.ruby-lang.org/ruby.git
 [mailing-lists]: /en/community/mailing-lists/
 [writing-patches]: /en/community/ruby-core/writing-patches/
-[1]: http://subversion.apache.org/
-[2]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/
-[3]: http://subversion.apache.org/faq.html
-[4]: http://svnbook.org
-[5]: http://www.pragmaticprogrammer.com/titles/svn/
-[6]: http://git-scm.com/
+[noncommitterhowto]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
+[svn-viewvc]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby
 [7]: https://github.com/ruby/ruby
-[8]: https://github.com/shyouhei/ruby/wiki/committerhowto
-[9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
-[14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/ja/documentation/repository-guide/index.md
+++ b/ja/documentation/repository-guide/index.md
@@ -4,46 +4,54 @@ title: "リポジトリガイド"
 lang: ja
 ---
 
+## Gitリポジトリ
+
+RubyのソースコードはGitリポジトリに保存されています。コミッタはこちらを使います。
+
+* [&lt;URL:https://git.ruby-lang.org/ruby.git&gt;][1]
+
+{% highlight sh %}
+$ git clone git@git.ruby-lang.org:ruby.git
+{% endhighlight %}
+
+また、GitHubにミラーが用意されています。
+
+* [&lt;URL:https://github.com/ruby/ruby.git&gt;][2]
+
+{% highlight sh %}
+$ git clone https://github.com/ruby/ruby.git
+{% endhighlight %}
+
+コミッタ以外でRubyの開発に参加したい方は、GitHubのミラーを使うとよいでしょう。次のHowto(英語)もご覧ください。
+
+* [&lt;URL:https://github.com/shyouhei/ruby/wiki/noncommitterhowto&gt;][3]
+
 ## SVNリポジトリ
 
-RubyのソースコードはSVNリポジトリに保存されており、ViewVC経由で参照できます:
+Rubyのソースコードは2019年4月22日までSVNリポジトリで管理されていたため、一部のブランチはまだSVNで管理されている場合があります。ViewVC経由で参照できます:
 
-* [&lt;URL:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby&gt;][1]
+* [&lt;URL:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby&gt;][4]
 
 また、Anonymous SVNも利用可能です:
 
-trunkの場合:
+2\.6の場合:
 
 {% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+$ svn co https://svn.ruby-lang.org/repos/ruby/branches/ruby_2_6 ruby
 {% endhighlight %}
 
-1\.8の場合:
-
-{% highlight sh %}
-$ svn co https://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8 ruby
-{% endhighlight %}
-
-その他のブランチ・タグなどは[&lt;URL:https://svn.ruby-lang.org/repos/ruby/&gt;][2]から確認してください。
-
-## Gitリポジトリ
-
-Gitをお使いの方は、[githubにあるRubyのリポジトリ][3]も利用可能です。
-
-また、これを使ってRubyの開発に参加したい方は、以下のHowto(英語)を読まれるとよいでしょう。
-
-* [非コミッター向け][4]
-* [コミッター向け][5]
+その他のブランチ・タグなどは[&lt;URL:https://svn.ruby-lang.org/repos/ruby/&gt;][5]から確認してください。
 
 それではみなさん、楽しいハックを！
 
 Posted by usa on 30 May 2006
+Updated by mame on 12 May 2019
 {: .post-info}
 
 
 
-[1]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby
-[2]: https://svn.ruby-lang.org/repos/ruby/
-[3]: https://github.com/ruby/ruby
-[4]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
-[5]: https://github.com/shyouhei/ruby/wiki/committerhowto
+[1]: https://git.ruby-lang.org/ruby.git
+[2]: https://github.com/ruby/ruby
+[3]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
+[4]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?root=ruby
+[5]: https://svn.ruby-lang.org/repos/ruby/


### PR DESCRIPTION
The change fixes the explanation of the repository guide.
Also, some explanations of en/community/ruby-core were obsolete.