### PR TITLE
Change links to snapshot

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -21,13 +21,6 @@ eol:
 
   - 2.3.8
 
-stable_snapshot:
-
-  url:
-    bz2: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.tar.bz2
-    gz: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.tar.gz
-    zip: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.zip
-
 stable_snapshots:
 
   - branch: ruby_2_7
@@ -35,18 +28,21 @@ stable_snapshots:
       gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.gz
       xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.xz
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.zip
+    version: '2.7'
 
   - branch: ruby_2_6
     url:
       gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.gz
       xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.xz
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.zip
+    version: '2.6'
 
   - branch: ruby_2_5
     url:
       gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.tar.gz
       xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.tar.xz
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.zip
+    version: '2.5'
 
 nightly_snapshot:
 
@@ -54,3 +50,4 @@ nightly_snapshot:
     gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.gz
     xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.xz
     zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.zip
+  version: '2.8'

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -28,9 +28,29 @@ stable_snapshot:
     gz: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.tar.gz
     zip: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.zip
 
+stable_snapshots:
+
+  - branch: ruby_2_7
+    url:
+      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.gz
+      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.xz
+      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.zip
+
+  - branch: ruby_2_6
+    url:
+      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.gz
+      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.xz
+      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.zip
+
+  - branch: ruby_2_5
+    url:
+      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.tar.gz
+      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.tar.xz
+      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_5.zip
+
 nightly_snapshot:
 
   url:
-    bz2: https://cache.ruby-lang.org/pub/ruby/snapshot.tar.bz2
-    gz: https://cache.ruby-lang.org/pub/ruby/snapshot.tar.gz
-    zip: https://cache.ruby-lang.org/pub/ruby/snapshot.zip
+    gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.gz
+    xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.xz
+    zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.zip

--- a/bg/downloads/index.md
+++ b/bg/downloads/index.md
@@ -54,7 +54,7 @@ Ruby може да бъде инсталиран и от изходен код �
 {% endif %}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Това е архвирано копие на последната стабилна версия.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Това е архивирано копие на последната версия в Git хранилището.

--- a/de/downloads/index.md
+++ b/de/downloads/index.md
@@ -53,7 +53,7 @@ vielleicht zu einem der oben erwähnten Drittanbieter-Werkzeuge greifen.
 {% endif %}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Hierbei handelt es sich um den neuesten Snapshot des stabilen Zweiges.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Hierbei handelt es sich um eine Kopie der Git von letzter Nacht.

--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -56,9 +56,9 @@ one of the third party tools mentioned above. They may help you.
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
-* **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
-    This is a tarball of the latest snapshot of the current stable branch.
+* **Snapshots:**{% for snapshot in site.data.downloads.stable_snapshots %}
+  * [Stable Snapshot of {{ snapshot.branch }} branch]({{ snapshot.url.gz }}):
+    This is a tarball of the latest snapshot of the current `{{ snapshot.branch }}` branch.{% endfor %}
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     This is a tarball of whatever is in Git, made nightly.
     This may contain bugs or other issues, use at your own risk!

--- a/es/downloads/index.md
+++ b/es/downloads/index.md
@@ -39,7 +39,7 @@ de ayuda.
   Ruby {{ site.data.downloads.stable[0] }}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Este es el tarball del último snapshot del branch de la versión actual estable.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Este es el tarball de lo que exista en Git, hecho diariamente.

--- a/fr/downloads/index.md
+++ b/fr/downloads/index.md
@@ -61,7 +61,7 @@ peut-être vous aider.
 {% endif %}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Archive de la dernière version publiée à partir de la branche stable courante.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Archive construite chaque nuit à partir du code le plus récent présent sur Git.

--- a/id/downloads/index.md
+++ b/id/downloads/index.md
@@ -57,7 +57,7 @@ salah satu kakas bantu pihak ketiga yang telah disebutkan sebelumnya. Itu mungki
 {% endif %}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Ini adalah *tarball* dari *snapshot branch* yang stabil saat ini.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Ini adalah *tarball* dari apapun yang ada di Git, *nightly*.

