### PR TITLE
Translate "Home" link in site navigation (id)

### DIFF
--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -3,7 +3,7 @@ ruby: Ruby
 slogan: Sahabat Terbaik Programmer
 
 sitelinks:
-- text: Home
+- text: Beranda
   url: /id
   home: true
 - text: Unduh


### PR DESCRIPTION
This is mentioned on issue #2331. Previously, there was changes that enable i18n for "Home" link (you can check on the PR #2312). cc: @kuntoaji 