### PR TITLE
Move Ruby 2.4 to EOL

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -19,12 +19,12 @@
   eol_date:
 
 - name: 2.5
-  status: normal maintenance
+  status: security maintenance
   date: 2017-12-25
-  eol_date:
+  eol_date: 2021-03-31
 
 - name: 2.4
-  status: security maintenance
+  status: eol
   date: 2016-12-25
   eol_date: 2020-03-31
 

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,16 +9,16 @@ stable:
 
   - 2.7.1
   - 2.6.6
-  - 2.5.8
 
 # optional
 security_maintenance:
 
-  - 2.4.10
+  - 2.5.8
 
 # optional
 eol:
 
+  - 2.4.10
   - 2.3.8
 
 stable_snapshot:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/

cc @mame @unak 