### PR TITLE
Use relative path for hashFiles() in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-bundle-${{ hashFiles('Gemfile.lock') }}
       - name: Install bundler
         run: gem install bundler --no-document
       - name: Install gem bundle


### PR DESCRIPTION
The hashFiles() function for GitHub workflows has just been fixed to work with paths relative to GITHUB_WORKSPACE, so there is no need for the workaround with `**/Gemfile.lock` any more, when we simply want a hash for `Gemfile.lock` located in the site's root directory.