### PR TITLE
Change faq links to en versions (tr)

### DIFF
--- a/tr/community/mailing-lists/ruby-talk-guidelines/index.md
+++ b/tr/community/mailing-lists/ruby-talk-guidelines/index.md
@@ -76,5 +76,5 @@ _Bu yönergeler [comp.lang.ruby SSS][clrFAQ]'dan alınmıştır._
 
 
 [ruby-lang]: /tr/
-[faq]: /tr/documentation/faq/
+[faq]: /en/documentation/faq/
 [clrFAQ]: http://rubyhacker.com/clrFAQ.html


### PR DESCRIPTION
FAQ is not translated yet.