### PR TITLE
update link to Poignant Guide

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -131,7 +131,7 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -74,7 +74,7 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 
 
 [1]: https://ruby.github.io/TryRuby/
-[3]: http://mislav.uniqpath.com/poignant-guide/
+[3]: https://poignant.guide
 [4]: http://www.moccasoft.de/papers/ruby_tutorial
 [5]: http://pine.fm/LearnToProgram/
 [6]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -131,7 +131,7 @@ If you have questions about Ruby the
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -68,7 +68,7 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 [2]: http://pine.fm/LearnToProgram/
 [3]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [4]: http://pragmaticprogrammer.com/titles/ruby/index.html
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [7]: http://www.ruby-doc.org/core
 [8]: https://ruby.github.io/rdoc/
 [9]: http://www.ruby-doc.org/stdlib

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -131,7 +131,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [2]: http://jeveuxapprendreruby.fr/
 [3]: https://ruby.github.io/TryRuby/
 [4]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://pine.fm/LearnToProgram/
 [7]: http://www.ruby-doc.org/docs/ApprendreProgrammer/Apprendre_%E0_Programmer.pdf
 [9]: http://rubylearning.com/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -130,7 +130,7 @@ adalah tempat yang baik untuk memulai.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -130,7 +130,7 @@ iniziare.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -131,7 +131,7 @@ lang: ko
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -134,7 +134,7 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -140,7 +140,7 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -144,7 +144,7 @@ olacaktır.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -141,7 +141,7 @@ là một nơi tuyệt vời.
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -112,7 +112,7 @@ ruby -v
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -107,7 +107,7 @@ lang: zh_tw
 
 [1]: https://ruby.github.io/TryRuby/
 [2]: http://rubykoans.com/
-[5]: http://mislav.uniqpath.com/poignant-guide/
+[5]: https://poignant.guide
 [6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/


### PR DESCRIPTION
The primary website for the Why's (Poignant) Guide to Ruby appears to have moved.  The old link now appears to be broken, so this patch updates the links in the documentation.