### PR TITLE
Enable i18n for "Home" link in site navigation

### DIFF
--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: най-добрият приятел на програмиста
 
 sitelinks:
+- text: Home
+  url: /bg
+  home: true
 - text: За сваляне
   url: /bg/downloads
 - text: Документация

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: Der beste Freund eines Programmierers
 
 sitelinks:
+- text: Home
+  url: /de
+  home: true
 - text: Downloads
   url: /de/downloads
 - text: Dokumentation

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: A Programmer's Best Friend
 
 sitelinks:
+- text: Home
+  url: /en
+  home: true
 - text: Downloads
   url: /en/downloads
 - text: Documentation

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: El mejor amigo de un desarrollador
 
 sitelinks:
+- text: Home
+  url: /es
+  home: true
 - text: Descargas
   url: /es/downloads
 - text: Documentación

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: A Programmer's Best Friend
 
 sitelinks:
+- text: Home
+  url: /fr
+  home: true
 - text: Téléchargements
   url: /fr/downloads
 - text: Documentation

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: Sahabat Terbaik Programmer
 
 sitelinks:
+- text: Home
+  url: /id
+  home: true
 - text: Unduh
   url: /id/downloads
 - text: Dokumentasi

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: Il migliore amico dei programmatori
 
 sitelinks:
+- text: Home
+  url: /it
+  home: true
 - text: Scarica
   url: /it/downloads
 - text: Documentazione

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: A Programmer's Best Friend
 
 sitelinks:
+- text: Home
+  url: /ja
+  home: true
 - text: ダウンロード
   url: /ja/downloads
 - text: ドキュメント

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -3,6 +3,9 @@ ruby: 루비
 slogan: 프로그래머의 단짝 친구
 
 sitelinks:
+- text: Home
+  url: /ko
+  home: true
 - text: 다운로드
   url: /ko/downloads
 - text: 문서

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: Najlepszy Przyjaciel Programisty
 
 sitelinks:
+- text: Home
+  url: /pl
+  home: true
 - text: Pobierz
   url: /pl/downloads
 - text: Dokumentacja

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: O melhor amigo do programador
 
 sitelinks:
+- text: Home
+  url: /pt
+  home: true
 - text: Downloads
   url: /pt/downloads
 - text: Documentação

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: лучший друг программиста
 
 sitelinks:
+- text: Home
+  url: /ru
+  home: true
 - text: Скачать
   url: /ru/downloads
 - text: Документация

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: BİR PROGRAMCININ EN İYİ ARKADAŞI
 
 sitelinks:
+- text: Home
+  url: /tr
+  home: true
 - text: İndirin
   url: /tr/downloads
 - text: Belgeler

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: Người bạn tri kỉ của lập trình viên
 
 sitelinks:
+- text: Home
+  url: /vi
+  home: true
 - text: Downloads
   url: /vi/downloads
 - text: Tài liệu

--- a/_data/locales/zh_cn.yml
+++ b/_data/locales/zh_cn.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: 程序员最好的朋友
 
 sitelinks:
+- text: Home
+  url: /zh_cn
+  home: true
 - text: 下载
   url: /zh_cn/downloads
 - text: 文档

--- a/_data/locales/zh_tw.yml
+++ b/_data/locales/zh_tw.yml
@@ -3,6 +3,9 @@ ruby: Ruby
 slogan: 程式設計師的摯友
 
 sitelinks:
+- text: Home
+  url: /zh_tw
+  home: true
 - text: 下載安裝
   url: /zh_tw/downloads
 - text: 文件

--- a/_includes/sitelinks.html
+++ b/_includes/sitelinks.html
@@ -4,5 +4,5 @@
   {% assign sitelinks = site.data.locales['en'].sitelinks %}
 {% endif %}
 {% for link in sitelinks %}
-  <a href="{{ link.url }}/">{{ link.text }}</a>
+  <a href="{{ link.url }}/"{% if link.home %} class="home"{% endif %}>{{ link.text }}</a>
 {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,6 @@
         </a>
 
         <div class="site-links">
-          <a href="/{{ page.lang }}/" class="home">Home</a>
           {% include sitelinks.html %}
           <a href="#" class="menu selected">Menu</a>
         </div>

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -363,8 +363,9 @@ div.post h3 a:hover { text-decoration: underline; }
   font-size: 15px;
 }
 
-#header div.site-links a.menu,
-#header div.site-links a.home { display: none; }
+#header div.site-links a.home,
+#footer div.site-links a.home,
+#header div.site-links a.menu { display: none; }
 
 #header div.site-links a.selected {
   color: white;


### PR DESCRIPTION
Integrate "Home" link with the other sitelinks to allow for localization via the `_data/locales/*.yml` files. For `en`:

```yaml
sitelinks:
- text: Home
  url: /en
  home: true
```

The `home` tag is introduced because the "Home" link requires special treatment; it needs the CSS class "home" which controls the link's visibility (it is only displayed in the hamburger menu for mobile view) and ensures proper highlighting when selected.

As a side effect of this change the "Home" link is added to the sitelinks in the footer, since the footer also uses `_includes/sitelinks.html`. To keep the appearance of the site unchanged, the footer "Home" link is set to `display: none`.