### PR TITLE
Fix typo of Fukuoka Ruby 2020 (en)

### DIFF
--- a/en/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/en/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -17,7 +17,7 @@ Entry Deadline: December 11, 2019
 
 ![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
-Matz and a group of panelists will select the winners of the Fukuoka Competition.The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
+Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
 
 [http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
 


### PR DESCRIPTION
This is a follow-up of #2183.