### PR TITLE
Translation of 2019-10-01-http-response-splitting-in-webrick-cve-2019…

### DIFF
--- a/es/news/_posts/2019-10-01-http-response-splitting-in-webrick-cve-2019-16254.md
+++ b/es/news/_posts/2019-10-01-http-response-splitting-in-webrick-cve-2019-16254.md
@@ -1,0 +1,44 @@
+---
+layout: news_post
+title: "CVE-2019-16254: Separación de respuesta HTTP en WEBrick (Corrección adicional)"
+author: "mame"
+translator: vtamara
+date: 2019-10-01 11:00:00 +0000
+tags: security
+lang: es
+---
+
+Hay una vulnerabilidad de separación de respuesta HTTP en el WEBrick
+incluido con Ruby. A esta vulnerabilidad se le ha asignado el identificador
+CVE [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254).
+
+## Detalles
+
+Si un programa que use WEBrick inserta datos de entrada con confiables en
+las cabeceras de la respuesta HTTP, un atacante puede explotarlo para
+inserta un caracter de nueva línea para dividir el encabezado, e insertar
+contenido maliciosos que engañe a los clientes.
+
+Este es el mismo incidente [CVE-2017-17742](https://www.ruby-lang.org/en/news/2018/03/28/http-response-splitting-in-webrick-cve-2017-17742/).
+La corrección anterior estaba incompleta, porque tenía en cuenta el vector
+CRLF, pero no tenía en cuenta un CR aislado o un LF aislado.
+
+Todos los usuarios que ejecuten una versión afectada debe actualizar
+de inmediato.
+
+## Versiones afectadas
+
+* Todas las versiones de la serie Ruby 2.3 o anteriores
+* Serie Ruby 2.4: Ruby 2.4.7 o anterior
+* Serie Ruby 2.5: Ruby 2.5.6 o anterior
+* Serie Ruby 2.6: Ruby 2.6.4 o anterior
+* Ruby 2.7.0-preview1
+* Rama master antes de la contribución 3ce238b5f9795581eb84114dcfbdf4aa086bfecc
+
+## Agradecimientos
+
+Gracias a [znz](https://hackerone.com/znz) por descubrir el problema.
+
+## Historia
+
+* Publicado en inglés originalmente el 2019-10-01 11:00:00 (UTC)


### PR DESCRIPTION
…-16254 (es)