### PR TITLE
Fix typo in 2.7.0-preview3 post (en)

### DIFF
--- a/en/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/en/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -208,7 +208,7 @@ NOTE: Too many deprecation warnings about keyword argument incompatibility have 
 
 * Promote stdlib to default gems
   * The following default gems was published at rubygems.org
-    * benchmarck
+    * benchmark
     * cgi
     * delegate
     * getoptlong


### PR DESCRIPTION
benchmarck -> benchmark