### PR TITLE
Do not specify teeny Ruby version in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6.3]
+        ruby: [2.6]
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-
-    env:
-      # override the Ruby version specified in the Gemfile
-      CUSTOM_RUBY_VERSION: ${{ matrix.ruby }}
 
     steps:
       - name: Dump environment
@@ -30,6 +26,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           architecture: x64
+      - name: Dump Ruby version
+        run: ruby -v
+      # override the Ruby version specified in the Gemfile
+      - name: Set CUSTOM_RUBY_VERSION for Gemfile
+        run: echo ::set-env name=CUSTOM_RUBY_VERSION::$(ruby -e 'puts RUBY_VERSION')
+      - name: Dump CUSTOM_RUBY_VERSION
+        run: echo $CUSTOM_RUBY_VERSION
       - name: Cache gem bundle
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Do not specify a teeny version number for the Ruby to be used
but let the setup-ruby action use the latest available version.
To facilitate this, the CUSTOM_RUBY_VERSION environment variable
(that is needed to override the version specified in the Gemfile)
is set to the full MAJOR.MINOR.TEENY version string in a step that
uses the set-env action.