### PR TITLE
Fix outdated content and links of mailing list page (id)

### DIFF
--- a/id/community/mailing-lists/index.md
+++ b/id/community/mailing-lists/index.md
@@ -12,27 +12,33 @@ komunitas Ruby.
 
 id-ruby
 : Milis Ruby Indonesia yang pertama dan paling aktif. Untuk berlangganan
-  milis id-ruby, silakan buka [Milis id-ruby][2]. (Arsip [Gmane][3]
-  \[[NNTP](nntp://news.gmane.org/gmane.comp.lang.ruby.region.indonesia),
-  [threaded HTTP][4], [bloggy HTTP][5], [RSS][6]\] dan [mailarchive][7])
+  milis id-ruby, silakan buka [Milis id-ruby][2]. (Arsip [mailarchive][3])
 
 ### Milis Berbahasa Inggris
 
 Ruby juga menyediakan milis berbahasa Inggris dengan komunitas global:
 
 Ruby-Talk
-: Milis Ruby internasional yang paling terkenal. ([Arsip][11], [Posting Guidelines][guidelines], [Arsip Komunitas][rubytalk])
+: Milis Ruby internasional yang paling terkenal. ([Arsip][4], [Posting Guidelines][guidelines], [Arsip Komunitas][rubytalk])
 
 Ruby-Core
 : Mendiskusikan implementasi *interpreter* Ruby, terutama
-  penanganan *patch* baru. ([Arsip][12])
+  penanganan *patch* baru. ([Arsip][5])
 
 Ruby-Doc
-: Mendiskusikan standar dan *tools* dokumentasi Ruby. ([Arsip][13])
+: Mendiskusikan standar dan *tools* dokumentasi Ruby. ([Arsip][6])
 
 Ruby-CVS
 : Milis ini melaporkan setiap *commit* yang terjadi pada *repository*
   Subversion (dulunya CVS) proyek Ruby.
+
+The comp.lang.ruby Newsgroup
+: Bagi yang memilih Usenet daripada milis bisa periksa
+  [comp.lang.ruby](news:comp.lang.ruby) *newsgroup*. ([FAQ][clrFAQ])
+
+Lihat [list.ruby-lang.org](http://lists.ruby-lang.org)
+untuk informasi lebih lanjut tentang semua milis pada ruby-lang.org,
+termasuk daftar milis dalam bahasa Jepang.
 
 ## Mulai atau Berhenti Berlangganan
 
@@ -45,14 +51,11 @@ manual](/id/community/mailing-lists/manual-instructions/).
 
 
 [guidelines]: /en/community/mailing-lists/ruby-talk-guidelines/
+[clrFAQ]: http://rubyhacker.com/clrFAQ.html
 [1]: http://id.wikipedia.org/wiki/Milis "Group diskusi di internet dimana setiap orang bisa berlangganan dan berpartisipasi didalamnya."
 [2]: http://groups.yahoo.com/group/id-ruby/
-[3]: http://gmane.org/info.php?group=gmane.comp.lang.ruby.region.indonesia
-[4]: http://news.gmane.org/gmane.comp.lang.ruby.region.indonesia
-[5]: http://blog.gmane.org/gmane.comp.lang.ruby.region.indonesia
-[6]: http://rss.gmane.org/gmane.comp.lang.ruby.region.indonesia
-[7]: http://www.mail-archive.com/id-ruby@yahoogroups.com/
-[11]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
-[12]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
-[13]: http://lists.ruby-lang.org/pipermail/ruby-doc/
+[3]: http://www.mail-archive.com/id-ruby@yahoogroups.com/
+[4]: http://blade.nagaokaut.ac.jp/ruby/ruby-talk/index.shtml
+[5]: http://blade.nagaokaut.ac.jp/ruby/ruby-core/index.shtml
+[6]: http://lists.ruby-lang.org/pipermail/ruby-doc/
 [rubytalk]: https://rubytalk.org/


### PR DESCRIPTION
Changes:

* Remove outdated links for mailing list archive of Bahasa Indonesia.
* Add "The comp.lang.ruby Newsgroup" to the list, see [this](https://github.com/ruby/www.ruby-lang.org/commit/b3c62820c575a6e5ae5effefd8878082068f8388#diff-43dacde9342e1b7e4004f82a89ac67dfR26) line
* Add link to lists.ruby-lang.org, see commit 5fe1fd3e484d6fc4347e8da032f9f4c04bc632a8
* Link FAQ to "comp.lang.ruby FAQ", see commit fa24bbe406bd3bfb26410e79e337b51f7d28395a

cc: @kuntoaji 