### PR TITLE
Fix address of git remote for committers

### DIFF
--- a/en/community/ruby-core/index.md
+++ b/en/community/ruby-core/index.md
@@ -39,7 +39,7 @@ If you have commit access, and if you want to push something,
 you should use the primary repository.
 
 {% highlight sh %}
-$ git clone git@git.ruby-lang.org:ruby/ruby.git
+$ git clone git@git.ruby-lang.org:ruby.git
 {% endhighlight %}
 
 ### Improving Ruby, Patch by Patch


### PR DESCRIPTION
`git clone` didn't work with `git@git.ruby-lang.org:ruby/ruby.git`, but it works with `git@git.ruby-lang.org:ruby.git`, so we better use the later here.