### PR TITLE
Fix description about frozen string

### DIFF
--- a/en/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/en/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -247,7 +247,12 @@ The final decision is not made, but will be fixed by the official release.
   and `nil.to_s` now always return a frozen String.
   The returned String is always the same for a given object.
   [Experimental]
-  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ reverted
+  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~
+* `Module#name`, `true.to_s`, `false.to_s`,
+  and `nil.to_s` now always return a frozen String.
+  The returned String is always the same for a given object.
+  [Experimental]
+  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150) reverted `Symbol#to_s` only
 
 * The performance of `CGI.escapeHTML` is improved.
   [GH-2226](https://github.com/ruby/ruby/pull/2226)

--- a/ja/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/ja/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -170,7 +170,8 @@ Ruby に添付されている REPL (Read-Eval-Print-Loop) である `irb` で、
 
   * `--jit-max-cache` オプションのデフォルト値が 1,000 から 100 に変更されました。
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` `nil.to_s` は常にfrozenな文字列を返すようになりました。返された文字列は常に同じオブジェクトとなります。 [Experimental]  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ 撤回されました
+* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` `nil.to_s` は常にfrozenな文字列を返すようになりました。返された文字列は常に同じオブジェクトとなります。 [Experimental]  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~
+* `Module#name`, `true.to_s`, `false.to_s` `nil.to_s` は常にfrozenな文字列を返すようになりました。返された文字列は常に同じオブジェクトとなります。 [Experimental]  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150) `Symbol#to_s` のみ撤回されました
 
 * `CGI.escapeHTML` のパフォーマンスが改善されました。 [GH-2226](https://github.com/ruby/ruby/pull/2226)
 


### PR DESCRIPTION
As far as I know, they reverted only `Symbol#to_s` for the frozen string feature.

Here is the result against 2.7.0-rc1:

```
irb(main):001:0> :a.to_s.frozen?
=> false
irb(main):003:0> true.to_s.frozen?
=> true
irb(main):004:0> false.to_s.frozen?
=> true
irb(main):005:0> nil.to_s.frozen?
=> true
irb(main):006:0> Enumerable.name.frozen?
=> true
```

See also:

- https://bugs.ruby-lang.org/issues/16150
- https://bugs.ruby-lang.org/projects/ruby-trunk/repository/git/revisions/bea322a352d820007dd4e6cab88af5de01854736/diff