### PR TITLE
Update Conferences page (zh_tw)

### DIFF
--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -6,65 +6,89 @@ lang: zh_tw
 
 全世界有越來越多的研討會讓 Ruby 程式設計師可以參與，分享他們的工作經驗、討論 Ruby 的未來，同時也歡迎新成員的加入。
 
+[RubyConferences.org][rc] 是一個簡單的 Ruby 研討會列表，由 Ruby 社群協作公布，你可以在此查詢到研討會的日期、地點、徵求訊息和報名資訊。
+
+
 ### 主要的 Ruby 大會
 
 [RubyConf][1]
-: 自 2001 年開始，每年由 [Ruby Central, Inc.][2] 主辦的國際性 Ruby 大會。參加的人數從 2001 到
-  2006 有十倍的成長。RubyConf 提供了各種 Ruby 相關技術的發表機會，例如 Test Unit 函式庫的作者
-  Nathaniel Talbott、Rake 的作者 Jim Weirich、Ruby on Rails 的創造者 David
-  Heinemeier Hansson、YAML 函式庫作者 Why the Lucky Stiff 以及 YARV 的作者 Sasada
-  Koichi on YARV。當然，還有 Ruby 發明人 Matz 也會在這裡演講。
+: 自 2001 年開始，每年由 [Ruby Central, Inc.][2] 主辦的國際性 Ruby 大會。
+  參加的人數從 2001 到 2006 有十倍的成長。
+  RubyConf 提供了各種 Ruby 相關技術的發表機會，
+  例如 Test Unit 函式庫的作者 Nathaniel Talbott、
+  Rake 的作者 Jim Weirich、Ruby on Rails 的創造者 David Heinemeier Hansson、
+  YAML 函式庫作者 Why the Lucky Stiff 以及 YARV 的作者 Sasada Koichi on YARV。
+  當然，還有 Ruby 發明人 Matz 也會在這裡演講。
 
 [RubyKaigi][3]
-: 自 2006 年開始的日本 Ruby 大會，由 [日本Rubyの会][4] 主辦。”Kaigi” 日文”研討會”的意思。RubyKaigi
-  有非常多的新鮮又有趣的演講，當然也包括了 Matz 的演講。
+: 自 2006 年開始的日本 Ruby 大會，由[日本Rubyの会][jpr]主辦。
+  「Kaigi」為日文「研討會」的意思。
+  RubyKaigi 有非常多新鮮又有趣的演講，當然也包括了 Matz 的演講。
 
-[EuRuKo][5]
-: 自 2003 年開始的歐洲 Ruby 大會 － European Ruby Conference
-  (EuRuKo)。第一次主辦在德國的卡爾斯魯厄(Karlsruhe)。由一群德國的 Ruby 愛好者，包括 Armin
-  Roehrl、Michael Neumann 等所主辦。EuRuKo 逐漸成長為 Ruby 世界的第二大年度盛事。
+[EuRuKo <small>(European Ruby Conference)</small>][4]
+: 自 2003 年開始的歐洲 Ruby 大會 － European Ruby Conference （EuRuKo）。
+  第一次主辦在德國的卡爾斯魯厄（Karlsruhe）。
+  由一群德國的 Ruby 愛好者，包括 Armin Roehrl、Michael Neumann 等所主辦。
+  EuRuKo 逐漸成長為 Ruby 世界的第二大年度盛事。
 
-[RubyConf Taiwan][6]
-: 自 2010 年起，由 [Ruby Taiwan][7] 社群主辦，為台灣唯一的 Ruby 程式語言年會，目標對象為所有 Ruby 相關的
-  IT 技術人員、系統管理員及程式開發者，並邀請來自國內外專業講者來分享他們的專案及經驗。
+[RubyConf Taiwan][rct]
+: 自 2010 年起，由 [Ruby Taiwan][rt] 社群主辦，為台灣唯一的 Ruby 程式語言年會，
+  目標對象為所有 Ruby 相關的 IT 技術人員、系統管理員及程式開發者，
+  並邀請來自國內外專業講者來分享他們的專案及經驗。
 
-[OSDC.TW][8]
-: 這是台灣的年度開放原碼開發者大會。雖然主題不限於 Ruby，但是每年也都有 Ruby 的相關演講。
-
-[RubyConf China][9]
-: 自 2009 年開始的中國 Ruby 大會，由 [ShanghaiOnRails][10] 所主辦。
+[RubyConf China][rcc]
+: 自 2009 年開始的中國 Ruby 大會，由 [ShanghaiOnRails][sor] 所主辦。
 
 ### 地區性的 Ruby 研討會
 
