### PR TITLE
Fix Linter's SHA length test

### DIFF
--- a/lib/linter.rb
+++ b/lib/linter.rb
@@ -83,6 +83,13 @@ class Linter
         errors[doc] << "missing translator variable"  if doc.translator_missing?
         errors[doc] << "missing date variable"  if doc.date_missing?
       end
+
+      if doc.release_post?
+        errors[doc] << "invalid SHA1 length"  if doc.sha1_length_invalid?
+        errors[doc] << "invalid SHA256 length"  if doc.sha256_length_invalid?
+        errors[doc] << "invalid SHA512 length"  if doc.sha512_length_invalid?
+      else
+      end
     end
   end
 

--- a/lib/linter/document.rb
+++ b/lib/linter/document.rb
@@ -100,22 +100,25 @@ class Linter
     end
 
     def sha1_length_invalid?
-      matchdata = content.match(/SHA1: *(?<sha>[0-9a-f]*)/)
+      matchdata = content.match(/SHA1: *(?<sha>[{0-9a-f]*)/)
       return nil  unless matchdata
+      return nil  if matchdata[:sha].start_with?("{{")  # {{ Liquid output }}
 
       matchdata[:sha].size != 40
     end
 
     def sha256_length_invalid?
-      matchdata = content.match(/SHA256: *(?<sha>[0-9a-f]*)/)
+      matchdata = content.match(/SHA256: *(?<sha>[{0-9a-f]*)/)
       return nil  unless matchdata
+      return nil  if matchdata[:sha].start_with?("{{")  # {{ Liquid output }}
 
       matchdata[:sha].size != 64
     end
 
     def sha512_length_invalid?
-      matchdata = content.match(/SHA512: *(?<sha>[0-9a-f]*)/)
+      matchdata = content.match(/SHA512: *(?<sha>[{0-9a-f]*)/)
       return nil  unless matchdata
+      return nil  if matchdata[:sha].start_with?("{{")  # {{ Liquid output }}
 
       matchdata[:sha].size != 128
     end

--- a/test/md_ok/en/_posts/2019-01-01-ruby-with-sha-sums-liquid-released.md
+++ b/test/md_ok/en/_posts/2019-01-01-ruby-with-sha-sums-liquid-released.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "Release Post"
+author: "stomar"
+translator:
+date: 2019-01-01 12:00:00 +0000
+lang: en
+---
+
+Content
+
+Sums:
+
+    SHA1:    {{ sha1 }}
+    SHA256:  {{ sha256 }}
+    SHA512:  {{ sha512 }}


### PR DESCRIPTION
The old tests did not work with the new style of using Liquid output instead of "hard coded" SHA sums; so they were removed completely. This PR reintroduces the tests and fixes them.