### PR TITLE
Update English installation instructions

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -52,6 +52,7 @@ Here are available installation methods:
   * [RubyInstaller](#rubyinstaller) (Windows)
   * [Ruby Stack](#rubystack)
 * [Managers](#managers)
+  * [asdf-vm](#asdf-vm)
   * [chruby](#chruby)
   * [rbenv](#rbenv)
   * [RVM](#rvm)
@@ -265,6 +266,15 @@ project and other advantages but are not officially supported. You can
 however find support within their respective communities.
 
 
+### asdf-vm
+{: #asdf-vm}
+
+[asdf-vm][asdf-vm] is an extendable version manager that can manage multiple
+language runtime versions on a per-project basis. You will need the
+[asdf-ruby][asdf-ruby] plugin (which in turn uses [ruby-build](#ruby-build))
+to install Ruby.
+
+
 ### chruby
 {: #chruby}
 
@@ -337,3 +347,5 @@ though, because the installed Ruby won't be managed by any tools.
 [installers]: /en/documentation/installation/#installers
 [readme]: https://github.com/ruby/ruby#how-to-compile-and-install
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
+[asdf-vm]: https://asdf-vm.com/
+[asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -50,7 +50,7 @@ Here are available installation methods:
   * [ruby-build](#ruby-build)
   * [ruby-install](#ruby-install)
   * [RubyInstaller](#rubyinstaller) (Windows)
-  * [RailsInstaller and Ruby Stack](#railsinstaller)
+  * [Ruby Stack](#rubystack)
 * [Managers](#managers)
   * [chruby](#chruby)
   * [rbenv](#rbenv)
@@ -245,15 +245,12 @@ to set up a full Ruby development environment.
 Just download it, run it, and you are done!
 
 
-### RailsInstaller and Ruby Stack
-{: #railsinstaller}
+### Ruby Stack
+{: #rubystack}
 
 If you are installing Ruby in order to use Ruby on Rails,
-you can use the following installers:
+you can use the following installer:
 
-* [RailsInstaller][railsinstaller] uses [RubyInstaller][rubyinstaller]
-  but gives you extra tools that help with Rails development. It
-  supports macOS and Windows.
 * [Bitnami Ruby Stack][rubystack] provides a complete development
   environment for Rails. It supports macOS, Linux, Windows, virtual
   machines, and cloud images.
@@ -329,7 +326,6 @@ though, because the installed Ruby won't be managed by any tools.
 [chruby]: https://github.com/postmodern/chruby#readme
 [uru]: https://bitbucket.org/jonforums/uru
 [rubyinstaller]: https://rubyinstaller.org/
-[railsinstaller]: http://railsinstaller.org/
 [rubystack]: http://bitnami.com/stack/ruby/installer
 [openindiana]: http://openindiana.org/
 [gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/


### PR DESCRIPTION
1. Remove [RailsInstaller](http://railsinstaller.org/en) as it has not been maintained. 
  RailsInstaller only has installers for Ruby 2.2 and 2.3 on Windows and Ruby 1.9 on OS X 10.8 (from 2012, macOS is now at 10.15)
2. Add [asdf-vm](https://asdf-vm.com/) to the list of package managers.
  asdf-vm is a modern, extendable version manager with plugins for a variety of languages. 