### PR TITLE
Removing ODS from success stories

### DIFF
--- a/bg/documentation/success-stories/index.md
+++ b/bg/documentation/success-stories/index.md
@@ -32,10 +32,6 @@ lang: bg
 * В MORPHA се използва Ruby за имплементирането на реактивната
   контролна част за сервизния робот на Siemens.
 
-#### Мрежи
-
-* [Open Domain Server][6] използва Ruby за реализацията на Dynamic DNS.
-
 #### Телефония
 
 * Ruby се използва в [Lucent][7] за изграждането на 3G безжични
@@ -62,7 +58,6 @@ lang: bg
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/de/documentation/success-stories/index.md
+++ b/de/documentation/success-stories/index.md
@@ -26,12 +26,6 @@ Projekten, die Ruby nutzen.
 * Im MORPHA Projekt, wurde Ruby eingesetzt, um für den Siemens
   Service Roboter die Reaktionskontrolle zu implementieren.
 
-#### Netzwerke
-
-* [Open Domain Server][4] setzt Ruby ein, um Benutzern mittels des
-  dynamischen DNS Clients die IP-Konfiguration in Echtzeit zu
-  aktualisieren und damit auf statische Domains zu mappen.
-
 #### Telephonie
 
 * Ruby wird bei [Lucent][5] in einem 3G Wireless Telefonieprodukt
@@ -57,7 +51,6 @@ Projekten, die Ruby nutzen.
 
 [1]: http://www.motorola.com
 [2]: https://www.uhn.ca/TorontoRehab
-[4]: http://ods.org/
 [5]: http://www.lucent.com/
 [6]: http://www.level3.com/
 [7]: http://www.basecamphq.com

--- a/en/documentation/success-stories/index.md
+++ b/en/documentation/success-stories/index.md
@@ -31,12 +31,6 @@ you’ll find a small sample of real world usage of Ruby.
 * At MORPHA project, Ruby was used to implement the reactive
   control part for the Siemens service robot.
 
-#### Networking
-
-* [Open Domain Server][6] uses Ruby to allow people using Dynamic DNS
-  clients to update in real time their IP configuration so that it can
-  be mapped to static domains.
-
 #### Telephony
 
 * Ruby is being used within [Lucent][7] on a 3G wireless telephony
@@ -77,7 +71,6 @@ you’ll find a small sample of real world usage of Ruby.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/fr/documentation/success-stories/index.md
+++ b/fr/documentation/success-stories/index.md
@@ -34,11 +34,6 @@ témoignages du « monde réel. »
 * Le projet MORPHA a utilisé Ruby pour implémenter la partie de
   contrôle réactif du robot de service Siemens.
 
-#### Réseaux
-
-* [Open Domain Server][7] fait usage de Ruby pour mapper en temps réel
-  les adresses statiques aux configurations DynDNS de leurs clients.
-
 #### Téléphonie
 
 * Ruby est utilisé sur un projet de [Lucent][8]\: un téléphone 3G sans
@@ -66,7 +61,6 @@ témoignages du « monde réel. »
 [3]: http://www.motorola.com
 [4]: http://www.sketchup.com/
 [5]: https://www.uhn.ca/TorontoRehab
-[7]: http://ods.org/
 [8]: http://www.lucent.com/
 [9]: http://www.level3.com/
 [10]: http://www.basecamphq.com

--- a/id/documentation/success-stories/index.md
+++ b/id/documentation/success-stories/index.md
@@ -34,12 +34,6 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 * Proyek MORPHA menggunakan Ruby untuk mengimplementasikan bagian
   pengendali reaktif dari robot Siemens yang digunakan.
 
-#### Jaringan Komputer
-
-* [Open Domain Server][6] menggunakan Ruby untuk memungkinkan pengguna
-  Dynamic DNS meng-*update* konfigurasi IP mereka secara *real time*
-  agar dapat dipetakan ke domain statis.
-
 #### Telekomunikasi
 
 * Ruby digunakan oleh [Lucent][7] pada produk wireless 3G yang mereka
