### PR TITLE
[CI] Update Install gem bundle step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Install bundler
         run: gem install bundler --no-document
       - name: Install gem bundle
-        run: bundle install --path vendor/bundle
+        run: |
+          bundle config set path 'vendor/bundle'
+          bundle install
       - name: Run tests
         run: bundle exec rake test


### PR DESCRIPTION
the `--path` option is deprecated, use `bundle config set path 'vendor/path'` instead.

<img width="1058" alt="スクリーンショット 2020-02-03 01 07 47" src="https://user-images.githubusercontent.com/1000669/73611096-ba332300-4621-11ea-87f5-d106e1a2d017.png">
