### PR TITLE
Add linter tests for release data

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -121,7 +121,7 @@
     xz:  202b1a5bf01e6c398b8745cf968027db507ef39df521b3b24e06c6894d507ffcef9e904fa0d3a47f8be98fe750ca15a9829eb75627dacb4679538a61dabbe368
 
 - version: 2.7.0-preview3
-  date: 2019-11-22
+  date: 2019-11-23
   post: /en/news/2019/11/23/ruby-2-7-0-preview3-released/
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2

--- a/lib/linter.rb
+++ b/lib/linter.rb
@@ -3,6 +3,7 @@ require "pathname"
 require 'yaml'
 
 require_relative "linter/document"
+require_relative "linter/release"
 
 
 class Linter
@@ -23,7 +24,9 @@ class Linter
     "ko/news/_posts/2005-07-01-xmlrpcipimethods-vulnerability.md"
   ]
 
-  attr_accessor :docs, :posts, :errors
+  RELEASES_FILE = "_data/releases.yml"
+
+  attr_accessor :docs, :posts, :releases, :errors
 
   # set to +false+ when running Linter in tests
   attr_accessor :exit_on_errors
@@ -32,6 +35,7 @@ class Linter
     @exit_on_errors = exit_on_errors
     @docs = []
     @posts = []
+    @releases = []
     @errors = Hash.new {|h, k| h[k] = [] }
   end
 
@@ -40,7 +44,9 @@ class Linter
     print "Checking markdown files..."
 
     load_files
+    load_releases
     check
+    check_releases
     report
 
     exit(1)  if errors.any? && exit_on_errors
@@ -57,6 +63,12 @@ class Linter
 
     @docs = md_files.map {|fn| Document.new(fn) }
     @posts = @docs.select {|doc| doc.post? }
+  end
+
+  def load_releases
+    releases_yaml = YAML.load_file(RELEASES_FILE) || []
+
+    @releases = releases_yaml.map {|release_data| Release.new(release_data) }
   end
 
   def syntax_highlighting_message(language)
@@ -101,15 +113,32 @@ class Linter
     end
   end
 
+  def invalid_url_message(post_url)
+    "post URL with unexpected format (`#{post_url}')"
+  end
+
+  def missing_post_message(filename)
+    "no release post file that matches given post URL" \
+    " (expected filename: `#{filename}')"
+  end
+
+  def check_releases
+    releases.each do |release|
+      errors[release] << invalid_url_message(release.post)  if release.post_url_invalid?
+      errors[release] << "release date and post date do not match"  if release.date_mismatch?
+      errors[release] << missing_post_message(release.filename)  if release.post_missing?
+    end
+  end
+
   def report
     if errors.empty?
       puts " ok"
     else
-      errors.replace errors.sort_by {|doc, _| doc.filename }.to_h
+      errors.replace errors.sort_by {|doc, _| doc.name }.to_h
 
       puts
       errors.each do |doc, messages|
-        puts doc.filename
+        puts doc.name
         puts messages.map {|msg| "  #{msg}" }
       end
     end

--- a/lib/linter/document.rb
+++ b/lib/linter/document.rb
@@ -15,6 +15,11 @@ class Linter
       @date = yaml["date"]
     end
 
+    # identifier displayed in error messages
+    def name
+      filename
+    end
+
     def post?
       filename.match? %r{/_posts/}
     end

--- a/lib/linter/release.rb
+++ b/lib/linter/release.rb
@@ -1,0 +1,61 @@
+class Linter
+  class Release
+
+    # identifier displayed in error messages
+    attr_reader :name
+
+    attr_reader :version, :date, :post, :filename
+
+    def initialize(data)
+      @version = data["version"]
+      @date = data["date"]
+      @post = data["post"]
+
+      @name = "Ruby #{version} release data (in `#{Linter::RELEASES_FILE}')"
+      @filename = filename_from_post_url
+    end
+
+    # Returns true if the post URL does not match the expected format:
+    #
+    #   /en/news/yyyy/mm/dd/ruby-2-7-0-released/
+    #
+    def post_url_invalid?
+      !%r{\A/en/news/\d{4}/\d\d/\d\d/[^/]*/\Z}.match?(post)
+    end
+
+    # Returns true if the release date and the post date do not match.
+    def date_mismatch?
+      return  if post_url_invalid?
+
+      date.to_s != post_date_string
+    end
+
+    # Returns true if the release post file corresponding to the
+    # given post URL does not exist.
+    def post_missing?
+      return  if post_url_invalid?
+
+      !File.exist?(filename)
+    end
+
+    private
+
+    # The date corresponding to the given post URL.
+    def post_date_string
+      %r{\A/en/news/(?<yyyy>\d{4})/(?<mm>\d\d)/(?<dd>\d\d)/(?<name>[^/]*)/\Z} =~ post
+
+      "#{yyyy}-#{mm}-#{dd}"
+    end
+
+    # The filename for the release post, corresponding to the given post URL:
+    #
+    #   URL:  /en/news/2019/12/25/ruby-2-7-0-released/
+    #   file: en/news/_posts/2019-12-25-ruby-2-7-0-released.md
+    #
+    def filename_from_post_url
+      %r{\A/en/news/(?<yyyy>\d{4})/(?<mm>\d\d)/(?<dd>\d\d)/(?<name>[^/]*)/\Z} =~ post
+
+      "en/news/_posts/#{yyyy}-#{mm}-#{dd}-#{name}.md"
+    end
+  end
+end

--- a/test/fixtures/errors/_data/releases.yml
+++ b/test/fixtures/errors/_data/releases.yml
@@ -1,0 +1,15 @@
+- version: 2.7.4
+  date: 2020-01-01
+  post: /en/news/2020/01/02/wrong-date/
+
+- version: 2.7.3
+  date: 2020-01-01
+  post: /en/news/2020/01/01/missing/
+
+- version: 2.7.2
+  date: 2020-01-01
+  post: /en/news/2020-01-01/malformed-post-url/
+
+- version: 2.7.1
+  date: 2020-01-01
+  post:

--- a/test/fixtures/ok/_data/releases.yml
+++ b/test/fixtures/ok/_data/releases.yml
@@ -1,0 +1,3 @@
+- version: 2.7.0
+  date: 2018-01-01
+  post: /en/news/2018/01/01/ok/

--- a/test/fixtures/output_errors.txt
+++ b/test/fixtures/output_errors.txt
@@ -1,4 +1,13 @@
 Checking markdown files...
+Ruby 2.7.1 release data (in `_data/releases.yml')
+  post URL with unexpected format (`')
+Ruby 2.7.2 release data (in `_data/releases.yml')
+  post URL with unexpected format (`/en/news/2020-01-01/malformed-post-url/')
+Ruby 2.7.3 release data (in `_data/releases.yml')
+  no release post file that matches given post URL (expected filename: `en/news/_posts/2020-01-01-missing.md')
+Ruby 2.7.4 release data (in `_data/releases.yml')
+  release date and post date do not match
+  no release post file that matches given post URL (expected filename: `en/news/_posts/2020-01-02-wrong-date.md')
 en/01_crlf_line_breaks.md
   wrong line breaks (CR/LF)
 en/02_no_newline_at_eof.md


### PR DESCRIPTION
Add some checks for the release data in `_data/releases.yml`:

* Make sure that release date and date in the post URL do match.
* Make sure that a release post file does exist which corresponds to the specified post URL. (To prevent broken links on the releases page.)