### PR TITLE
Remove defunct RubyNation website from the EN version

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -46,9 +46,6 @@ events.
 Ruby Central has also teamed up with [SVForum][7] (previously known as SDForum)
 to produce the Silicon Valley Ruby Conference, entering its second year in 2007.
 
-[RubyNation][8] is an annual Ruby conference serving the Virginia, West
-Virginia, Maryland, and Washington, DC areas.
-
 [WindyCityRails][9] is an annual gathering for all who are passionate about
 Ruby on Rails. The Chicago-based conference has served the Ruby
 community since 2008.
@@ -82,7 +79,6 @@ O’Reilly), and Canada on Rails.
 [4]: http://euruko.org
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org


### PR DESCRIPTION
Removed the URL from the english version of the website.

Not sure what the best way to do the other languages, as it seems you need approval from all maintainers which may or may not happen. So just doing english for now.