### PR TITLE
Fix typo in english libraries index page

### DIFF
--- a/en/libraries/index.md
+++ b/en/libraries/index.md
@@ -4,7 +4,7 @@ title: "Libraries"
 lang: en
 ---
 
-As most programming languages, Ruby leverages a wide set of third-party
+As with most programming languages, Ruby leverages a wide set of third-party
 libraries.
 {: .summary}
 


### PR DESCRIPTION
"As most programming languages"

to

"As **with** most programming languages"

Perhaps the original way is correct, but grammatically it did not make sense to me. Have a great day!