### PR TITLE
Translate multi post in 2019-08-28 (zh_tw) 

### DIFF
--- a/zh_tw/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
+++ b/zh_tw/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
@@ -1,0 +1,63 @@
+---
+layout: news_post
+title: "RDoc 中多個 jQeury 安全性風險"
+author: "aycabta"
+translator: Vincent Lin
+date: 2019-08-28 09:00:00 +0000
+tags: security
+lang: zh_tw
+---
+
+
+在 Ruby 內包含的 RDoc 所附帶的 jQeury 存在關於跨網站指令碼攻擊（XSS）的安全性風險。
+建議所有使用者將 Ruby 更新至已包含修復版本 RDoc 的最新版本。
+
+## 詳情
+
+以下為已回報的安全性風險
+
+* [CVE-2012-6708](https://nvd.nist.gov/vuln/detail/CVE-2012-6708)
+* [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
+
+強烈建議所有 Ruby 使用者升級你的 Ruby，或盡快採用以下解決方法。
+你仍須重新產生現有的 RDoc 文件，以完全緩解風險。
+
+## 受影響版本
+
+* Ruby 2.3 系列：全部
+* Ruby 2.4 系列：2.4.6 以及之前的版本
+* Ruby 2.5 系列：2.5.5 以及之前的版本
+* Ruby 2.6 系列：2.6.3 以及之前的版本
+* 在 master commit f308ab2131ee675000926540cbb8c13c91dc3be5 之前
+
+## 必要措施
+
+RDoc 是靜態文件產生工具。
+修補工具本身不足以緩解這些安全性風險。
+
+因此，必須使用新的 RDoc 來重新產生由先前版本生成的 RDoc 文件。
+
+## 因應措施
+
+原則上，你應該要升級你的 Ruby 至最新版本。
+RDoc 6.1.2 以及之後的版本包含安全性修復，因此，如果您無法升級 Ruby 本身，請將 RDoc 升級到最新版本。
+
+如同前述，您必須重新生成現有的 RDoc 文件。
+
+```
+gem install rdoc -f
+```
+
+*更新：* 此文的初始版本部分提到了 rdoc-6.1.1.gem，但其仍存在風險。請確保你安裝了 rdoc-6.1.2 或之後的版本。
+
+至於開發版本，請更新至 master 分支至最新 HEAD。
+
+## 鳴謝
+
+感謝 [Chris Seaton](https://hackerone.com/chrisseaton) 回報此風險。
+
+## 歷史
+
+* 最初發佈於 2019-08-28 09:00:00 UTC
+* RDoc 版本修正於 2019-08-28 11:50:00 UTC
+* 細部語言修正於 2019-08-28 12:30:00 UTC

--- a/zh_tw/news/_posts/2019-08-28-ruby-2-4-7-released.md
+++ b/zh_tw/news/_posts/2019-08-28-ruby-2-4-7-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.4.7 發佈"
+author: "usa"
+translator: Vincent Lin
+date: 2019-08-28 09:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.4.7 發佈了。
+
+此次發佈包含了安全性修復。
+詳情請參閱下面項目：
+
+* [RDoc 中多個 jQeury 安全性風險](/zh_tw/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+Ruby 2.4 現處於安全維護期，並將於 2020 年 3 月底停止維護。
+此後 Ruby 2.4 的全部維護將終止。
+我們建議您開始規劃遷移到更新版本的 Ruby，例如 Ruby 2.6 或 2.5。
+
+## 下載
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.bz2>
+
+      SIZE:   12826941 bytes
+      SHA1:   9eac11cd50a2c11ff310e88087f25a0ceb5d0994
+      SHA256: c10d6ba6c890aacdf27b733e96ec3859c3ff33bfebb9b6dc8e96879636be7bf5
+      SHA512: 2665bca5f55d4b37f100eec0e2e632d41158139b85fcb8d5806c6dc1699e64194f17b9fe757b5afd6aa2c6e7ccabba8710a9aa8182a2d697add11f2b76cf6958
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz>
+
+      SIZE:   16036496 bytes
+      SHA1:   607384450348bd87028cd8d1ebf09f21103d0cd2
+      SHA256: cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89
+      SHA512: 2fbada1cf92dc3b1cbdaf05186ff2e5d8e0ce4ac9dc736148116e365bec6d557a2115838404c982b527adbb27677340acfbbb7c873004f0cb4be8a07857e6473
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.xz>
+
+      SIZE:   10118948 bytes
+      SHA1:   6ed0e943bfcbf181384b48e7873361f1acaf106d
+      SHA256: a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
+      SHA512: df637c5803ddd83f759e9c24b0e7ca1f6cae7c7b353409583d92dbffece0d9d02b48905d6552327a1522a4a37d4e2d22c6c11bd991383835be35e2f31739d649
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.zip>
+
+      SIZE:   17659539 bytes
+      SHA1:   3f991d6b5296e9d0df405033e336bb973d418354
+      SHA256: 1016797925e55c78d9c15633da8ddbd19daed2993a99d35377d2a16c3175cfe5
+      SHA512: 1bddd5616edb1a671224bc1c22cc3ac6f70e96e41cb2937efb437e8920fe09ce2ef0f29c591499d3682ac547e1d3eb7474f89ff86a3834d25724329e4927ed76
+
+## 發佈記
+
+感謝所有幫助發佈此一版本的人，特別是風險的回報者。

--- a/zh_tw/news/_posts/2019-08-28-ruby-2-5-6-released.md
+++ b/zh_tw/news/_posts/2019-08-28-ruby-2-5-6-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.5.6 發佈"
+author: "usa"
+translator: Vincent Lin
+date: 2019-08-28 09:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.5.6 發佈了。
+
+此次發佈包含上個版本發佈後約 40 個錯誤修復，也包含一個安全性修復。
+詳情請參閱下面項目：
+
+* [RDoc 中多個 jQeury 安全性風險](/zh_tw/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6)。
+
+## 下載
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.bz2>
+
+      SIZE:   14073430 bytes
+      SHA1:   a1b497237770d2a0d1386408fc264ad16f3efccf
+      SHA256: 24fc2a417e71150cd2229ec204afc8f467ebb15a8e295aab5d4bceebfb05e18d
+      SHA512: e4511d42d19a7bb39ea79f66bb4eca54b63c2a9d27addc035d6d670c1e59ee48a0c6e9c6bc7d082d1f1114b0668831dce3b7422034517f3c4a06ced0e47a7914
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz>
+
+      SIZE:   17684288 bytes
+      SHA1:   d2dd34da5f3b63a0075e50133f60eb35d71b7543
+      SHA256: 1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7
+      SHA512: dc34243129a40b4b16fe171d70bcbdac255819868c608f3ca9f2866124fd6cfde0f3990d5e08a42752427d9066981ca14a634679b9bed5bca9f349a8526d0f35
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.xz>
+
+      SIZE:   11323612 bytes
+      SHA1:   5008b35d386c4b663b7956a0790b6aa7ae5dc9a9
+      SHA256: 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
+      SHA512: 4fe5f8bad5d320f8f17b02ce15afee341e7b0074efcfd98d8944e0cb7c448e0660c4553dd5c0328ee3b49fea3247642f85c60bdce431ed57f58b6326dfd48ee1
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.zip>
+
+      SIZE:   21263348 bytes
+      SHA1:   4a3859319dd9f1f4d43e2a2bf874ca8233d39b15
+      SHA256: c86b0a9bfe47df5639cf134eabd3ebc2711794226ccb02e22094e46aa3e887f4
+      SHA512: 8aa96c4e6692ed8c9f8fe4ceb2a91829bb5fa98ef53a4bc85f3a3d0cd66d60bb80985359bd9f7020de7d1cc39c7223559aa20dfdcc01d890624b71b935c6f8da
+
+## 發佈記
+
+感謝所有幫助發佈此一版本的人。
+
+Ruby 2.5 的維護（包含本版本）是基於 Ruby 協會的「穩定版本協議」。

--- a/zh_tw/news/_posts/2019-08-28-ruby-2-6-4-released.md
+++ b/zh_tw/news/_posts/2019-08-28-ruby-2-6-4-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Ruby 2.6.4 發佈"
+author: "nagachika"
+translator: Vincent Lin
+date: 2019-08-28 09:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.6.4 發佈了。
+
+此次發佈包含一個 RDoc 的安全性修復。
+詳情請參閱下面項目：
+
+* [RDoc 中多個 jQeury 安全性風險](/zh_tw/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4)。
+
+## 下載
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2>
+
+      SIZE:   14426299 bytes
+      SHA1:   fa1c7b7f91edb92de449cb1ae665901ba51a8b81
+      SHA256: fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7
+      SHA512: a9fa2f51fb5f86cd8dcaa0925fe6f13d4f19f110b5d4c5fd251f199d16aaf920db39ad3bb50460eb94ab8d471ab2ac8bb54daea4a3bb080eaf45250aac3437fe
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz>
+
+      SIZE:   16503137 bytes
+      SHA1:   2eaddc428cb5d210cfc256a7e6947196ed24355b
+      SHA256: 4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937
+      SHA512: 3dad0d98695e10ece015933e96114ffd9a10d3c59d1ead8a9ab041df113aabee3f4100aa7ffe7ef5c43b62ac3c7506c3f3ceeb8828b2a800b6d0f4119d5bf926
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.xz>
+
+      SIZE:   11727940 bytes
+      SHA1:   6ef7d60b8aaa5efb04de2eb4b682f91bc0ab3910
+      SHA256: df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+      SHA512: 930a4162fdb008d2446247908c14269fd13db4dc80bd2bb201a65a69c03f5933f97b4c5079ccd2a12db4934ff97b2debaa10a6c6f5c3060e55873f4397747eaa
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.zip>
+
+      SIZE:   19922060 bytes
+      SHA1:   3e1d98afc7804a291abe42f0b8e2e98219e41ca3
+      SHA256: 8446eaaa633a8d55146df0874154b8eb1e5ea5a000d803503d83fd67d9e9372c
+      SHA512: 5696f2921b8488bde42536dd23d933c8a5ab9ce33632760d217d79567324c4a20f8007d4815f33e56c0a764d1ca372b40c41a5937f9938bb1d63ea078d10d657
+
+
+## 發佈記
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發佈，在此感謝他們。


### PR DESCRIPTION
Translate jQuery vulnerabilities in RDoc and Ruby 2.4.7, 2.5.6, 2.6.4 released (zh_tw)

- zh_tw/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
- zh_tw/news/_posts/2019-08-28-ruby-2-4-7-released.md 
- zh_tw/news/_posts/2019-08-28-ruby-2-5-6-released.md 
- zh_tw/news/_posts/2019-08-28-ruby-2-6-4-released.md

Thank you.