### PR TITLE
Use Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-rvm: 2.6.5
+rvm: 2.7.0
 cache: bundler
 env:
   - TASK=test

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby ENV['CUSTOM_RUBY_VERSION'] || '~> 2.6.5'
+ruby ENV['CUSTOM_RUBY_VERSION'] || '~> 2.7.0'
 
 gem 'rake'
 gem 'jekyll', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ DEPENDENCIES
   validate-website (~> 1.6)
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.0p0
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
A lot of warnings right now has been fixed in jekyll/jekyll#7948. Waiting for a new Jekyll release.