### PR TITLE
Fix a typo in downloads (fr)

### DIFF
--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -38,7 +38,7 @@ Ruby à partir des sources. Si vous rencontrez des difficultés en compilant Rub
 envisagez d'utiliser l'un des outils tiers mentionnés plus haut. Ils pourront
 peut-être vous aider.
 
-* **Dernière version stables:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
+* **Dernière versions stables:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
   * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
     sha256: {{ release.sha256.gz }}{% endfor %}
 


### PR DESCRIPTION
Pointed out by @bricesanchez at [here](https://github.com/ruby/www.ruby-lang.org/commit/76fd0dd9eef318db2ac434acda6a97ed732555f4#r36286548), thanks!

