### PR TITLE
Add GitHub actions workflow for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: build (${{ matrix.ruby }})
+    name: build (${{ matrix.ruby }} / ${{ matrix.os }})
 
     strategy:
       matrix:
         ruby: [2.6.3]
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     env:
       # override the Ruby version specified in the Gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build (${{ matrix.ruby }})
+
+    strategy:
+      matrix:
+        ruby: [2.6.3]
+
+    runs-on: ubuntu-latest
+
+    env:
+      # override the Ruby version specified in the Gemfile
+      CUSTOM_RUBY_VERSION: ${{ matrix.ruby }}
+
+    steps:
+      - name: Dump environment
+        run: env | sort
+      - name: Checkout ruby/www.ruby-lang.org
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          architecture: x64
+      - name: Install bundler
+        run: gem install bundler --no-document
+      - name: Install gem bundle
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           architecture: x64
+      - name: Cache gem bundle
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
       - name: Install bundler
         run: gem install bundler --no-document
       - name: Install gem bundle
-        run: bundle install
+        run: bundle install --path vendor/bundle
       - name: Run tests
         run: bundle exec rake ci

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ www.ruby-lang.org
 
 [![Join the chat at https://gitter.im/ruby/www.ruby-lang.org](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ruby/www.ruby-lang.org?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[![Build Status](https://github.com/ruby/www.ruby-lang.org/workflows/ci/badge.svg)](https://github.com/ruby/www.ruby-lang.org/actions?query=branch%3Amaster)
+
 [![Build Status](https://travis-ci.org/ruby/www.ruby-lang.org.svg?branch=master)](https://travis-ci.org/ruby/www.ruby-lang.org)
 
 This is the [Jekyll](http://www.jekyllrb.com/) source of


### PR DESCRIPTION
Use GitHub actions workflow for running `rake ci`.