### PR TITLE
Add rubytalk.org as additional archive to mailing list page (en)

### DIFF
--- a/en/community/mailing-lists/index.md
+++ b/en/community/mailing-lists/index.md
@@ -12,7 +12,7 @@ Ruby has four primary English speaking mailing lists:
 
 Ruby-Talk
 : This is the most popular mailing-list and deals with general topics
-  about Ruby. ([Archives][3], [Posting Guidelines][guidelines])
+  about Ruby. ([Archives][3], [Posting Guidelines][guidelines], [Community Archive][rubytalk])
 
 Ruby-Core
 : This list deals with core and implementation topics about Ruby, often
@@ -47,3 +47,4 @@ subscribing the [manual way](manual-instructions/).
 [3]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
 [4]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
 [5]: http://lists.ruby-lang.org/pipermail/ruby-doc/
+[rubytalk]: https://rubytalk.org/


### PR DESCRIPTION
Part of https://github.com/ruby/www.ruby-lang.org/issues/1730.

<img width="641" alt="スクリーンショット 2019-10-27 12 33 56" src="https://user-images.githubusercontent.com/1000669/67629207-66909b00-f8b6-11e9-8eda-23be3a6980a6.png">
