### PR TITLE
Switch off autoplay in 2.7.0-rc1 post

### DIFF
--- a/en/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/en/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -80,7 +80,7 @@ for a given class, module, or method.
 Besides, source lines shown at `binding.irb` and inspect results
 for core-class objects are now colorized.
 
-<video autoplay="autoplay" controls="controls" muted="muted" width="576" height="259">
+<video controls="controls" muted="muted" width="576" height="259">
   <source src="https://cache.ruby-lang.org/pub/media/irb_improved_with_key_take2.mp4" type="video/mp4">
 </video>
 

--- a/ja/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/ja/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -53,7 +53,7 @@ Ruby に添付されている REPL (Read-Eval-Print-Loop) である `irb` で、
 また、rdoc 連携も提供されるようになっています。`irb` 内で、クラス、モジュール、メソッドのリファレンスをその場で確認できるようになりました。 [[Feature #14683]](https://bugs.ruby-lang.org/issues/14683), [[Feature #14787]](https://bugs.ruby-lang.org/issues/14787), [[Feature #14918]](https://bugs.ruby-lang.org/issues/14918)
 これに加え、`binding.irb`で表示される周辺のコードや、コアクラスのオブジェクトのinspect結果に色がつくようになっています。
 
-<video autoplay="autoplay" controls="controls" muted="muted" width="576" height="259">
+<video controls="controls" muted="muted" width="576" height="259">
   <source src="https://cache.ruby-lang.org/pub/media/irb_improved_with_key_take2.mp4" type="video/mp4">
 </video>
 


### PR DESCRIPTION
It's more annoying than helping. At the time when one reaches the paragraph, the video has been playing for some time already, and one needs to stop and rewind. It's better to simply start the video at the time one wants to see it.