-[Ruby Central][2] 提供了 [地區性研討會贊助計畫][11] ，提供一些經費給地區性團體來組織活動。
+[Ruby Central][2] 提供了[地區性研討會贊助計畫][6]，提供一些經費給地區性團體來組織活動。
 
-自 2007 年起，Ruby Central 也與 [SVForum][12] 合作主辦矽谷的 Ruby 研討會。
+自 2007 年起，Ruby Central 也與 [SVForum][7] 合作主辦矽谷的 Ruby 研討會。
 
-[RubyNation][13] 則是美國東岸(Virginia, West Virginia, Maryland, and
-Washington, DC 等地區)的 Ruby 年度大會。
+[RubyNation][8]是美國東岸（Virginia, West Virginia, Maryland 和 Washington, DC 等地區）的 Ruby 年度大會。
+
+[WindyCityRails][9]：是一群由對於 Ruby on Rails 充滿熱情的愛好者所舉辦的年度聚會，從 2008 年於芝加哥開始於社群舉行。
+
+[Steel City Ruby][16]：於匹茲堡舉辦的研討會。
+
+[GoRuCo][19]：一年一度於紐約市舉辦的單日單軌 Ruby 研討會。
+
+[DeccanRubyConf][20]：一年一度於印度浦納舉辦的單日單軌 Ruby 研討會，主題圍繞在當天充滿樂趣的活動。
+
+[Southeast Ruby][21]：位於納許維爾（田納西州）的工作坊與研討會。
 
 ### 其他研討會
 
-自 2004 年起的 [O’Reilly Open Source Conference][14] (OSCON) 研討會也包括了一整軌的
-Ruby 演講，並逐年增加中。也有許多研討會以 [Ruby on Rails][15] 為主題，包括了 Ruby Central 的
-[RailsConf][16] 、 [RailsConf Europe][17] 以及 Canada on Rails.
+自 2004 年起的 [O’Reilly Open Source Conference][10] (OSCON)
+研討會也包括了一整軌的 Ruby 演講，並逐年增加中。
+也有許多研討會以 [Ruby on Rails][11] 為主題，包括了 Ruby Central 的
+[RailsConf][12]、[RailsConf Europe][13]
+（2006 年由 Ruby Central 和 [Skills Matter][14] 共同舉辦，
+2007 年由 Ruby Central 和 O’Reilly 共同舉辦）以及 Canada on Rails.
 
 
 
+[rct]: http://rubyconf.tw
+[rt]:  http://ruby.tw
+[rcc]: http://rubyconfchina.org
+[sor]: http://groups.google.com/group/shanghaionrails
+[jpr]: http://jp.rubyist.net/
+
+[rc]: http://rubyconferences.org/
 [1]: http://rubyconf.org/
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
-[4]: http://jp.rubyist.net/
-[5]: http://euruko.org/
-[6]: http://rubyconf.tw
-[7]: http://ruby.tw
-[8]: http://osdc.tw
-[9]: http://rubyconfchina.org
-[10]: http://groups.google.com/group/shanghaionrails
-[11]: http://rubycentral.org/community/grant
-[12]: http://www.svforum.org
-[13]: http://rubynation.org/
-[14]: http://conferences.oreillynet.com/os2006/
-[15]: http://www.rubyonrails.org
-[16]: http://www.railsconf.org
-[17]: http://europe.railsconf.org
+[4]: http://euruko.org
+[6]: http://rubycentral.org/community/grant
+[7]: http://www.svforum.org
+[8]: http://rubynation.org/
+[9]: http://windycityrails.org
+[10]: http://conferences.oreillynet.com/os2006/
+[11]: http://www.rubyonrails.org
+[12]: http://www.railsconf.org
+[13]: http://europe.railsconf.org
+[14]: http://www.skillsmatter.com
+[16]: http://steelcityruby.org/
+[19]: http://goruco.com/
+[20]: http://www.deccanrubyconf.org/
+[21]: https://southeastruby.com/


### PR DESCRIPTION
Update translation in conferences page.
  1. Keep `zh_tw` conferences page up to date with `en` page.
  2. Remove broken link `OSDC.TW`

Thank you.