--- a/it/downloads/index.md
+++ b/it/downloads/index.md
@@ -46,7 +46,7 @@ esserti di aiuto.
   Ruby {{ site.data.downloads.stable[0] }}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Questo è il tarball dell'ultimo snapshot del branch stabile corrente.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Questo è il tarball di ciò che c’è in Git, generato giornalmente.

--- a/ja/dev/index.md
+++ b/ja/dev/index.md
@@ -27,8 +27,10 @@ Rubyの不具合や機能追加の要望などは[Redmine(問題追跡システ�
 開発中のソースコードを取得できます。
 詳しくは[リポジトリガイド](/ja/documentation/repository-guide)のページを参照してください。
 
-また、毎日、日本時間の午前4時頃に、開発版系列(現在はRuby 2.7)および安定版系列(現在はRuby
-2.6)のソースコードのスナップショットを作成しています。 それぞれ、以下のリンクからダウンロードできます。
+また、毎日、日本時間の午後10時頃に、開発版系列(現在はRuby
+{{ site.data.downloads.nightly_snapshot.version }})および安定版系列(現在はRuby
+{{ site.data.downloads.stable_snapshots[0].version }})のソースコードのスナップショットを作成しています。
+それぞれ、以下のリンクからダウンロードできます。
 
 * [開発版スナップショット][3]
 * [安定版スナップショット][4]
@@ -50,4 +52,4 @@ Posted by usa on 13 Aug 2008
 [1]: https://bugs.ruby-lang.org/projects/ruby/wiki
 [2]: https://bugs.ruby-lang.org/
 [3]: {{ site.data.downloads.nightly_snapshot.url.gz }}
-[4]: {{ site.data.downloads.stable_snapshot.url.gz }}
+[4]: {{ site.data.downloads.stable_snapshots[0].url.gz }}

--- a/ja/downloads/index.md
+++ b/ja/downloads/index.md
@@ -50,9 +50,9 @@ lang: ja
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
-* **スナップショット:**
-  * [安定版のスナップショット]({{ site.data.downloads.stable_snapshot.url.gz }}):
-    最も新しい現在の安定版ブランチのスナップショットのtarballです。
+* **スナップショット:**{% for snapshot in site.data.downloads.stable_snapshots %}
+  * [{{ snapshot.branch }}ブランチの安定版スナップショット]({{ snapshot.url.gz }}):
+    現在の{{ snapshot.branch }}ブランチのスナップショットのtarballです。{% endfor %}
   * [ナイトリースナップショット]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     毎晩Gitから作成しているtarballです。
     バグやその他の問題があるかもしれません。利用する場合は自己責任でお願いします！

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -56,8 +56,8 @@ lang: ko
 {% endif %}
 
 * **스냅숏:**{% for snapshot in site.data.downloads.stable_snapshots %}
-  * [안정 스냅숏]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
-    안정 브랜치의 최신 스냅숏을 tarball로 압축한 것입니다.
+  * [{{ snapshot.branch }} 브랜치의 안정 스냅숏]({{ snapshot.url.gz }}):
+    `{{ snapshot.branch }}` 브랜치의 최신 스냅숏을 tarball로 압축한 것입니다.{% endfor %}
   * [나이틀리 스냅숏]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     나이틀리로 제작된 Git 상의 모든 것을 tarball로 압축한 것입니다.
     본 스냅숏은 버그 혹은 기타 이슈를 포함하고 있을 수 있으니 주의하여

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -55,7 +55,7 @@ lang: ko
     sha256: {{ release.sha256.gz }}{% endfor %}
 {% endif %}
 
-* **스냅숏:**
+* **스냅숏:**{% for snapshot in site.data.downloads.stable_snapshots %}
   * [안정 스냅숏]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     안정 브랜치의 최신 스냅숏을 tarball로 압축한 것입니다.
   * [나이틀리 스냅숏]({{ site.data.downloads.nightly_snapshot.url.gz }}):

--- a/ko/downloads/index.md
+++ b/ko/downloads/index.md
@@ -56,7 +56,7 @@ lang: ko
 {% endif %}
 
 * **스냅숏:**
-  * [안정 스냅숏]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [안정 스냅숏]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     안정 브랜치의 최신 스냅숏을 tarball로 압축한 것입니다.
   * [나이틀리 스냅숏]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     나이틀리로 제작된 Git 상의 모든 것을 tarball로 압축한 것입니다.

--- a/pl/downloads/index.md
+++ b/pl/downloads/index.md
@@ -42,7 +42,7 @@ skorzystanie z narzędzi osób trzecich wspomnianych powyżej. Mogą ci pomóc.
   Ruby {{ site.data.downloads.stable[0] }}
 
 * **Migawki:**
-  * [Stabilna migawka]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stabilna migawka]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     To jest tarball ostatniej migawki stabilnej obecnego stabilnego brancha.
   * [Nocna migawka]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     To jest tarball tego co jest w Git, przygotowany

--- a/pt/downloads/index.md
+++ b/pt/downloads/index.md
@@ -53,7 +53,7 @@ mencionadas acima. Elas podem te ajudar.
 {% endif %}
 
 * **Snapshots:**
-  * [Snapshot Estável]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Snapshot Estável]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Este é um arquivo compactado com o snapshot mais recente do branch estável.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Este é um arquivo compactado do que está no Git, criado todas as noites.