@@ -81,7 +75,6 @@ kecil contoh dari berbagai penggunaan Ruby di dunia nyata.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/it/documentation/success-stories/index.md
+++ b/it/documentation/success-stories/index.md
@@ -32,13 +32,6 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 * Il progetto MORPHA utilizza Ruby per implementare il controllo
   della reattività dei componenti della Simens service robot.
 
-#### Networking
-
-* [Open Domain Server][6] utilizza Ruby per permettere alle persone di
-  utilizzare dei programmi che permettono di aggiornare in tempo reale i
-  loro DNS dinamici, così che possano essere collegati a un dominio
-  statico.
-
 #### Telefonia
 
 * Ruby viene utilizzato in [Lucent][7] un prodotto telefonico di terza
@@ -75,7 +68,6 @@ alcuni esempi reali di come viene utilizzato Ruby nel mondo.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/ko/documentation/success-stories/index.md
+++ b/ko/documentation/success-stories/index.md
@@ -31,11 +31,6 @@ lang: ko
 * MORPHA 프로젝트에서는, 루비는 Siemens 서비스 로봇의 반응 컨트롤
   부분에 사용되고 있습니다.
 
-#### 네트워킹
-
-* [Open Domain Server][6]에서는 루비를 정적 도메인에 매핑할 수 있도록
-  다이나믹 DNS 클라이언트의 IP 설정을 실시간 업데이트하는데 사용합니다.
-
 #### 전화
 
 * 루비는 3G 무선 전화 제품인 [Lucent][7]에서도 사용됩니다.
@@ -72,7 +67,6 @@ lang: ko
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/pl/documentation/success-stories/index.md
+++ b/pl/documentation/success-stories/index.md
@@ -28,12 +28,6 @@ Rubiego w rzeczywistości.
 * W projekcie MORPHA, Ruby został użyty do implementacji systemu
   kontroli reakcji Robota usługowego firmy Siemens.
 
-#### Sieci
-
-* [Open Domain Server][6] używa Rubiego aby umożliwić korzystanie z
-  dynamicznych klientów DNS do aktualizacji w czasie rzeczywistym ich
-  adresów IP w taki sposób, żeby wskazywały na statyczne domeny.
-
 #### Telefonia
 
 * [Lucent][7] używa Rubiego w swoim produkcie telefonii bezprzewodowej
@@ -83,7 +77,6 @@ Rubiego w rzeczywistości.
 [2]: http://www-106.ibm.com/developerworks/linux/library/l-oslab/
 [3]: http://www.motorola.com
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/pt/documentation/success-stories/index.md
+++ b/pt/documentation/success-stories/index.md
@@ -32,12 +32,6 @@ Aqui você encontrará uma pequena amostra do uso de Ruby no mundo real.
 * No projeto MORPHA, Ruby foi usado para implementar a parte do
   controle reativo do robô de serviços da Siemens.
 
-#### Redes
-
-* O [Open Domain Server][6] usa Ruby de forma a permitir que as pessoas
-  usem clientes de DNS Dinâmicos para a atualização em tempo real das
-  configurações de IP para que possam ser mapeadas em domínios estáticos.
-
 #### Telefonia
 
 * Ruby está sendo utilizado na [Lucent][7] num produto de telefonia
@@ -76,7 +70,6 @@ Aqui você encontrará uma pequena amostra do uso de Ruby no mundo real.
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/ru/documentation/success-stories/index.md
+++ b/ru/documentation/success-stories/index.md
@@ -34,13 +34,6 @@ lang: ru
 * В проекте MORPHA, Ruby был задействован для создания реактивных
   элементов управления для обслуживающего робота Siemens.
 
-#### Сеть
-
-* [Open Domain Server][6] использует Ruby, чтобы позволить людям
-  использовать динамические DNS клиенты для того, чтобы онлайн обновлять
-  их конфигурацию IP таким образом, что он может быть привязан к
-  статическим доменам.
-
 #### Телефония
 
 * Ruby используется в [Lucent][7], в их 3G беспроводном телефонном
