### PR TITLE
Correct release note on frozen to_s in 2.7.0-preview3

### DIFF
--- a/en/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/en/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -231,11 +231,11 @@ The final decision is not made, but will be fixed by the official release.
 
   * The default value of `--jit-max-cache` is changed from 1,000 to 100.
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s`,
+* ~~`Symbol#to_s`~~ (reverted), `Module#name`, `true.to_s`, `false.to_s`,
   and `nil.to_s` now always return a frozen String.
   The returned String is always the same for a given object.
   [Experimental]
-  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ reverted
+  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * The performance of `CGI.escapeHTML` is improved.
   [GH-2226](https://github.com/ruby/ruby/pull/2226)

--- a/ja/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/ja/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -158,7 +158,7 @@ Ruby に添付されている REPL (Read-Eval-Print-Loop) である `irb` で、
 
   * `--jit-max-cache` オプションのデフォルト値が 1,000 から 100 に変更されました。
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` `nil.to_s` は常にfrozenな文字列を返すようになりました。返された文字列は常に同じオブジェクトとなります。 [Experimental]  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ 撤回されました
+* ~~`Symbol#to_s`~~ (撤回されました), `Module#name`, `true.to_s`, `false.to_s` `nil.to_s` は常にfrozenな文字列を返すようになりました。返された文字列は常に同じオブジェクトとなります。 [Experimental]  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML` のパフォーマンスが改善されました。 [GH-2226](https://github.com/ruby/ruby/pull/2226)
 


### PR DESCRIPTION
Only changes to Symbol#to_s is reverted (ruby/ruby@bea322a352) and Module#name, true.to_s, false.to_s and nil.to_s are still frozen in preview3.