### PR TITLE
Update the Silicon Valley Ruby Conference section on Conferences

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -43,8 +43,9 @@ event dates, location, CFP (Call For Proposals) and Registration information.
 to offset expenses for local and regional groups wanting to organize
 events.
 
-Ruby Central has also teamed up with [SVForum][7] (previously known as SDForum)
-to produce the Silicon Valley Ruby Conference, entering its second year in 2007.
+Ruby Central had also teamed up with SVForum (previously known as SDForum)
+to produce the Silicon Valley Ruby Conference, which ran for 2 years for 2006 
+and 2007.
 
 [RubyNation][8] is an annual Ruby conference serving the Virginia, West
 Virginia, Maryland, and Washington, DC areas.
@@ -81,7 +82,6 @@ O’Reilly), and Canada on Rails.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [6]: http://rubycentral.org/community/grant
-[7]: http://www.svforum.org
 [8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/


### PR DESCRIPTION
SVForum doesn't exist anymore, and the conference ran for two years
only. So updating the context, might be useful for anyone who might want
to restart the conference.