@@ -79,7 +72,6 @@ lang: ru
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/tr/documentation/success-stories/index.md
+++ b/tr/documentation/success-stories/index.md
@@ -33,12 +33,6 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 * MORPHA projesinde, Ruby Siemens servis robotunun reaktif denetim
   kısmını uygulamak için kullanıldı.
 
-#### Ağ
-
-* [Open Domain Server][5] IP ayarlarının gerçek zamanlı olarak
-  güncellenmesini ve böylece statik domainler ile eşlenebilmesini
-  sağlayan “Dynamic DNS” istemcileri Ruby ile yazıldı.
-
 #### Telefonculuk
 
 * Ruby 3G kablosuz telefonculuk ürünü olan [Lucent][6] içinde
@@ -76,7 +70,6 @@ olarak. Burada Ruby’nin gerçek dünyadan örneklerini görebilirsiniz.
 [1]: http://www.larc.nasa.gov/
 [2]: http://www.sketchup.com/
 [3]: https://www.uhn.ca/TorontoRehab
-[5]: http://ods.org/
 [6]: http://www.lucent.com/
 [7]: http://www.level3.com/
 [8]: http://www.basecamphq.com

--- a/vi/documentation/success-stories/index.md
+++ b/vi/documentation/success-stories/index.md
@@ -31,12 +31,6 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 
 * Dự án MORPHA dùng Ruby để triển khai phần tương tác phản hồi của cho rô-bô dịch vụ của Siemens.
 
-#### Mạng
-
-* [Open Domain Server][6] dùng Ruby để cho phép người dùng sử dụng trình client
-  DNS động (Dynamic DNS) để cập nhật cấu hình IP của họ trong thời gian thực,
-  giúp IP kết nối vào những domain tĩnh.
-
 #### Viễn thông
 
 * Ruby được sử dụng bên trong [Lucent][7] để phát triển các sản phảm viễn thông 3G.
@@ -71,7 +65,6 @@ nó như thứ tiêu khiển. Trong trang này, bạn sẽ tìm thấy những v
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/zh_cn/documentation/success-stories/index.md
+++ b/zh_cn/documentation/success-stories/index.md
@@ -27,10 +27,6 @@ lang: zh_cn
 
 * 在 MORPHA 项目，Ruby 用来实现西门子服务机器人的反应控制部分。
 
-#### 网络
-
-* [Open Domain Server][6] 使用 Ruby 帮助人们使用动态域名解析客户端实时更新IP配置，达到映射到静态域的目的。
-
 #### 电讯
 
 * [朗讯][7]一个3G无线电话产品中使用了 Ruby。
@@ -57,7 +53,6 @@ lang: zh_cn
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com

--- a/zh_tw/documentation/success-stories/index.md
+++ b/zh_tw/documentation/success-stories/index.md
@@ -25,11 +25,6 @@ lang: zh_tw
 
 * 在 MORPHA 計畫中，使用 Ruby 來實作西門子公司服務型機器人的反應控制部份。
 
-#### 網路
-
-* [Open Domain Server][6] 使用 Ruby 讓使用者可以使用『動態DNS客戶端程式』及時更新 IP
-  設定來對應到靜態網域設定。
-
 #### 電信
 
 * Ruby 也被用在 [Lucent][7] 3G無線電信產品中。
@@ -52,7 +47,6 @@ lang: zh_tw
 [2]: http://www.motorola.com
 [3]: http://www.sketchup.com/
 [4]: https://www.uhn.ca/TorontoRehab
-[6]: http://ods.org/
 [7]: http://www.lucent.com/
 [8]: http://www.level3.com/
 [9]: http://www.basecamphq.com


### PR DESCRIPTION
According to [archive.org][1] ODS is not longer on business and about Feb 2019 their website started to return 403

[1]: https://web.archive.org/web/20190226032335/http://www.ods.org/