### PR TITLE
Correct release note on frozen to_s in 2.7.0-preview3 (de, es, ko, zh_cn, zh_tw)

### DIFF
--- a/de/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/de/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -260,7 +260,7 @@ jedoch bis zur offiziellen Veröffentlichung nachgeholt.
   * Der Standardwert von `--jit-max-cache` wird von 1.000 auf 100
     geändert.
 
-* `Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` und
+* ~~`Symbol#to_s`~~ (rückgängig gemacht), `Module#name`, `true.to_s`, `false.to_s` und
   `nil.to_s` geben jetzt immer einen eingefrorenen String zurück. Der
   zurückgegebene String ist für das jeweilige Objekt immer derselbe.
   [Experimenell] [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)

--- a/es/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/es/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -252,12 +252,11 @@ la versión oficial.
 
   * El valor por omisión de `--jit-max-cache` cambió de 1,000 a 100
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s`
+* ~~`Symbol#to_s`~~ (revertido), `Module#name`, `true.to_s`, `false.to_s`
   y `nil.to_s` ahora siempre retornan una cadena congelada.
   La cadena retornada es siempre la misma para
   un objeto dado. [Experimental]
-  [[Característica#16150]](https://bugs.ruby-lang.org/issues/16150)~~
-  revertido
+  [[Característica#16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * Se mejora el desempeño de `CGI.escapeHTML`.
   [GH-2226](https://github.com/ruby/ruby/pull/2226)

--- a/ko/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/ko/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -222,9 +222,9 @@ NOTE: 키워드 인자 비호환으로 인한 너무 많은 폐기 경고가 번
 
   * `--jit-max-cache`의 기본값이 1,000에서 100으로 변경됩니다.
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s`, `nil.to_s`가 이제 항상 얼린 문자열을 반환합니다.
+* ~~`Symbol#to_s`~~ (취소되었습니다.), `Module#name`, `true.to_s`, `false.to_s`, `nil.to_s`가 이제 항상 얼린 문자열을 반환합니다.
   주어진 객체에 대해 항상 동일한 문자열이 반환됩니다. [실험적]
-  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ 취소되었습니다.
+  [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML`의 성능이 향상되었습니다. [GH-2226](https://github.com/ruby/ruby/pull/2226)
 

--- a/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -177,7 +177,7 @@ end
 
   * `--jit-max-cache` 的默认值从 1,000 调整到 100。
 
-* ~~`Symbol#to_s`~~ (已回复), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 现在始终返回一个冻结（frozen）字符串。返回的字符串始终和给定的对象相等。 [实验性]  [[功能 #16150]](https://bugs.ruby-lang.org/issues/16150)
+* ~~`Symbol#to_s`~~ (已撤回), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 现在始终返回一个冻结（frozen）字符串。返回的字符串始终和给定的对象相等。 [实验性]  [[功能 #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML` 的性能被提升了。[GH-2226](https://github.com/ruby/ruby/pull/2226)
 

--- a/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -231,7 +231,7 @@ end
   *关于我们使用方言的具体信息请查阅：<https://bugs.ruby-lang.org/projects/ruby-master/wiki/C99>
 
 * ~~`Regexp#match{?}` 传入 `nil` 会产生 TypeError。
-  [[Feature #13083]](https://bugs.ruby-lang.org/issues/13083)~~ 已回复
+  [[Feature #13083]](https://bugs.ruby-lang.org/issues/13083)~~ 已撤回
 
 3895 个文件变更，213426 行新增(+)，96934 行删除(-)
 

--- a/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_cn/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -177,7 +177,7 @@ end
 
   * `--jit-max-cache` 的默认值从 1,000 调整到 100。
 
-* Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 现在始终返回一个冻结（frozen）字符串。返回的字符串始终和给定的对象相等。 [实验性]  [[功能 #16150]](https://bugs.ruby-lang.org/issues/16150)
+* ~~`Symbol#to_s`~~ (已回复), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 现在始终返回一个冻结（frozen）字符串。返回的字符串始终和给定的对象相等。 [实验性]  [[功能 #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML` 的性能被提升了。[GH-2226](https://github.com/ruby/ruby/pull/2226)
 

--- a/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -240,7 +240,7 @@ end
   * 關於我們語言的詳細資訊：<https://bugs.ruby-lang.org/projects/ruby-master/wiki/C99>
 
 * ~~`Regexp#match{?}` 傳入 `nil` 會產生 TypeError。
-  [[Feature #13083]](https://bugs.ruby-lang.org/issues/13083)~~ 已回復
+  [[Feature #13083]](https://bugs.ruby-lang.org/issues/13083)~~ 已取消
 
 3895 個檔案變更，213426 行增加（+），96934 行刪減（-）
 

--- a/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -184,7 +184,7 @@ end
 
   * `--jit-max-cache` 的預設值從 1,000 調整至 100。
 
-* ~~`Symbol#to_s`, `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 現在始終返回一個凍結（frozen）字串。返回的字串始終和給定的物件相等。 [實驗性質] [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)~~ 已回復
+* ~~`Symbol#to_s`~~ (已回復), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 現在始終返回一個凍結（frozen）字串。返回的字串始終和給定的物件相等。 [實驗性質] [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML` 的效能得到了提升。[GH-2226](https://github.com/ruby/ruby/pull/2226)
 

--- a/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/zh_tw/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -184,7 +184,7 @@ end
 
   * `--jit-max-cache` 的預設值從 1,000 調整至 100。
 
-* ~~`Symbol#to_s`~~ (已回復), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 現在始終返回一個凍結（frozen）字串。返回的字串始終和給定的物件相等。 [實驗性質] [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
+* ~~`Symbol#to_s`~~ (已取消), `Module#name`, `true.to_s`, `false.to_s` 和 `nil.to_s` 現在始終返回一個凍結（frozen）字串。返回的字串始終和給定的物件相等。 [實驗性質] [[Feature #16150]](https://bugs.ruby-lang.org/issues/16150)
 
 * `CGI.escapeHTML` 的效能得到了提升。[GH-2226](https://github.com/ruby/ruby/pull/2226)
 


### PR DESCRIPTION
Hello!
Done as in PR #2308 for de, es, ko, zh_cn and zh_tw translations.