### PR TITLE
Add Linter test for correct syntax highlighting

### DIFF
--- a/de/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/de/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -43,13 +43,13 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.

--- a/en/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/en/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -28,13 +28,13 @@ The `GC.compact` method is introduced for compacting the heap. This function com
 Pattern matching, widely used feature in functional programming languages, is introduced as an experimental feature. [#14912](https://bugs.ruby-lang.org/issues/14912)
 It can traverse a given object and assign its value if it matches a pattern.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 For more details, please see [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 

--- a/en/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/en/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -29,13 +29,13 @@ The `GC.compact` method is introduced for compacting the heap. This function com
 Pattern matching, widely used feature in functional programming languages, is introduced as an experimental feature. [[Feature #14912]](https://bugs.ruby-lang.org/issues/14912)
 It can traverse a given object and assign its value if it matches a pattern.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 For more details, please see [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 
@@ -60,12 +60,12 @@ deprecated, and conversion will be removed in Ruby 3.  [[Feature #14183]](https:
   splat operator to avoid the warning and ensure correct behavior in
   Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # warned
   def foo(**kw);    end; foo({key: 42})   # warned
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * When a method call passes keywords to a method that accepts keywords,
   but it does not pass enough required positional arguments, the
@@ -73,12 +73,12 @@ deprecated, and conversion will be removed in Ruby 3.  [[Feature #14183]](https:
   warning is emitted.  Pass the argument as a hash instead of keywords
   to avoid the warning and ensure correct behavior in Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # warned
   def foo(h, key: 42); end; foo(key: 42)   # warned
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * When a method accepts specific keywords but not a keyword splat, and
   a hash or keywords splat is passed to the method that includes both
@@ -86,50 +86,50 @@ deprecated, and conversion will be removed in Ruby 3.  [[Feature #14183]](https:
   a warning will be emitted.  You will need to update the calling code
   to pass separate hashes to ensure correct behavior in Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # warned
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # warned
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  ```
+  {% endhighlight %}
 
 * If a method does not accept keywords, and is called with keywords,
   the keywords are still treated as a positional hash, with no warning.
   This behavior will continue to work in Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # OK
-  ```
+  {% endhighlight %}
 
 * Non-symbols are allowed as a keyword argument keys if method accepts
   arbitrary keywords.  [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * <code>**nil</code> is allowed in method definitions to explicitly mark
   that the method accepts no keywords. Calling such a method with keywords
   will result in an ArgumentError.  [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  ```
+  {% endhighlight %}
 
 * Passing an empty keyword splat to a method that does not accept keywords
   no longer passes an empty hash, unless the empty hash is necessary for
   a required parameter, in which case a warning will be emitted.  Remove
   the double splat to continue passing a positional hash.  [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} and warning
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## Other Notable New Features
 
@@ -140,36 +140,36 @@ deprecated, and conversion will be removed in Ruby 3.  [[Feature #14183]](https:
 * A beginless range is experimentally introduced.  It might not be as useful
   as an endless range, but would be good for DSL purpose. [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-  ```ruby
+  {% highlight ruby %}
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  ```
+  {% endhighlight %}
 
 * `Enumerable#tally` is added.  It counts the occurrence of each element.
 
-  ```ruby
+  {% highlight ruby %}
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  ```
+  {% endhighlight %}
 
 * Calling a private method on `self` is now allowed.  [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) [[Feature #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * `Enumerator::Lazy#eager` is added.  It generates a non-lazy enumerator
   from a lazy enumerator.  [[Feature #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## Performance improvements
 

--- a/es/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/es/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -30,7 +30,7 @@ El método `GC.compact` se introduce para compactar el montón (heap). Esta func
 El reconocimiento de patrones, es una característica ampliamente usada en lenguajes de programación funcional, se introduce como característica experimental.  [#14912](https://bugs.ruby-lang.org/issues/14912)
 Puede recorrer un objeto dado y asignar su valor si concuerda con un patrón.
 
-```ruby
+{% highlight ruby %}
 json ='{
 	"nombre": "Alice",
 	"edad": 30,
@@ -45,7 +45,7 @@ case JSON.parse(json, symbolize_names: true)
 in {nombre: "Alice", hijos: [{nombre: "Bob", edad: edad}]}
   p edad
 end
-```
+{% endhighlight %}
 
 Puede ver más detalles en [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 

--- a/es/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/es/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -42,7 +42,7 @@ experimental.
 [[Característica #14912]](https://bugs.ruby-lang.org/issues/14912)
 Puede recorrer un objeto dado y asignar su valor si concuerda con un patrón.
 
-```ruby
+{% highlight ruby %}
 json ='{
 	"nombre": "Alice",
 	"edad": 30,
@@ -57,7 +57,7 @@ case JSON.parse(json, symbolize_names: true)
 in {nombre: "Alice", hijos: [{nombre: "Bob", edad: edad}]}
   p edad
 end
-```
+{% endhighlight %}
 
 Puede ver más detalles en [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 
@@ -93,12 +93,12 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   operador doble splat all llamarla para evitar la advertencia y asegurar el
   comportamiento correcto en Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # advertencia
   def foo(**kw);    end; foo({key: 42})   # advertencia
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * Si la llamada a un método pasa palabras clave a un método que acepta
   palabras clave, pero no pasa suficientes argumentos posicionales,
@@ -107,12 +107,12 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   Pase los argumentos como un diccionario en lugar de palabras clave para
   evitar la advertencia y asegurar el comportamiento correcto en Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # warned
   def foo(h, key: 42); end; foo(key: 42)   # warned
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * Si un método acepta palabras clave especificas, pero no una palabra
   clave splat, y si se pasa un diccionario o palabra clave splat al método
@@ -121,40 +121,40 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   Tendrá que actualizar el código que hace la llamada para pasar diccionarios
   separados y asegurar el comportamiento correcto en Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # warned
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # warned
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  ```
+  {% endhighlight %}
 
 * Si un método no acepta palabras clave, y se llama con palabras clave,
   las palabras clave se tratarán como un diccionario posicional, sin
   advetencias.  Este comportamiento seguirá operando en Ruby 3.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # OK
-  ```
+  {% endhighlight %}
 
 * Las cadenas que no sean símbolos se aceptarán como argumentos con
   palabras clave si el método acepta palabras clave arbitrarias.
   [[Característica #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * <code>**nil</code> se permite en la definición de métodos para marcar
   explicitamente que el método no acepta palabras clave.  Llamar
   a un método así con palabras clave resultará en un `ArgumentError`.
   [[Característica #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  ```
+  {% endhighlight %}
 
 * Si se pasa una palabra clave splat a un método que no acepta
   palabras clave, ya no pasará un diccionario vacío, a menos que el
@@ -163,12 +163,12 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   pasando un diccionario posicional.
   [[Característica #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} and warning
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## Otras caracerísticas nuevas y notables
 
@@ -198,23 +198,23 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   [[Característica #11297]](https://bugs.ruby-lang.org/issues/11297),
   [[Característica #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * Se añade `Enumerator::Lazy#eager`.  Que genera un enumerador no-perezoso
   a partir de un enumerador perezoso.
   [[Característica #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## Mejoras en desempeño
 

--- a/id/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/id/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -36,13 +36,13 @@ fungsional, dikenalkan sebagai sebuah fitur eksperimental. [#14912](https://bugs
 Ini dapat melewati sebuah objek dan menetapkan nilanya jika cocok dengan sebuah
 pola.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 Untuk lebih detail, mohon lihat [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 

--- a/ja/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/ja/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -25,13 +25,13 @@ Ruby 2.7では`GC.compact` というメソッドを導入し、ヒープをコ�
 関数型言語で広く使われているパターンマッチという機能が実験的に導入されました。
 渡されたオブジェクトの構造がパターンと一致するかどうかを調べ、一致した場合にその値を変数に代入するといったことができるようになります。 [#14912](https://bugs.ruby-lang.org/issues/14912)
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 詳細については [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7) を参照してください。
 

--- a/ja/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/ja/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -25,13 +25,13 @@ Ruby 2.7では`GC.compact` というメソッドを導入し、ヒープをコ�
 関数型言語で広く使われているパターンマッチという機能が実験的に導入されました。
 渡されたオブジェクトの構造がパターンと一致するかどうかを調べ、一致した場合にその値を変数に代入するといったことができるようになります。 [[Feature #14912]](https://bugs.ruby-lang.org/issues/14912)
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 詳細については [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7) を参照してください。
 
@@ -51,60 +51,60 @@ Ruby に添付されている REPL (Read-Eval-Print-Loop) である `irb` で、
 
 * メソッド呼び出しにおいて最後の引数としてハッシュオブジェクトを渡し、他にキーワード引数を渡さず、かつ、呼ばれたメソッドがキーワード引数を受け取るとき、警告が表示されます。キーワード引数として扱いたい場合は、明示的にdouble splat演算子（`**`）を足すことで警告を回避できます。このように書けばRuby 3でも同じ意味で動きます。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # warned
   def foo(**kw);    end; foo({key: 42})   # warned
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * キーワード引数を受け取るメソッドにキーワード引数を渡すが、必須引数が不足している場合に、キーワード引数は最後の必須引数として解釈され、警告が表示されます。警告を回避するには、キーワードではなく明示的にハッシュとして渡してください。このように書けばRuby 3でも同じ意味で動きます。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # warned
   def foo(h, key: 42); end; foo(key: 42)   # warned
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * メソッドがキーワード引数を受け取るがdouble splat引数は受け取らず、かつ、メソッド呼び出しでSymbolと非Symbolの混ざったハッシュを渡す（もしくはハッシュをdouble splatでキーワードとして渡す）場合、ハッシュは分割され、警告が表示されます。Ruby 3でもハッシュの分割を続けたい場合は、呼び出し側で明示的に分けるようにしてください。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # warned
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # warned
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  ```
+  {% endhighlight %}
 
 * メソッドがキーワード引数を受け取らず、呼び出し側でキーワード引数を渡した場合、ハッシュの引数としてみなされる挙動は変わらず、警告も表示されません。Ruby 3でもこのコードは動き続ける予定です。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # OK
-  ```
+  {% endhighlight %}
 
 * メソッドが任意のキーワードを受け取る場合、非Symbolがキーワード引数のキーとして許容されるようになります。[[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * メソッド定義で<code>**nil</code>と書くことで、このメソッドがキーワードを受け取らないことを明示できるようになりました。このようなメソッドをキーワード引数付きで呼び出すとArgumentErrorになります。[[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  ```
+  {% endhighlight %}
 
 * キーワード引数を受け取らないメソッドに対して空のハッシュをdouble splatで渡すとき、空のハッシュが渡る挙動はなくなりました。ただし、必須引数が不足する場合は空のハッシュが渡され、警告が表示されます。ハッシュの引数として渡したい場合はdouble splatをつけないようにしてください。
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} and warning
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## 主要な新機能
 
@@ -114,35 +114,35 @@ Ruby に添付されている REPL (Read-Eval-Print-Loop) である `irb` で、
 
 * 開始値省略範囲式が試験的に導入されました。これは終了値省略範囲式ほど有用ではないと思われますが、しかし DSL のような目的には役立つかもしれません。 [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-  ```ruby
+  {% highlight ruby %}
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  ```
+  {% endhighlight %}
 
 * `Enumerable#tally` が追加されました。各要素の出現回数を数えます。
 
-  ```ruby
+  {% highlight ruby %}
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  ```
+  {% endhighlight %}
 
 * レシーバを`self`としてprivateメソッドを呼び出すことが許容されるようになりました。 [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) [[Feature #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * `Enumerator::Lazy#eager` が追加されました。lazyなEnumeratorを非lazyなEnumeratorに変換します。
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## パフォーマンスの改善
 

--- a/ko/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/ko/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -28,13 +28,13 @@ lang: ko
 함수형 언어에서 널리 알려진 기능인 패턴 매칭이 실험적으로 도입되었습니다. [#14912](https://bugs.ruby-lang.org/issues/14912)
 이는 패턴에 일치하는 경우, 주어진 객체를 순회하여 그 값을 대입합니다.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 더 자세한 설명은 [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)을 확인해 주세요.
 

--- a/lib/linter.rb
+++ b/lib/linter.rb
@@ -59,6 +59,12 @@ class Linter
     @posts = @docs.select {|doc| doc.post? }
   end
 
+  def syntax_highlighting_message(language)
+    "wrong syntax highlighting: " +
+    "use '{% highlight #{language} %}...{% endhighlight %}' " +
+    "instead of '```#{language}' block"
+  end
+
   def check
     docs.each do |doc|
       errors[doc] << "missing or invalid lang variable"  if doc.lang_invalid?
@@ -66,6 +72,8 @@ class Linter
       errors[doc] << "no newline at end of file"  if doc.no_newline_at_eof?
       errors[doc] << "blank line(s) at end of file"  if doc.blank_line_at_eof?
       errors[doc] << "wrong line breaks (CR/LF)"  if doc.crlf_line_breaks?
+      errors[doc] << syntax_highlighting_message("ruby")  if doc.fenced_code?("ruby")
+      errors[doc] << syntax_highlighting_message("sh")  if doc.fenced_code?("sh")
 
       unless WHITESPACE_EXCLUSIONS.include?(doc.filename)
         errors[doc] << "trailing whitespace"  if doc.trailing_whitespace?

--- a/lib/linter/document.rb
+++ b/lib/linter/document.rb
@@ -123,6 +123,10 @@ class Linter
       matchdata[:sha].size != 128
     end
 
+    def fenced_code?(language)
+      content.match?(/^ *``` *#{language}$/)
+    end
+
     private
 
     def read_yaml_and_content(filename)

--- a/pt/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/pt/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -30,7 +30,7 @@ páginas possam ser usadas e a heap possa ser mais _CoW friendly_. [#15626](http
 Pattern matching, funcionalidade amplamenta utilizada em linguagens para programação funcional, é introduzida como uma funcionalidade experimental. [#14912](https://bugs.ruby-lang.org/issues/14912)
 Ela pode examinar um dado objeto e definir seu valor se um padrão for .
 
-```ruby
+{% highlight ruby %}
 json ='{
  	"nombre": "Alice",
  	"edad": 30,
@@ -46,7 +46,7 @@ in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 Para mais detalhes, por favor, veja [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
 

--- a/test/md_errors/en/20_fenced_ruby_code_block.md
+++ b/test/md_errors/en/20_fenced_ruby_code_block.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: "Page"
+lang: en
+---
+
+Content
+
+  ```ruby
+  puts "Hello"
+  ```

--- a/test/md_errors/en/21_fenced_sh_code_block.md
+++ b/test/md_errors/en/21_fenced_sh_code_block.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: "Page"
+lang: en
+---
+
+Content
+
+  ``` sh
+  echo 'Hello'
+  ```

--- a/test/output_errors.txt
+++ b/test/output_errors.txt
@@ -24,6 +24,10 @@ en/11_blank_line_at_eof.md
   blank line(s) at end of file
 en/12_blank_lines_at_eof.md
   blank line(s) at end of file
+en/20_fenced_ruby_code_block.md
+  wrong syntax highlighting: use '{% highlight ruby %}...{% endhighlight %}' instead of '```ruby' block
+en/21_fenced_sh_code_block.md
+  wrong syntax highlighting: use '{% highlight sh %}...{% endhighlight %}' instead of '```sh' block
 en/_posts/2000-01-01-old-lang-variable-nil.md
   missing or invalid lang variable
 en/_posts/2000-01-02-old-translator-variable-wrong-type.md

--- a/tr/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/tr/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -32,13 +32,13 @@ Desen eşleştirme deneysel bir özellik olarak eklenmiştir, bu özellik fonksi
 [#14912](https://bugs.ruby-lang.org/issues/14912)
 Bu özellik, verilen bir nesne üzerinde yürüyebilir ve eğer bu nesne bir desenle eşleşirse, bu nesnenin değerini atayabilir.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 Daha fazla ayrıntı için lütfen [Desen eşleştirme - Ruby 2.7'de yeni bir özellik](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)'e bakın.
 

--- a/tr/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/tr/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -33,13 +33,13 @@ Desen eşleştirme deneysel bir özellik olarak eklenmiştir, bu özellik fonksi
 [Özellik #14912](https://bugs.ruby-lang.org/issues/14912)
 Bu özellik, verilen bir nesne üzerinde yürüyebilir ve eğer bu nesne bir desenle eşleşirse, bu nesnenin değerini atayabilir.
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 Daha fazla ayrıntı için lütfen [Desen eşleştirme - Ruby 2.7'de yeni bir özellik](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)'e bakın.
 
@@ -64,69 +64,69 @@ Anahtar kelime argümanlarının ve konumsal argümanların otomatik dönüştü
 * Eğer bir metod çağrısı son argümanı olarak bir Hash geçirirse, ve hiç anahtar kelime geçirmezse, ve çağrılan metod anahtar kelimeler kabul ediyorsa, bir uyarı yayınlanır.
   Anahtar kelime olarak anlaşılmasını sağlamak, uyarıdan kaçınmak ve Ruby 3'te doğru davranıştan emin olmak için çift yıldız operatörü ekleyin.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # uyarı yayınlanır
   def foo(**kw);    end; foo({key: 42})   # uyarı yayınlanır
   def foo(key: 42); end; foo(**{key: 42}) # İyi
   def foo(**kw);    end; foo(**{key: 42}) # İyi
-  ```
+  {% endhighlight %}
 
 * Eğer bir metod çağrısı, anahtar kelimeler kabul eden bir metoda anahtar kelimeler geçirirse fakat yeterli sayıda zorunlu konumsal argüman geçirmezse, anahtar kelimeler gerekli son konumsal argüman olarak düşünülür ve bir uyarı yayınlanır.
   Uyarıdan kaçınmak ve Ruby 3'te doğru davranıştan emin olmak için argümanı anahtar kelimeler olarak değil de, hash olarak geçirin.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # uyarı yayınlanır
   def foo(h, key: 42); end; foo(key: 42)   # uyarı yayınlanır
   def foo(h, **kw); end; foo({key: 42})    # İyi
   def foo(h, key: 42); end; foo({key: 42}) # İyi
-  ```
+  {% endhighlight %}
 
 * Bir metod belirli anahtar kelimeler bekliyor fakat yıldızlı anahtar kelime beklemiyorsa, ve metoda bir hash ya da hem Symbol hem de Symbol olmayan anahtarları içeren yıldızlı anahtar kelimeler geçirildiyse, hash ayrılmaya devam eder, ve bir uyarı yayınlanır.
   Ruby 3'te doğru davranıştan emin olmak için çağıran kodu ayrı hash'ler geçirecek şekilde güncellemeniz gerekiyor.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # uyarı yayınlanır
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # uyarı yayınlanır
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # İyi
-  ```
+  {% endhighlight %}
 
 * Eğer bir metod anahtar kelime kabul etmiyor ve anahtar kelimeler ile çağrıldıysa, anahtar kelimeler yine konumsal hash olarak düşünülür, herhangi bir uyarı yayınlanmaz.
   Bu davranış Ruby 3'te çalışmaya devam edecek.
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # İyi
-  ```
+  {% endhighlight %}
 
 * Eğer metod keyfi anahtar kelimeler kabul ediyorsa, anahtar kelime argüman anahtarları olarak sembol olmayanlara izin verilir.
   [[Özellik #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * Harici olarak metodun anahtar kelime almadığını belirtmek için metod tanımlarında <code>**nil</code> kullanılabilir.
   Böyle bir metodu anahtar kelimeler ile çağırmak ArgumentError ile sonuçlanır.
   [[Özellik #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # İyi
   def foo(h, **nil); end; foo({"str" => 1}) # İyi
-  ```
+  {% endhighlight %}
 
 * Anahtar kelime almayan bir metoda boş bir anahtar kelime yıldızı geçirmek artık boş bir hash geçirmiyor.
   Ancak gerekli bir parametre için boş bir hash gerekliyse, bir uyarı yayınlanır.
   Konumsal bir hash geçirmeye devam etmek için çift yıldızı kaldırın.
   [[Özellik #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} ve uyarı
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## Dikkate Değer Diğer Yeni Özellikler
 
@@ -140,39 +140,39 @@ Anahtar kelime argümanlarının ve konumsal argümanların otomatik dönüştü
   Bu, sonsuz aralık kadar kullanışlı olmayabilir, fakat DSL kullanımları için iyi olacaktır.
   [[Özellik #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-  ```ruby
+  {% highlight ruby %}
   ary[..3]  # ary[0..3] ile aynı
   rel.where(sales: ..100)
-  ```
+  {% endhighlight %}
 
 * `Enumerable#tally` eklendi.
   Bu metod, her öğenin kaç kere geçtiğini sayar.
 
-  ```ruby
+  {% highlight ruby %}
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  ```
+  {% endhighlight %}
 
 * `self` üstünden özel bir metodu çağırmaya artık izin verilmiyor.
   [[Özellik #11297]](https://bugs.ruby-lang.org/issues/11297) [[Özellik #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * `Enumerator::Lazy#eager` eklendi.
   Bu, tembel bir numaralandırıcıdan tembel olmayan bir numaralandırıcı oluşturur.
   [[Özellik #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## Performans iyileştirmeleri
 

--- a/zh_cn/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/zh_cn/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -28,13 +28,13 @@ lang: zh_cn
 
 在函数式编程中非常常用的模式匹配功能，作为实验性功能被加入了。[#14912](https://bugs.ruby-lang.org/issues/14912) 它可以遍历一个对象，并在其满足某一模式时进行赋值。
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 关于更多信息，请查阅 [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)。
 

--- a/zh_cn/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/zh_cn/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -29,13 +29,13 @@ lang: zh_cn
 
 在函数式编程中非常常用的模式匹配功能，作为实验性功能被加入了。[功能 #14912](https://bugs.ruby-lang.org/issues/14912) 它可以遍历一个对象，并在其满足某一模式时进行赋值。
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 关于更多信息，请查阅 [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)。
 
@@ -53,60 +53,60 @@ end
 
 * 当方法传入一个 Hash 作为最后一个参数，或者传入的参数没有关键词的时候，会抛出警告。如果需要继续将其视为关键词参数，则需要加入两个星号来避免警告并确保在 Ruby 3 中行为正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # warned
   def foo(**kw);    end; foo({key: 42})   # warned
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * 当方法传入一个 Hash 到一个接受关键词参数的方法中，但是没有传递足够的位置参数，关键词参数会被视为最后一个位置参数，并抛出一个警告。请将参数包装为 Hash 对象来避免警告并确保在 Ruby 3 中行为正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # warned
   def foo(h, key: 42); end; foo(key: 42)   # warned
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * 当方法接受关键词参数传入，但不会进行关键词分割（splat），且传入同时含有 Symbol 和非 Symbol 的 key，那么 Hash 会被分割，但是会抛出警告。你需要在调用时传入两个分开的 Hash 来确保在 Ruby 3 中行为正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # warned
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # warned
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  ```
+  {% endhighlight %}
 
 * 当一个方法不接受关键词，但是调用时传入了关键词，关键词会被视为位置参数，不会有警告抛出。这一行为将会在 Ruby 3 中继续工作。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # OK
-  ```
+  {% endhighlight %}
 
 * 如果方法支持任意参数传入，那么非 Symbol 也会被允许作为关键词参数传入。[[功能 #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * <code>**nil</code> 被允许使用在方法定义中，用来标记方法不接受关键词参数。以关键词参数调用这些方法会抛出 ArgumentError [[功能 #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  ```
+  {% endhighlight %}
 
 * 将空的关键词分割（splat）传入一个不接受关键词的方法不会继续被当作空 Hash 处理，除非空哈希被作为一个必要参数，并且这种情况会抛出警告。请移除双星号来将 Hash 作为位置参数传入。[[功能 #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} and warning
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## 其它值得关注的新特性
 
@@ -117,35 +117,35 @@ end
 
 * 无头范围实验性地加入了。它可能尽管没有无限范围那么有用，但它对开发 DSL 是非常有用的。[功能 #14799](https://bugs.ruby-lang.org/issues/14799)
 
-  ```ruby
+  {% highlight ruby %}
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  ```
+  {% endhighlight %}
 
 * 新增了 `Enumerable#tally`，它会计算每个元素出现的次数。
 
-  ```ruby
+  {% highlight ruby %}
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  ```
+  {% endhighlight %}
 
 * 允许在 `self` 上调用私有方法 [[功能 #11297]](https://bugs.ruby-lang.org/issues/11297) [[功能 #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * 新增 `Enumerator::Lazy#eager`。它会产生一个非懒惰的迭代器。[[功能 #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## 性能改进
 

--- a/zh_tw/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/zh_tw/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -27,13 +27,13 @@ lang: zh_tw
 
 在函數式編程語言中廣泛地被使用的 Pattern matching，作為實驗性的功能加入了。[#14912](https://bugs.ruby-lang.org/issues/14912) 它可以遍歷給定的物件並在其比對成功時賦值。
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 更多詳細資訊，請參閱 [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)。
 

--- a/zh_tw/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/zh_tw/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -28,13 +28,13 @@ lang: zh_tw
 
 在函數式編程語言中廣泛地被使用的 Pattern matching，作為實驗性的功能加入了。[Feature #14912](https://bugs.ruby-lang.org/issues/14912) 它可以遍歷給定的物件並在其比對成功時賦值。
 
-```ruby
+{% highlight ruby %}
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-```
+{% endhighlight %}
 
 更多詳細資訊，請參閱 [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)。
 
@@ -52,60 +52,60 @@ end
 
 * 當方法將 Hash 作爲最後一個參數傳入，或者傳入的參數沒有關鍵字的時候，会拋出警告。如果需要繼續將其視爲關鍵字參數，則需要加入兩個星號來避免警告並在 Ruby 3 在中行爲正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(key: 42); end; foo({key: 42})   # warned
   def foo(**kw);    end; foo({key: 42})   # warned
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * 當方法傳入 Hash 到一個接受關鍵字參數的方法中，但沒有傳入足夠的位置參數，關鍵字參數會被視爲最後一個位置參數，並拋出一個警告。請將參數包裝爲 Hash 物件來避免警告，並在 Ruby 3 在中行爲正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **kw); end; foo(key: 42)      # warned
   def foo(h, key: 42); end; foo(key: 42)   # warned
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  ```
+  {% endhighlight %}
 
 * 當方法接受關鍵字參數傳入，但不會進行關鍵字分割（splat），且傳入同時含有 Symbol 和非 Symbol 的 key，那麼 Hash 會被分割，但是會拋出警告。你需要傳入兩個分開的 Hash 來確保 Ruby 3 中行爲正常。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # warned
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # warned
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  ```
+  {% endhighlight %}
 
 * 當一個方法不接受關鍵字參數，但傳入了關鍵字參數，關鍵字會被視爲位置參數，不會有警告拋出。這一行爲會在 Ruby 3 中繼續工作。
 
-  ```ruby
+  {% highlight ruby %}
   def foo(opt={});  end; foo( key: 42 )   # OK
-  ```
+  {% endhighlight %}
 
 * 如果方法支援任意參數傳入，那麼非 Symbol 也會被允許作爲關鍵字參數傳入。[[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  ```
+  {% endhighlight %}
 
 * <code>**nil</code> 被允許使用在方法的定義中，用來標記不接受關鍵字參數。以關鍵詞參數來使用這些方法會拋出 ArgumentError [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  ```
+  {% endhighlight %}
 
 * 將空的關鍵字分割（splat）傳入一個不接受關鍵字參數的方法不會繼續被當作空雜湊處理，除非空雜湊被作爲一個必要參數，並且這種情況會拋出警告。請移除雙星號将雜湊作爲位置參數傳入。[[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  ```ruby
+  {% highlight ruby %}
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} and warning
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  ```
+  {% endhighlight %}
 
 ## 其他值得注意的新特點
 
@@ -115,35 +115,35 @@ end
 
 * 無始範圍試驗性的加入了。他可能沒有無盡範圍那麼有用，但他以 DSL 為目的來說是好的。[Feature #14799](https://bugs.ruby-lang.org/issues/14799)
 
-  ```ruby
+  {% highlight ruby %}
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  ```
+  {% endhighlight %}
 
 * 新增了 `Enumerable#tally`，它將會計算每個元素出現的次數。
 
-  ```ruby
+  {% highlight ruby %}
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  ```
+  {% endhighlight %}
 
 * 允許在 `self` 上調用私有方法 [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) [[Feature #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  ```ruby
+  {% highlight ruby %}
   def foo
   end
   private :foo
   self.foo
-  ```
+  {% endhighlight %}
 
 * 新增 `Enumerator::Lazy#eager`。它會產生一個非懶惰的 Enumerator。[[功能 #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  ```ruby
+  {% highlight ruby %}
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  ```
+  {% endhighlight %}
 
 ## 效能改進
 


### PR DESCRIPTION
Fenced code blocks as known from e.g. GitHub flavored markdown will not work. Instead a `highlight` tag must be used, e.g.

```
{% highlight ruby %}
puts "Hello"
{% endhighlight %}
```