### PR TITLE
Remove Ruby User’ Guide references

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -66,11 +66,6 @@ ruby -v
 : Първото издание на книгата [Pragmatic Programmers][10], напълно
   безплатно.
 
-[Ruby User’s Guide][11]
-: Ръководството е превод на оригинала от Yukihiro Matsumoto (създателя
-  на Ruby). Тази версия (от Goto Kentaro и Mark Slagell) представя много
-  аспекти от програмирането на Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Безплатно online ръководство със съдържание за начинаещи и средно
   напреднали.
@@ -142,7 +137,6 @@ ruby -v
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -39,11 +39,6 @@ Ruby-Programmieren sicher nützlich sein werden.
 : Dies ist die erste Auflage des bekannten Pickaxe-Buches der
   Pragmatic Programmers. Es ist kostenlos im Internet verfügbar (englisch).
 
-[Ruby User’s Guide][7]
-: Übersetzung der japanischen Version von Yukihiro Matsumoto (der Vater
-  von Ruby), diese Seite bietet einen Überblick über viele Aspekte der
-  Programmiersprache Ruby (englisch).
-
 [Programmieren mit Ruby][8]
 : Ein deutschsprachiges Buch zum Thema Ruby von Armin Roehrl, Stefan
   Schmiedl und Clemens Wyss. Es steht vollständig kostenlos im Internet
@@ -83,7 +78,6 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 [4]: http://www.moccasoft.de/papers/ruby_tutorial
 [5]: http://pine.fm/LearnToProgram/
 [6]: http://www.ruby-doc.org/docs/ProgrammingRuby/
-[7]: http://www.rubyist.net/~slagell/ruby/
 [8]: http://www.approximity.com/rubybuch2/
 [9]: http://www.ruby-doc.org/core
 [10]: http://www.ruby-doc.org/stdlib

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -40,12 +40,6 @@ serán útiles a la hora de desarrollar con Ruby.
   parlantes. Este pequeño libro está en camino a convertirse en un
   clásico de Ruby.
 
-[La guía del usuario Ruby][6]
-: Traducida al inglés desde su versión original japonesa escrita por
-  Yukihiro Matsumoto (el creador de Ruby), esta versión de Goto Kentaro
-  y Mark Slagell es un buen resumen de varios aspectos del lenguaje
-  Ruby.
-
 ### Documentación de referencia
 
 [Referencia del núcleo de Ruby][7]
@@ -75,7 +69,6 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 [3]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [4]: http://pragmaticprogrammer.com/titles/ruby/index.html
 [5]: http://mislav.uniqpath.com/poignant-guide/
-[6]: http://www.rubyist.net/~slagell/ruby/
 [7]: http://www.ruby-doc.org/core
 [8]: https://ruby.github.io/rdoc/
 [9]: http://www.ruby-doc.org/stdlib

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -90,11 +90,6 @@ pour les nombreuses façons d'obtenir Ruby.
   première version du [livre le plus populaire sur Ruby][13],
   par les *Pragmatic Programmers*.
 
-[*Ruby User’s Guide*][14]
-: Traduit depuis le texte original japonais de Yukihiro Matsumoto (le
-  créateur de Ruby), cette version de Goto Kentaro et Mark Slagell
-  présente l’essentiel des différents aspects du langage Ruby.
-
 [*The Ruby Programming Wikibook*][15]
 : Un manuel gratuit destiné aux débutants et aux programmeurs de niveaux
   intermédiaire. Propose également une référence du langage.
@@ -144,7 +139,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [11]: http://www.meshplex.org/wiki/Ruby/Ruby_on_Rails_programming_tutorials
 [12]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [13]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[14]: http://www.rubyist.net/~slagell/ruby/
 [15]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [16]: http://www.ruby-doc.org/core
 [17]: https://ruby.github.io/rdoc/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -51,11 +51,6 @@ dapat membaca [panduan instalasi](installation/) untuk memasang Ruby.
 : Ini salah satu karya penting untuk pemrograman Ruby dalam Bahasa Inggris.
   Edisi pertama [Pragmatic Programmers’ book][10] ini tersedia gratis *online*.
 
