### PR TITLE
Remove defunct RubyNation website (translations)

### DIFF
--- a/bg/community/conferences/index.md
+++ b/bg/community/conferences/index.md
@@ -49,9 +49,6 @@ Ruby програмистите по света все по-често орга�
 Ruby Central също така работи с [SVForum][7] в усилията си за Silicon
 Valley Ruby Conference.
 
-[RubyNation][8] е ежегодна Ruby конференция, която се провежда във
-Virginia, West Virginia, Maryland, и Washington, DC.
-
 ### Присъствие на Ruby в други конференции
 
 Ruby присъства на [O’Reilly Open Source Conference][10] (OSCON) от 2004
@@ -70,7 +67,6 @@ Central и [Skills Matter][14], и през 2007 г. с помощта на Ruby
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org

--- a/id/community/conferences/index.md
+++ b/id/community/conferences/index.md
@@ -50,9 +50,6 @@ Ruby Central juga bekerja sama dengan SVForum (sebelumnya dikenal
 sebagai SDForum) untuk mengadakan Silicon Valley Ruby Conference, yang sudah
 berlangsung pada tahun 2006 dan 2007.
 
-[RubyNation][8] adalah sebuah konferensi Ruby tahunan yang bertempat di
-Virginia, West Virginia, Maryland dan Washington, DC.
-
 [WindyCityRails][9] adalah sebuah pertemuan tahunan untuk semua yang antusias
 dengan Ruby on Rails. Konferensi yang berlokasi di Chicago ini sudah melayani
 komunitas Ruby sejak 2008.
@@ -89,7 +86,6 @@ on Rails.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [6]: http://rubycentral.org/community/grant
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/it/community/conferences/index.md
+++ b/it/community/conferences/index.md
@@ -55,9 +55,6 @@ Ruby Central si è anche collegata con [SVForum][7] per produrre la
 Conferenza Ruby di Silicon Valley, che ha avuto il suo secondo incontro
 annuale nel 2007.
 
-[RubyNation][8] è una conferenza annnuale su Ruby tenuta nell'area della
-Virginia, West Virginia, Maryland, e Washington, DC.
-
 WindCityRails è un incontro annuale per tutti gli appassionati di Ruby on
 Rails. Questa conferenza di Chicago viene organizzata per la comunità
 Ruby dal 2008. Visita [http://windycityrails.org][9] per maggiori dettagli.
@@ -101,7 +98,6 @@ e in 2007 da Ruby Central e O’Reilly), e infine Canada on Rails.
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/pt/community/conferences/index.md
+++ b/pt/community/conferences/index.md
@@ -48,9 +48,6 @@ organizar eventos.
 A Ruby Central juntou-se também com a [SVForum][6] para realizar a
 “Silicon Valley Ruby Conference”, entrando no seu segundo ano em 2007.
 
-A [RubyNation][7] é uma conferência anual de Ruby às áreas da Virginia, West
-Virginia, Maryland e Washington, DC.
-
 A WindyCityRails é um encontro anual para todos os que são apaixonados em
 Ruby on Rails. A conferência situada em Chicago atende à comunidade Ruby
 desde 2008. Visite [http://windycityrails.org][8] para mais detalhes.
@@ -84,7 +81,6 @@ O’Reilly) e, para finalizar a Canada on Rails.
 [4]: http://euruko.org
 [5]: http://rubycentral.org/community/grant
 [6]: http://www.svforum.org
-[7]: http://rubynation.org/
 [8]: http://windycityrails.org
 [9]: http://conferences.oreillynet.com/os2006/
 [10]: http://www.rubyonrails.org

--- a/ru/community/conferences/index.md
+++ b/ru/community/conferences/index.md
@@ -47,9 +47,6 @@ Ruby Central также сотрудничает с [SVForum][7], чтобы о�
 Valley Ruby Conference, участвуя в этом со второй такой конференции в 2007
 году.
 
-[RubyNation][8] ежегодная Ruby конференция, проводимая в Virginia, West
-Virginia, Maryland, и Washington, округ Колумбия.
-
 [WindyCityRails][9] является ежегодной конференцией для всех, кто обожает
 Ruby on Rails. Событие проводится в Chicago сообществом Ruby начиная с
 2008 года.
@@ -72,7 +69,6 @@ O’Reilly), и Canada on Rails.
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/vi/community/conferences/index.md
+++ b/vi/community/conferences/index.md
@@ -47,9 +47,6 @@ thời gian, địa điểm, kêu gọi đề xuất và thông tin đăng kí c
 Ruby Central đã hợp tác với [SVForum][7] để tạo ra thung lũng Silicon dành cho
 các hội thảo về Ruby trong khu vực lần thứ 2 trong năm 2007.
 
-[RubyNation][8] là cuộc hội thảo Ruby thường niên dành cho các khu vực Virginia,
-Tây Virginia, Maryland, và Washington, DC.
-
 [WindyCityRails][9] là nơi tập trung hàng năm dành cho những người đam mê
 Ruby on Rails. Trụ sở hội thảo tại Chicago đã phục vụ cộng đồng Ruby từ
 năm 2008.
@@ -93,7 +90,6 @@ và Canada on Rails.
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/zh_cn/community/conferences/index.md
+++ b/zh_cn/community/conferences/index.md
@@ -36,9 +36,6 @@ Ruby 相关的报道，而且我们总是对 Ruby 相关的内容更感兴趣。
 
 自2006年起，Ruby Central 还携手 [SVForum][7] 主办了硅谷 Ruby 研讨会。
 
-[RubyNation][8] 是美国东岸（Virginia, West Virginia, Maryland, and
-Washington, DC 等地区）的年度 Ruby 大会。
-
 [WindyCityRails][9] 是一个为 Ruby on Rails 爱好者准备的年会。自2008年起，总部位于芝加哥的研讨会就一直为 Ruby 社区服务。
 
 [Madison Ruby][15]: 威斯康星州的麦迪逊（Madison, WI）
@@ -70,7 +67,6 @@ Ruby 相关的内容都在逐年增加。许多研讨会都以 [Ruby on Rails][1
 [5]: http://www.osdc.com.au/
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -45,8 +45,6 @@ lang: zh_tw
 
 自 2007 年起，Ruby Central 也與 [SVForum][7] 合作主辦矽谷的 Ruby 研討會。
 
-[RubyNation][8]是美國東岸（Virginia, West Virginia, Maryland 和 Washington, DC 等地區）的 Ruby 年度大會。
-
 [WindyCityRails][9]：是一群由對於 Ruby on Rails 充滿熱情的愛好者所舉辦的年度聚會，從 2008 年於芝加哥開始於社群舉行。
 
 [Steel City Ruby][16]：於匹茲堡舉辦的研討會。
@@ -81,7 +79,6 @@ lang: zh_tw
 [4]: http://euruko.org
 [6]: http://rubycentral.org/community/grant
 [7]: http://www.svforum.org
-[8]: http://rubynation.org/
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org


### PR DESCRIPTION
This PR is a follow-up from PR #2178 which just removed RubyNation from English version of the conference page. So, I did the same thing but for other language.

Please, kindly give the review. Thank you.