### PR TITLE
Improve 'check' and 'test' rake tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Install gem bundle
         run: bundle install --path vendor/bundle
       - name: Run tests
-        run: bundle exec rake ci
+        run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rvm: 2.6.5
 cache: bundler
 env:
-  - TASK=ci
+  - TASK=test
 before_install: gem install bundler:2.0.2
 script: bundle exec rake $TASK
 # Notifications, used by our Gitter channel.

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,6 @@ LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tr vi zh_cn zh_tw]
 CONFIG = "_config.yml"
 
 task :default => [:build]
-task :ci      => [:test]
 
 desc "Build the Jekyll site"
 task :build do

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,9 @@ CONFIG = "_config.yml"
 
 task :default => [:build]
 
+desc "Run tests (lint, build)"
+task :test => [:lint, :build]
+
 desc "Build the Jekyll site"
 task :build do
   require "lanyon"
@@ -102,9 +105,6 @@ namespace :new_post do
     end
   end
 end
-
-desc "Run tests (lint, build)"
-task :test => [:lint, :build]
 
 desc "Run linter on markdown files"
 task :lint do

--- a/Rakefile
+++ b/Rakefile
@@ -104,11 +104,11 @@ namespace :new_post do
   end
 end
 
-desc "Alias for `check'"
-task :test => [:check]
+desc "Alias for `lint'"
+task :test => [:lint]
 
-desc "Run some tests on markdown files"
-task :check do
+desc "Run linter on markdown files"
+task :lint do
   require_relative "lib/linter"
   Linter.new.run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tr vi zh_cn zh_tw]
 CONFIG = "_config.yml"
 
 task :default => [:build]
-task :ci      => [:test, :build]
+task :ci      => [:test]
 
 desc "Build the Jekyll site"
 task :build do
@@ -104,8 +104,8 @@ namespace :new_post do
   end
 end
 
-desc "Alias for `lint'"
-task :test => [:lint]
+desc "Run tests (lint, build)"
+task :test => [:lint, :build]
 
 desc "Run linter on markdown files"
 task :lint do


### PR DESCRIPTION
* Rename 'check' task to 'lint' and improve description

  The name 'lint' is more specific about what the task does; it also makes clearer that this task is not related to the other 'check:*' tasks (and does not invoke them).

* Change 'test' task to run linter and build the site

  Use 'test' task to invoke all tasks meant to run on CI. Having an alias for 'lint' is not necessary.

* Remove 'ci' task and use 'test' instead