-[Ruby User’s Guide][11]
-: Diterjemahkan dari versi Jepang asli ditulis oleh Yukihiro
-  Matsumoto (pencipta Ruby), versi ini, oleh Goto Kentaro dan
-  Mark Slagell adalah gambaran baik dari banyak aspek dari bahasa Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Manual *online* gratis dengan konten untuk pemula dan menengah ditambah
   referensi bahasa Ruby secara menyeluruh.
@@ -141,7 +136,6 @@ adalah tempat yang baik untuk memulai.
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -62,13 +62,6 @@ ed arrivano fino alla programmazione OOP e lo sviluppo web.
   prima edizione del [Pragmatic Programmers’ book][10] è disponibile
   online gratuitamente.
 
-[Ruby User’s Guide][11]
-: Tradotto in inglese dalla versione originale Giapponese scritta da
-  Yukihiro Matsumoto (il creatore di Ruby).
-  Questa traduzione, curata da Goto Kentaro e Mark Slagell, è
-  un’eccellente punto di partenza per imparare molti aspetti importanti
-  del linguaggio Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Un manuale online gratuito per persone con conoscenze di livello base
   o intermedio, contenente anche delle parti di riferimento complete.
@@ -143,7 +136,6 @@ iniziare.
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -59,11 +59,6 @@ lang: ko
 : 영어로 된 독창적인 루비 책입니다. [Pragmatic Programmers의 책][10]
   1판이 무료로 온라인에 공개되어 있습니다.
 
-[Ruby User’s Guide][11] (영문)
-: Yukihiro Matsumoto(루비의 창시자)의 글을 영문으로 번역한 것입니다.
-  루비 언어를 여러 관점에서 전반적으로 설명합니다.
-  이 버전은 고토 켄타로 님과 Mark Slagell 님이 작업 해주셨습니다.
-
 [The Ruby Programming Wikibook][12] (영문)
 : 초보자와 중급자를 위한 무료 온라인 매뉴얼과 전 언어 레퍼런스입니다.
 
@@ -142,7 +137,6 @@ lang: ko
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -66,11 +66,6 @@ Znajdziesz tutaj odnośniki do podręczników, tutoriali i materiałów
   wydanie książki zostało wydane w języku polskim pod tytułem:
   "Programowanie w języku Ruby".
 
-[Ruby User’s Guide][11]
-: Przetłumaczone z orzginalnej japońskiej wersji napisanej przez Yukihiro
-  Matsumoto (twórca Rubiego), ta wersja, napisana przez Goto Kentaro i
-  Marka Slagella jest dobrym przeglądem wielu aspektów języka Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Darmowy manual z materiałem dla początkujących i średnio zaawansowanych
   wraz z dokładnymi odniesieniami.
@@ -145,7 +140,6 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -71,11 +71,6 @@ diversas maneiras de obter o Ruby.
 : Trabalho seminal de Ruby em inglês, a primeira edição do [Pragmatic
   Programmers’ book][10] está disponível gratuitamente online.
 
-[Ruby User’s Guide][11]
-: Traduzido do original em japonês escrito por Yukihiro Matsumoto (o
-  criador do Ruby), esta versão, por Goto Kentaro e Mark Slagell,
-  é uma boa visão sobre muitos aspectos da linguagem Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Manual online gratuito, com conteúdo para iniciantes e intermediário,
   além de uma referência completa para a linguagem.
@@ -153,7 +148,6 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 [8]: http://aprendaaprogramar.rubyonrails.com.br/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -70,11 +70,6 @@ ruby -v
 : Основополагающая работа по Ruby на английском в первом издании,
   [книга от Pragmatic Programmers][10], доступна бесплатно онлайн.
 
