### PR TITLE
Add posts about Rubyist Magazine 60 published (ja)

### DIFF
--- a/ja/news/_posts/2019-08-18-rubyist-magazine-0060-published.md
+++ b/ja/news/_posts/2019-08-18-rubyist-magazine-0060-published.md
@@ -1,0 +1,33 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0060号 発行"
+author: "miyohide"
+translator:
+date: 2019-08-18 17:00:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0060号][3]がリリースされました([\[ruby-list:50811\]][4])。
+今号は、
+
+* [巻頭言](https://magazine.rubyist.net/articles/0060/0060-ForeWord.html)
+* [『なるほどUnixプロセス』を読む前にちょっとだけナルホドとなる記事](https://magazine.rubyist.net/articles/0060/0060-NaruhodoUnixTip.html)
+* [AWS Lambdaで作るサーバーレスMastodon Bot](https://magazine.rubyist.net/articles/0060/0060-AWS-Lambda-Mastodon-Bot.html)
+* [TokyoGirls.rb Meetup vol.1開催レポート](https://magazine.rubyist.net/articles/0060/0060-TokyoGirlsrb01Report.html)
+* [Yokohama.rbの紹介と第100回レポート](https://magazine.rubyist.net/articles/0060/0060-yokohamarb100thReport.html)
+* [RegionalRubyKaigi レポート (73) 名古屋 Ruby 会議 04](https://magazine.rubyist.net/articles/0060/0060-NagoyaRubyKaigi04Report.html)
+* [RegionalRubyKaigi レポート (74) TokyuRuby 会議 13](https://magazine.rubyist.net/articles/0060/0060-TokyuRubyKaigi13Report.html)
+* [RegionalRubyKaigi レポート (75) とちぎ Ruby 会議 08](https://magazine.rubyist.net/articles/0060/0060-tochigiRubyKaigi08Report.html)
+* [RegionalRubyKaigi レポート (76) Tama Ruby 会議 01](https://magazine.rubyist.net/articles/0060/0060-TamaRubyKaigi01Report.html)
+* [Rails Girls Nagano 1st 開催 レポート](https://magazine.rubyist.net/articles/0060/0060-RailsGirlsNagano1stReport.html)
+* [Rails Girls Sendai 2nd 開催レポート](https://magazine.rubyist.net/articles/0060/0060-RailsGirlsSendai2ndReport.html)
+* [Rails Girls Tokyo 12th レポート](https://magazine.rubyist.net/articles/0060/0060-RailsGirlsTokyo12th.html)
+* [0060 号 編集後記](https://magazine.rubyist.net/articles/0060/0060-EditorsNote.html)
+
+ という構成となっています。
+ お楽しみください。
+
+[1]: https://ruby-no-kai.org/
+[2]: https://magazine.rubyist.net/
+[3]: https://magazine.rubyist.net/articles/0060/0060-index.html
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50811


### PR DESCRIPTION
RubiMa Editors have released Rubyist Magazine 60 (in japanese).