### PR TITLE
Update translation of community/mailing-lists (ko)

### DIFF
--- a/ko/community/mailing-lists/index.md
+++ b/ko/community/mailing-lists/index.md
@@ -10,23 +10,25 @@ lang: ko
 루비는 4개의 주요한 메일링 리스트(영문)를 가지고 있습니다.
 
 Ruby-Talk
-: 이 곳은 가장 유명한 메일링 리스트로 루비에 관한 일반적인 주제를 다룹니다.
-  ([Archives][3])
+: 이곳은 가장 유명한 메일링 리스트로 루비에 관한 일반적인 주제를 다룹니다.
+  ([아카이브][3], [포스팅 지침][guidelines], [커뮤니티 아카이브][rubytalk])
 
 Ruby-Core
-: 이 곳은 루비의 코어와 구현에 관한 주제를 다룹니다. 주로 패치의 리뷰에
-  활용되고 있습니다. ([Archives][4])
+: 이곳은 루비의 코어와 구현에 관한 주제를 다룹니다. 주로 패치의 리뷰에
+  활용되고 있습니다. ([아카이브][4])
 
 Ruby-Doc
-: 이 곳에서는 문서화 표준과 도구에 관한 토론을 합니다. ([Archives][5])
+: 이곳에서는 문서화 표준과 도구에 관한 토론을 합니다. ([아카이브][5])
 
 Ruby-CVS
-: 이 곳에서는 루비의 Subversion 저장소의 커밋들이 보고됩니다.
+: 이곳에서는 루비의 Subversion 저장소의 커밋들이 보고됩니다.
 
 comp.lang.ruby 뉴스그룹
 : 유즈넷을 통해 메일링 리스트를 구독하는 것을 선호하시는 분들은
-  [comp.lang.ruby](news:comp.lang.ruby) 뉴스그룹에서 체크아웃하세요.
+  [comp.lang.ruby](news:comp.lang.ruby) 뉴스그룹에서 체크아웃하세요. ([FAQ][clrFAQ])
 
+ruby-lang.org의 일본어 리스트를 포함한 모든 메일링 리스트에 대해 자세히 알고
+싶다면 [lists.ruby-lang.org](http://lists.ruby-lang.org)를 참조하세요.
 
 ## 구독과 해지
 
@@ -37,6 +39,9 @@ comp.lang.ruby 뉴스그룹
 
 
 
+[guidelines]: /en/community/mailing-lists/ruby-talk-guidelines/
+[clrFAQ]: http://rubyhacker.com/clrFAQ.html
 [3]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
 [4]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
 [5]: http://lists.ruby-lang.org/pipermail/ruby-doc/
+[rubytalk]: https://rubytalk.org/


### PR DESCRIPTION
I see the first commit of ko/community/mailing-lists/index.md is 4a5680269ca19c908885642df7732d673404b28e, try this to see the diff:
``` sh
git diff 4a56802 -- en/community/mailing-lists/index.md
```

Additional updates:
- 이 곳 → 이곳
- Translate links
  - Files under en/community/mailing-lists/ruby-talk-guidelines/ are not translated yet, so I linked to en version

``` diff
diff --git a/en/community/mailing-lists/index.md b/en/community/mailing-lists/index.md
index 05794b78..05237383 100644
--- a/en/community/mailing-lists/index.md
+++ b/en/community/mailing-lists/index.md
@@ -12,8 +12,7 @@ Ruby has four primary English speaking mailing lists:
 
 Ruby-Talk
 : This is the most popular mailing-list and deals with general topics
-  about Ruby. Ruby-Talk is mirrored by [Ruby-Forum.com][1]. ([FAQ][2]
-  and [Archives][3])
+  about Ruby. ([Archives][3], [Posting Guidelines][guidelines], [Community Archive][rubytalk])
 
 Ruby-Core
 : This list deals with core and implementation topics about Ruby, often
@@ -21,15 +20,18 @@ Ruby-Core
 
 Ruby-Doc
 : This list is for discussing documentation standards and tools for
-  Ruby. ([Archives at Gmane][5])
+  Ruby. ([Archives][5])
 
 Ruby-CVS
-: This list reports all commits to Ruby’s CVS repository.
+: This list reports all commits to Ruby’s Subversion repository.
 
 The comp.lang.ruby Newsgroup
 : Those who prefer Usenet over mailing lists will want to checkout the
-  [comp.lang.ruby](news:comp.lang.ruby) newsgroup.
+  [comp.lang.ruby](news:comp.lang.ruby) newsgroup. ([FAQ][clrFAQ])
 
+See [lists.ruby-lang.org](http://lists.ruby-lang.org)
+for more information about all mailing lists on ruby-lang.org,
+including the lists in Japanese language.
 
 ## Subscribe or Unsubscribe
 
@@ -40,8 +42,9 @@ subscribing the [manual way](manual-instructions/).
 
 
 
-[1]: http://ruby-forum.com
-[2]: http://rubyhacker.com/clrFAQ.html
+[guidelines]: ruby-talk-guidelines/
+[clrFAQ]: http://rubyhacker.com/clrFAQ.html
 [3]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
 [4]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
-[5]: http://dir.gmane.org/gmane.comp.lang.ruby.documentation
+[5]: http://lists.ruby-lang.org/pipermail/ruby-doc/
+[rubytalk]: https://rubytalk.org/
```