--- a/ru/downloads/index.md
+++ b/ru/downloads/index.md
@@ -58,7 +58,7 @@ lang: ru
 {% endif %}
 
 * **Слепки:**
-  * [Стабильный слепок]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Стабильный слепок]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Это архив свежайшего слепка текущей стабильной ветки.
   * [Nightly-слепок]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Это архив того, что есть в Git, сделанный ночью.

--- a/tr/downloads/index.md
+++ b/tr/downloads/index.md
@@ -69,7 +69,7 @@ Bunlar size yardımcı olabilir.
 {% endif %}
 
 * **Anlıklar:**
-  * [Kararlı Anlık]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Kararlı Anlık]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Bu, şu anki kararlı dalın son anlığının bir tar arşividir.
     [Gecelik Anlık]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Bu, Git'de her ne varsa onun bir tar arşividir, gecelik olarak yapılır.

--- a/vi/downloads/index.md
+++ b/vi/downloads/index.md
@@ -52,7 +52,7 @@ dụng một trong những công cụ của bên thứ ba đã được đề c�
 {% endif %}
 
 * **Snapshots:**
-  * [Stable Snapshot]({{ site.data.downloads.stable_snapshot.url.gz }}):
+  * [Stable Snapshot]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
     Đây là một tarball của snapshot mới nhất của nhánh ổn định hiện hành.
   * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
     Đây là một tarball của mã mới nhất hiện hữu trong Git. Gói này được

--- a/zh_cn/downloads/index.md
+++ b/zh_cn/downloads/index.md
@@ -49,7 +49,7 @@ lang: zh_cn
 {% endif %}
 
 * **快照：**
-  * [稳定版快照]({{ site.data.downloads.stable_snapshot.url.gz }})：当前稳定版 tarball 的最新快照
+  * [稳定版快照]({{ site.data.downloads.stable_snapshots[0].url.gz }})：当前稳定版 tarball 的最新快照
   * [每日构建版快照]({{ site.data.downloads.nightly_snapshot.url.gz }})：这是 Git 上的 tarball，每晚构建。可能有问题或 bug，谨慎使用！
 
 更多有关特定发行版本、特别是老旧版本的资讯，请参阅[版本页面][releases]。

--- a/zh_tw/downloads/index.md
+++ b/zh_tw/downloads/index.md
@@ -49,7 +49,7 @@ lang: zh_tw
 {% endif %}
 
 * **快照：**
-  * [穩定版快照]({{ site.data.downloads.stable_snapshot.url.gz }})：
+  * [穩定版快照]({{ site.data.downloads.stable_snapshots[0].url.gz }})：
     這是當前穩定版本分支的 tarball 的最新快照；
   * [最新版本]({{ site.data.downloads.nightly_snapshot.url.gz }})：
     這是 Git 上的 tarball，每晚更新。


### PR DESCRIPTION
[`Deprecate pub/ruby/*snapshot* and use pub/ruby/snapshot/* instead`](https://bugs.ruby-lang.org/issues/16630) is accepted at today's developer meeting.

So I change links to snapshot tarballs first.
After a while, I remove `pub/ruby/snapshot.*` and `pub/ruby/stable-snapshot.*`.