### PR TITLE
Add posts about Rubyist Magazine 61 published (ja)

### DIFF
--- a/ja/news/_posts/2020-02-02-rubyist-magazine-0061-published.md
+++ b/ja/news/_posts/2020-02-02-rubyist-magazine-0061-published.md
@@ -1,0 +1,28 @@
+---
+layout: news_post
+title: "Rubyist Magazine 0061号 発行"
+author: "miyohide"
+translator:
+date: 2020-02-02 17:33:00 +0000
+lang: ja
+---
+
+[日本Rubyの会][1]有志による、ウェブ雑誌[Rubyist Magazine][2]の[0061号][3]がリリースされました([\[ruby-list:50872\]][4])。
+今号は、
+
+* [巻頭言](https://magazine.rubyist.net/articles/0061/0061-ForeWord.html)
+* [Rubyist Hotlinks 【第38回】国分崇志さん](https://magazine.rubyist.net/articles/0061/0061-Hotlinks.html)
+* [TokyoGirls.rb Meetup vol.2開催レポート](https://magazine.rubyist.net/articles/0061/0061-TokyoGirlsrb02Report.html)
+* [RegionalRubyKaigiレポート（77）大阪Ruby会議02](https://magazine.rubyist.net/articles/0061/0061-OsakaRubyKaigi02Report.html)
+* [RegionalRubyKaigiレポート（78）富山Ruby会議01](https://magazine.rubyist.net/articles/0061/0061-ToyamaRubyKaigi01Report.html)
+* [RegionalRubyKaigiレポート（79）鹿児島Ruby会議01](https://magazine.rubyist.net/articles/0061/0061-KagoshimaRubyKaigi01Report.html)
+* [RegionalRubyKaigiレポート（80）平成Ruby会議01](https://magazine.rubyist.net/articles/0061/0061-HeiseiRubyKaigi01Report.html)
+* [0061 号 編集後記](https://magazine.rubyist.net/articles/0061/0061-EditorsNote.html)
+
+ という構成となっています。
+ お楽しみください。
+
+[1]: https://ruby-no-kai.org/
+[2]: https://magazine.rubyist.net/
+[3]: https://magazine.rubyist.net/articles/0061/0061-index.html
+[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50872


### PR DESCRIPTION
RubiMa Editors have released Rubyist Magazine 61 (in japanese).