### PR TITLE
Fix `RUBY_VESRION` typo in positional args/kwargs post

### DIFF
--- a/en/news/_posts/2019-12-12-separation-of-positional-and-keyword-arguments-in-ruby-3-0.md
+++ b/en/news/_posts/2019-12-12-separation-of-positional-and-keyword-arguments-in-ruby-3-0.md
@@ -162,7 +162,7 @@ Unfortunately, we need to use the old-style delegation (i.e., no `**kwargs`) bec
 
 {% highlight ruby %}
 def ruby2_keywords(*)
-end if RUBY_VESRION < "2.7"
+end if RUBY_VERSION < "2.7"
 {% endhighlight %}
 
 ---


### PR DESCRIPTION
It should be `RUBY_VERSION` :)