### PR TITLE
Fix spelling of Shell#test (en)

### DIFF
--- a/en/news/_posts/2019-10-01-code-injection-shell-test-cve-2019-16255.md
+++ b/en/news/_posts/2019-10-01-code-injection-shell-test-cve-2019-16255.md
@@ -14,7 +14,7 @@ A code injection vulnerability of Shell#[] and Shell#test in a standard library 
 
 Shell#[] and its alias Shell#test defined in lib/shell.rb allow code injection if the first argument (aka the "command" argument) is untrusted data.  An attacker can exploit this to call an arbitrary Ruby method.
 
-Note that passing untrusted data to methods of Shell is dangerous in general.  Users must never do it.  However, we treat this particular case as a vulnerability because the purpose of Shell#[] and Shell#[] is considered file testing.
+Note that passing untrusted data to methods of Shell is dangerous in general.  Users must never do it.  However, we treat this particular case as a vulnerability because the purpose of Shell#[] and Shell#test is considered file testing.
 
 All users running an affected release should upgrade immediately.
 
@@ -33,3 +33,4 @@ Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for discovering this issu
 ## History
 
 * Originally published at 2019-10-01 11:00:00 (UTC)
+* Fixed minor spelling problem at 2019-10-05 12:00:00 (UTC)


### PR DESCRIPTION
This fixes a spelling issue in the Shell test post. It says Shell#[] where it should say Shell#test.