-[Ruby User’s Guide][11]
-: Переведенная с японского языка версия, написанная Yukihiro Matsumoto
-  (создатель Ruby), эта версия Goto Kentaro и Mark Slagell является
-  отличным обзором многих аспектов языка Ruby.
-
 [The Ruby Programming Wikibook][12]
 : Бесплатное онлайн-руководство для начинающих и продвинутых, плюс
   полная документация языка.
@@ -148,7 +143,6 @@ ruby -v
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -63,12 +63,6 @@ isterseniz, [kurulum kılavuzu](installation/)nu okuyabilirsiniz.
   kaynakları arasında hatırı sayılır bir yere sahip olan bu kitabı,
   çevrimiçi okuyabilirsiniz.
 
-[Ruby Kullanıcı Kılavuzu][ruby-kullanici-kilavuzu] (Türkçe)
-: Ruby diliyle ilgili pek çok alanda hoş görüşler sunan bu belgenin
-  orijinali Yukihiro Matsumoto (Ruby’nin yaratıcısı) tarafından yazılmış
-  olup, Goto Kentaro ve Mark Slagell tarafından [İngilizce’ye][11], Pınar
-  Yanardağ tarafından da Türkçe’ye çevirilmiştir.
-
 [Ruby Programming Vikikitabı][12]
 : Başlangıç ve ileri düzeyde içeriğe sahip olan çevrimiçi, tam bir dil
   başvurusu da sunan bir kitapçık.
@@ -153,7 +147,6 @@ olacaktır.
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -70,11 +70,6 @@ việc cài đặt Ruby.
 : Hội thảo làm việc trên Ruby bằng Tiếng Anh, phiên bản đầu tiên
   [Sách của Lập trình viên thực dụng][10] hiện đang được miễn phí trực tuyến.
 
-[Hướng dẫn người sử dụng Ruby][11]
-: Được dịch từ bản gốc Tiếng Nhật của tác giả Yukihiro Matsumoto (Cha đẻ của
-  Ruby), phiên bản này được dịch bởi Goto Kentaro và Mark Slagell là tổng quan
-  tốt về rất nhiều khía cạnh của ngôn ngữ Ruby.
-
 [Sách bách khoa lập trình Ruby][12]
 : Một hướng dẫn trực tuyến miễn phí với người mới bắt đầu và nội dung trung
   cấp cộng với một tài liệu tham khảo ngôn ngữ chi tiết.
@@ -152,7 +147,6 @@ là một nơi tuyệt vời.
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -52,9 +52,6 @@ ruby -v
 [Programming Ruby][9]
 : 最有影响的 Ruby 英文教材，[Pragmatic Programmers 出版的第一版][10]可以在网上免费阅读。
 
-[Ruby 用户指南][11]
-: 译自松本行弘（Ruby 的发明者）的日文版原作，Goto Kentaro 和 Mark Slagell 在这部教材里介绍了 Ruby 各个方面的功能。
-
 [Ruby 编程百科全书][12]
 : 免费的在线语言参考资料，内容从 Ruby 初级到中级。
 
@@ -118,7 +115,6 @@ ruby -v
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -41,9 +41,6 @@ lang: zh_tw
 [Programming Ruby][9]
 : 這是 Ruby 的第一本英文書，第一版開放線上免費閱讀 [Pragmatic Programmers' book][10] 。
 
-[Ruby 使用手冊][11]
-: 原日文版出自 Yukihiro Matsumoto (Ruby 發明人)，英文版為 Goto Kentaro 和 Mark Slagell 翻譯，[繁體中文版][ruby-user-guide-zh_tw]由 [Ruby Taiwan][rubytw] 翻譯。這是一個不錯的 Ruby 導覽。
-
 [The Ruby Programming Wikibook][12]
 : 給初學者到中等程度的線上手冊以及語言參考。
 
@@ -113,7 +110,6 @@ lang: zh_tw
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [10]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[11]: http://www.rubyist.net/~slagell/ruby/
 [12]: http://en.wikibooks.org/wiki/Ruby_programming_language
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/


### PR DESCRIPTION
Follow up of #2304. The Ruby User’s Guide link is now invalid.