### PR TITLE
Add tr to admin/translation-status page

### DIFF
--- a/_plugins/translation_status.rb
+++ b/_plugins/translation_status.rb
@@ -8,7 +8,7 @@ module Jekyll
   # Outputs HTML.
   module TranslationStatus
 
-    LANGS =  %w[en de es id ja ko pt zh_cn zh_tw]
+    LANGS =  %w[en de es id ja ko pt tr zh_cn zh_tw]
     START_DATE = '2013-04-01'
 
     OK_CHAR      = '✓'


### PR DESCRIPTION
Since the last 10 news are translated and
@ruby/www-ruby-lang-org-i18n-tr team is here, I feel that the Turkish
language should be in admin/translation-status page