### PR TITLE
Translate 2019-08-28 releases of Ruby (ko)

### DIFF
--- a/ko/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
+++ b/ko/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
@@ -1,63 +1,63 @@
 ---
 layout: news_post
-title: "Multiple jQuery vulnerabilities in RDoc"
+title: "RDoc의 jQuery 취약점 다수 발견"
 author: "aycabta"
-translator:
+translator: "yous"
 date: 2019-08-28 09:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
 
-There are multiple vulnerabilities about Cross-Site Scripting (XSS) in jQuery shipped with RDoc which bundled in Ruby.
-All Ruby users are recommended to update Ruby to the latest release which includes the fixed version of RDoc.
+루비에 포함되어 있는 RDoc과 함께 배포되는 jQuery에 크로스 사이트 스크립팅(XSS) 취약점이 다수 발견되었습니다.
+모든 루비 사용자는 취약점을 수정한 RDoc이 포함된 최신 루비 릴리스로 업데이트하기 바랍니다.
 
-## Details
+## 세부 내용
 
-The following vulnerabilities have been reported.
+아래와 같은 취약점이 보고되었습니다.
 
 * [CVE-2012-6708](https://nvd.nist.gov/vuln/detail/CVE-2012-6708)
 * [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
 
-It is strongly recommended for all Ruby users to upgrade your Ruby installation or take one of the following workarounds as soon as possible.
-You also have to re-generate existing RDoc documentations to completely mitigate the vulnerabilities.
+모든 루비 사용자는 가능한 빨리 설치된 루비를 업그레이드하거나 아래 해결 방법으로 조치하기 바랍니다.
+취약점을 완전히 해소하려면 기존의 RDoc 문서를 다시 생성해야 합니다.
 
-## Affected Versions
+## 해당 버전
 
-* Ruby 2.3 series: all
-* Ruby 2.4 series: 2.4.6 and earlier
-* Ruby 2.5 series: 2.5.5 and earlier
-* Ruby 2.6 series: 2.6.3 and earlier
-* prior to master commit f308ab2131ee675000926540cbb8c13c91dc3be5
+* 루비 2.3 버전대: 모든 버전
+* 루비 2.4 버전대: 2.4.6 이하
+* 루비 2.5 버전대: 2.5.5 이하
+* 루비 2.6 버전대: 2.6.3 이하
+* f308ab2131ee675000926540cbb8c13c91dc3be5 커밋 이전의 master
 
-## Required actions
+## 필요한 조치
 
-RDoc is a static documentation generation tool.
-Patching the tool itself is insufficient to mitigate these vulnerabilities.
+RDoc은 정적 문서 생성 도구입니다.
+도구 자체를 패치하는 것만으로는 이번 취약점을 해소할 수 없습니다.
 
-So, RDoc documentations generated with previous versions have to be re-generated with newer RDoc.
+따라서 이전 버전의 RDoc을 통해 생성된 문서는 새 RDoc으로 다시 생성해야 합니다.
 
-## Workarounds
+## 해결 방법
 
-In principle, you should upgrade your Ruby installation to the latest version.
-RDoc 6.1.2 or later includes the fix for the vulnerabilities, so upgrade RDoc to the latest version if you can’t upgrade Ruby itself.
+원칙적으로, 설치된 루비를 최신 버전으로 업그레이드해야 합니다.
+RDoc 6.1.2나 그 이후의 버전은 취약점에 대한 패치를 포함하고 있으므로, 루비를 업그레이드할 수 없다면 RDoc을 최신 버전으로 업그레이드해 주세요.
 
-Note that as mentioned earlier, you have to regenerate existing RDoc documentations.
+앞에서 언급한 것처럼 기존의 RDoc 문서를 다시 생성해야 합니다.
 
 ```
 gem install rdoc -f
 ```
 
-*Update:* The initial version of this post partially mentioned rdoc-6.1.1.gem, which was still vulnerable. Please make sure that you install rdoc-6.1.2 or later.
+*업데이트:* 이 글의 초기 버전은 여전히 취약한 rdoc-6.1.1.gem을 언급했습니다. rdoc-6.1.2나 그 이후의 버전을 설치해주세요.
 
-Regarding the development version, update to the latest HEAD of master branch.
+개발 버전은 master 브랜치의 최신 HEAD로 업데이트해 주세요.
 
-## Credits
+## 도움을 준 글
 
-Thanks to [Chris Seaton](https://hackerone.com/chrisseaton) for reporting the issue.
+이 문제를 보고해 준 [Chris Seaton](https://hackerone.com/chrisseaton)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2019-08-28 09:00:00 UTC
-* RDoc version fixed at 2019-08-28 11:50:00 UTC
-* Minor language fixes at 2019-08-28 12:30:00 UTC
+* 2019-08-28 09:00:00 UTC 최초 공개
+* 2019-08-28 11:50:00 UTC RDoc 버전 수정
+* 2019-08-28 12:30:00 UTC 사소한 표현 수정

--- a/ko/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
+++ b/ko/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
@@ -1,0 +1,63 @@
+---
+layout: news_post
+title: "Multiple jQuery vulnerabilities in RDoc"
+author: "aycabta"
+translator:
+date: 2019-08-28 09:00:00 +0000
+tags: security
+lang: en
+---
+
+
+There are multiple vulnerabilities about Cross-Site Scripting (XSS) in jQuery shipped with RDoc which bundled in Ruby.
+All Ruby users are recommended to update Ruby to the latest release which includes the fixed version of RDoc.
+
+## Details
+
+The following vulnerabilities have been reported.
+
+* [CVE-2012-6708](https://nvd.nist.gov/vuln/detail/CVE-2012-6708)
+* [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
+
+It is strongly recommended for all Ruby users to upgrade your Ruby installation or take one of the following workarounds as soon as possible.
+You also have to re-generate existing RDoc documentations to completely mitigate the vulnerabilities.
+
+## Affected Versions
+
+* Ruby 2.3 series: all
+* Ruby 2.4 series: 2.4.6 and earlier
+* Ruby 2.5 series: 2.5.5 and earlier
+* Ruby 2.6 series: 2.6.3 and earlier
+* prior to master commit f308ab2131ee675000926540cbb8c13c91dc3be5
+
+## Required actions
+
+RDoc is a static documentation generation tool.
+Patching the tool itself is insufficient to mitigate these vulnerabilities.
+
+So, RDoc documentations generated with previous versions have to be re-generated with newer RDoc.
+
+## Workarounds
+
+In principle, you should upgrade your Ruby installation to the latest version.
+RDoc 6.1.2 or later includes the fix for the vulnerabilities, so upgrade RDoc to the latest version if you can’t upgrade Ruby itself.
+
+Note that as mentioned earlier, you have to regenerate existing RDoc documentations.
+
+```
+gem install rdoc -f
+```
+
+*Update:* The initial version of this post partially mentioned rdoc-6.1.1.gem, which was still vulnerable. Please make sure that you install rdoc-6.1.2 or later.
+
+Regarding the development version, update to the latest HEAD of master branch.
+
+## Credits
+
+Thanks to [Chris Seaton](https://hackerone.com/chrisseaton) for reporting the issue.
+
+## History
+
+* Originally published at 2019-08-28 09:00:00 UTC
+* RDoc version fixed at 2019-08-28 11:50:00 UTC
+* Minor language fixes at 2019-08-28 12:30:00 UTC

--- a/ko/news/_posts/2019-08-28-ruby-2-4-7-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-4-7-released.md
@@ -1,0 +1,54 @@
+---
+layout: news_post
+title: "Ruby 2.4.7 Released"
+author: "usa"
+translator:
+date: 2019-08-28 09:00:00 +0000
+lang: en
+---
+
+Ruby 2.4.7 has been released.
+
+This release includes a security fix.
+Please check the topics below for details.
+
+* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+Ruby 2.4 is now under the state of the security maintenance phase, until
+the end of March of 2020.  After that date, maintenance of Ruby 2.4
+will be ended. We recommend you start planning the migration to newer
+versions of Ruby, such as 2.6 or 2.5.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.bz2>
+
+      SIZE:   12826941 bytes
+      SHA1:   9eac11cd50a2c11ff310e88087f25a0ceb5d0994
+      SHA256: c10d6ba6c890aacdf27b733e96ec3859c3ff33bfebb9b6dc8e96879636be7bf5
+      SHA512: 2665bca5f55d4b37f100eec0e2e632d41158139b85fcb8d5806c6dc1699e64194f17b9fe757b5afd6aa2c6e7ccabba8710a9aa8182a2d697add11f2b76cf6958
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz>
+
+      SIZE:   16036496 bytes
+      SHA1:   607384450348bd87028cd8d1ebf09f21103d0cd2
+      SHA256: cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89
+      SHA512: 2fbada1cf92dc3b1cbdaf05186ff2e5d8e0ce4ac9dc736148116e365bec6d557a2115838404c982b527adbb27677340acfbbb7c873004f0cb4be8a07857e6473
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.xz>
+
+      SIZE:   10118948 bytes
+      SHA1:   6ed0e943bfcbf181384b48e7873361f1acaf106d
+      SHA256: a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
+      SHA512: df637c5803ddd83f759e9c24b0e7ca1f6cae7c7b353409583d92dbffece0d9d02b48905d6552327a1522a4a37d4e2d22c6c11bd991383835be35e2f31739d649
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.zip>
+
+      SIZE:   17659539 bytes
+      SHA1:   3f991d6b5296e9d0df405033e336bb973d418354
+      SHA256: 1016797925e55c78d9c15633da8ddbd19daed2993a99d35377d2a16c3175cfe5
+      SHA512: 1bddd5616edb1a671224bc1c22cc3ac6f70e96e41cb2937efb437e8920fe09ce2ef0f29c591499d3682ac547e1d3eb7474f89ff86a3834d25724329e4927ed76
+
+## Release Comment
+
+Thanks to everyone who helped with this release, especially, to reporters of the vulnerability.

--- a/ko/news/_posts/2019-08-28-ruby-2-4-7-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-4-7-released.md
@@ -1,25 +1,24 @@
 ---
 layout: news_post
-title: "Ruby 2.4.7 Released"
+title: "루비 2.4.7 릴리스"
 author: "usa"
-translator:
+translator: "yous"
 date: 2019-08-28 09:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 2.4.7 has been released.
+루비 2.4.7이 릴리스되었습니다.
 
-This release includes a security fix.
-Please check the topics below for details.
+이 릴리스는 보안 수정 1개를 포함합니다.
+자세한 사항은 아래 글을 확인해보세요.
 
-* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+* [RDoc의 jQuery 취약점 다수 발견](/ko/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
 
-Ruby 2.4 is now under the state of the security maintenance phase, until
-the end of March of 2020.  After that date, maintenance of Ruby 2.4
-will be ended. We recommend you start planning the migration to newer
-versions of Ruby, such as 2.6 or 2.5.
+루비 2.4는 현재 보안 유지보수 단계이고, 기한은 2020년 3월입니다. 이날 이후 루비
+2.4의 유지보수는 종료됩니다. 루비 2.6, 2.5 등의 새 루비 버전으로 업그레이드할
+계획을 세우길 바랍니다.
 
-## Download
+## 다운로드
 
 * <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.bz2>
 
@@ -49,6 +48,6 @@ versions of Ruby, such as 2.6 or 2.5.
       SHA256: 1016797925e55c78d9c15633da8ddbd19daed2993a99d35377d2a16c3175cfe5
       SHA512: 1bddd5616edb1a671224bc1c22cc3ac6f70e96e41cb2937efb437e8920fe09ce2ef0f29c591499d3682ac547e1d3eb7474f89ff86a3834d25724329e4927ed76
 
-## Release Comment
+## 릴리스 코멘트
 
-Thanks to everyone who helped with this release, especially, to reporters of the vulnerability.
+이 릴리스를 만드는 데 도움을 준 모든 분, 특히 취약점을 보고해준 분에게 감사드립니다.

--- a/ko/news/_posts/2019-08-28-ruby-2-5-6-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-5-6-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.5.6 Released"
+author: "usa"
+translator:
+date: 2019-08-28 09:00:00 +0000
+lang: en
+---
+
+Ruby 2.5.6 has been released.
+
+This release includes about 40 bug fixes after the previous release, and also includes a security fix.
+Please check the topics below for details.
+
+* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+See the [commit log](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6) for details.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.bz2>
+
+      SIZE:   14073430 bytes
+      SHA1:   a1b497237770d2a0d1386408fc264ad16f3efccf
+      SHA256: 24fc2a417e71150cd2229ec204afc8f467ebb15a8e295aab5d4bceebfb05e18d
+      SHA512: e4511d42d19a7bb39ea79f66bb4eca54b63c2a9d27addc035d6d670c1e59ee48a0c6e9c6bc7d082d1f1114b0668831dce3b7422034517f3c4a06ced0e47a7914
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz>
+
+      SIZE:   17684288 bytes
+      SHA1:   d2dd34da5f3b63a0075e50133f60eb35d71b7543
+      SHA256: 1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7
+      SHA512: dc34243129a40b4b16fe171d70bcbdac255819868c608f3ca9f2866124fd6cfde0f3990d5e08a42752427d9066981ca14a634679b9bed5bca9f349a8526d0f35
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.xz>
+
+      SIZE:   11323612 bytes
+      SHA1:   5008b35d386c4b663b7956a0790b6aa7ae5dc9a9
+      SHA256: 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
+      SHA512: 4fe5f8bad5d320f8f17b02ce15afee341e7b0074efcfd98d8944e0cb7c448e0660c4553dd5c0328ee3b49fea3247642f85c60bdce431ed57f58b6326dfd48ee1
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.zip>
+
+      SIZE:   21263348 bytes
+      SHA1:   4a3859319dd9f1f4d43e2a2bf874ca8233d39b15
+      SHA256: c86b0a9bfe47df5639cf134eabd3ebc2711794226ccb02e22094e46aa3e887f4
+      SHA512: 8aa96c4e6692ed8c9f8fe4ceb2a91829bb5fa98ef53a4bc85f3a3d0cd66d60bb80985359bd9f7020de7d1cc39c7223559aa20dfdcc01d890624b71b935c6f8da
+
+## Release Comment
+
+Thanks to everyone who helped with this release.
+
+The maintenance of Ruby 2.5, including this release, is based on the “Agreement for the Ruby stable version” of the Ruby Association.

--- a/ko/news/_posts/2019-08-28-ruby-2-5-6-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-5-6-released.md
@@ -1,22 +1,22 @@
 ---
 layout: news_post
-title: "Ruby 2.5.6 Released"
+title: "루비 2.5.6 릴리스"
 author: "usa"
-translator:
+translator: "yous"
 date: 2019-08-28 09:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 2.5.6 has been released.
+루비 2.5.6이 릴리스되었습니다.
 
-This release includes about 40 bug fixes after the previous release, and also includes a security fix.
-Please check the topics below for details.
+이 릴리스는 지난 릴리스 이후로 버그 수정 약 40개와 보안 수정 1개를 포함합니다.
+자세한 사항은 아래 글을 확인해보세요.
 
-* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+* [RDoc의 jQuery 취약점 다수 발견](/ko/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
 
-See the [commit log](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6) for details.
+자세한 내용은 [커밋 로그](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6)를 확인해주세요.
 
-## Download
+## 다운로드
 
 * <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.bz2>
 
@@ -46,8 +46,8 @@ See the [commit log](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6) for d
       SHA256: c86b0a9bfe47df5639cf134eabd3ebc2711794226ccb02e22094e46aa3e887f4
       SHA512: 8aa96c4e6692ed8c9f8fe4ceb2a91829bb5fa98ef53a4bc85f3a3d0cd66d60bb80985359bd9f7020de7d1cc39c7223559aa20dfdcc01d890624b71b935c6f8da
 
-## Release Comment
+## 릴리스 코멘트
 
-Thanks to everyone who helped with this release.
+이 릴리스를 만드는 데 도움을 준 모든 분에게 감사드립니다.
 
-The maintenance of Ruby 2.5, including this release, is based on the “Agreement for the Ruby stable version” of the Ruby Association.
+이 릴리스를 포함한 루비 2.5의 유지보수는 Ruby Association의 "루비 안정 버전에 관한 협의"에 기반에 이루어집니다.

--- a/ko/news/_posts/2019-08-28-ruby-2-6-4-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-6-4-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.6.4 Released"
+author: "nagachika"
+translator:
+date: 2019-08-28 09:00:00 +0000
+lang: en
+---
+
+Ruby 2.6.4 has been released.
+
+This release includes a security fix of rdoc.
+Please check the topics below for details.
+
+* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+See the [commit logs](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4) for changes in detail.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2>
+
+      SIZE:   14426299 bytes
+      SHA1:   fa1c7b7f91edb92de449cb1ae665901ba51a8b81
+      SHA256: fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7
+      SHA512: a9fa2f51fb5f86cd8dcaa0925fe6f13d4f19f110b5d4c5fd251f199d16aaf920db39ad3bb50460eb94ab8d471ab2ac8bb54daea4a3bb080eaf45250aac3437fe
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz>
+
+      SIZE:   16503137 bytes
+      SHA1:   2eaddc428cb5d210cfc256a7e6947196ed24355b
+      SHA256: 4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937
+      SHA512: 3dad0d98695e10ece015933e96114ffd9a10d3c59d1ead8a9ab041df113aabee3f4100aa7ffe7ef5c43b62ac3c7506c3f3ceeb8828b2a800b6d0f4119d5bf926
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.xz>
+
+      SIZE:   11727940 bytes
+      SHA1:   6ef7d60b8aaa5efb04de2eb4b682f91bc0ab3910
+      SHA256: df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+      SHA512: 930a4162fdb008d2446247908c14269fd13db4dc80bd2bb201a65a69c03f5933f97b4c5079ccd2a12db4934ff97b2debaa10a6c6f5c3060e55873f4397747eaa
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.zip>
+
+      SIZE:   19922060 bytes
+      SHA1:   3e1d98afc7804a291abe42f0b8e2e98219e41ca3
+      SHA256: 8446eaaa633a8d55146df0874154b8eb1e5ea5a000d803503d83fd67d9e9372c
+      SHA512: 5696f2921b8488bde42536dd23d933c8a5ab9ce33632760d217d79567324c4a20f8007d4815f33e56c0a764d1ca372b40c41a5937f9938bb1d63ea078d10d657
+
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2019-08-28-ruby-2-6-4-released.md
+++ b/ko/news/_posts/2019-08-28-ruby-2-6-4-released.md
@@ -1,22 +1,22 @@
 ---
 layout: news_post
-title: "Ruby 2.6.4 Released"
+title: "루비 2.6.4 릴리스"
 author: "nagachika"
-translator:
+translator: "yous"
 date: 2019-08-28 09:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 2.6.4 has been released.
+루비 2.6.4가 릴리스되었습니다.
 
-This release includes a security fix of rdoc.
-Please check the topics below for details.
+이 릴리스는 rdoc의 보안 수정 1개를 포함합니다.
+자세한 사항은 아래 글을 확인해보세요.
 
-* [Multiple jQuery vulnerabilities in RDoc](/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+* [RDoc의 jQuery 취약점 다수 발견](/ko/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
 
-See the [commit logs](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4) for changes in detail.
+자세한 내용은 [커밋 로그](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4)를 확인해주세요.
 
-## Download
+## 다운로드
 
 * <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2>
 
@@ -47,7 +47,7 @@ See the [commit logs](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4) for 
       SHA512: 5696f2921b8488bde42536dd23d933c8a5ab9ce33632760d217d79567324c4a20f8007d4815f33e56c0a764d1ca372b40c41a5937f9938bb1d63ea078d10d657
 
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 신고해준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.


### PR DESCRIPTION
Ref: #2125, #2127, #2128 

The actual diff: https://github.com/ruby/www.ruby-lang.org/commit/c9ecf20a7d2383e05ccd212686f5acb0675342c9