### PR TITLE
Support of Ruby 2.4 has ended

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -19,12 +19,12 @@
   eol_date:
 
 - name: 2.5
-  status: normal maintenance
+  status: security maintenance
   date: 2017-12-25
   eol_date:
 
 - name: 2.4
-  status: security maintenance
+  status: eol
   date: 2016-12-25
   eol_date: 2020-03-31
 

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,17 +9,16 @@ stable:
 
   - 2.7.1
   - 2.6.6
-  - 2.5.8
 
 # optional
 security_maintenance:
 
-  - 2.4.10
+  - 2.5.8
 
 # optional
 eol:
 
-  - 2.3.8
+  - 2.4.10
 
 stable_snapshot:
 

--- a/en/news/_posts/2020-04-02-support-of-ruby-2-4-has-ended.md
+++ b/en/news/_posts/2020-04-02-support-of-ruby-2-4-has-ended.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "Support of Ruby 2.4 has ended"
+author: "antonpaisov"
+translator:
+date: 2019-04-02 00:00:00 +0000
+lang: en
+---
+
+We announce that all support of the Ruby 2.4 series has ended.
+
+After the release of Ruby 2.4.6 on April 1, 2019,
+the support of the Ruby 2.4 series was in the security maintenance phase.
+Now, after one year has passed, this phase has ended.
+Therefore, on March 31, 2020, all support of the Ruby 2.4 series ends.
+Security and bug fixes from more recent Ruby versions will no longer be
+backported to 2.4. There won't be any patches of 2.4 either.
+We highly recommend that you upgrade to Ruby 2.7 or 2.6 as soon as possible.
+
+## About currently supported Ruby versions
+
+### Ruby 2.7 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+### Ruby 2.6 series
+
+Currently in normal maintenance phase.
+We will backport bug fixes and release with the fixes whenever necessary.
+And, if a critical security issue is found, we will release an urgent fix
+for it.
+
+### Ruby 2.5 series
+
+Currently in security maintenance phase.
+We will never backport any bug fixes to 2.5 except security fixes.
+If a critical security issue is found, we will release an urgent fix for it.
+We are planning to end the support of the Ruby 2.5 series on March 31, 2021.

--- a/en/news/_posts/2020-04-02-support-of-ruby-2-4-has-ended.md
+++ b/en/news/_posts/2020-04-02-support-of-ruby-2-4-has-ended.md
@@ -3,7 +3,7 @@ layout: news_post
 title: "Support of Ruby 2.4 has ended"
 author: "antonpaisov"
 translator:
-date: 2019-04-02 00:00:00 +0000
+date: 2020-04-02 00:00:00 +0000
 lang: en
 ---
 


### PR DESCRIPTION
As Ruby 2.4 reached its EOL on March 31, here's a post about it.
Similar to the one from last year https://github.com/ruby/www.ruby-lang.org/pull/2008

cc @unak @hsbt @JuanitoFatas 