### PR TITLE
Fix CVE-2020-10663 name in latest news posts (en, tr)

### DIFF
--- a/en/news/_posts/2020-03-31-ruby-2-4-10-released.md
+++ b/en/news/_posts/2020-03-31-ruby-2-4-10-released.md
@@ -11,7 +11,7 @@ Ruby 2.4.10 has been released.
 
 This release includes a security fix.  Please check the topics below for details.
 
-* [CVE-2020-16255: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
 
 Ruby 2.4 is now under the state of the security maintenance phase, until the end of March of 2020.
 After that date, maintenance of Ruby 2.4 will be ended.

--- a/en/news/_posts/2020-03-31-ruby-2-5-8-released.md
+++ b/en/news/_posts/2020-03-31-ruby-2-5-8-released.md
@@ -12,7 +12,7 @@ Ruby 2.5.8 has been released.
 This release includes security fixes.
 Please check the topics below for details.
 
-* [CVE-2020-16255: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
 * [CVE-2020-10933: Heap exposure vulnerability in the socket library]({% link en/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
 
 See the [commit logs](https://github.com/ruby/ruby/compare/v2_5_7...v2_5_8) for details.

--- a/en/news/_posts/2020-03-31-ruby-2-6-6-released.md
+++ b/en/news/_posts/2020-03-31-ruby-2-6-6-released.md
@@ -12,7 +12,7 @@ Ruby 2.6.6 has been released.
 This release includes security fixes.
 Please check the topics below for details.
 
-* [CVE-2020-16255: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
 * [CVE-2020-10933: Heap exposure vulnerability in the socket library]({% link en/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
 
 See the [commit logs](https://github.com/ruby/ruby/compare/v2_6_5...v2_6_6) for details.

--- a/en/news/_posts/2020-03-31-ruby-2-7-1-released.md
+++ b/en/news/_posts/2020-03-31-ruby-2-7-1-released.md
@@ -12,7 +12,7 @@ Ruby 2.7.1 has been released.
 This release includes security fixes.
 Please check the topics below for details.
 
-* [CVE-2020-16255: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)]({% link en/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
 * [CVE-2020-10933: Heap exposure vulnerability in the socket library]({% link en/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
 
 See the [commit logs](https://github.com/ruby/ruby/compare/v2_7_0...v2_7_1) for details.

--- a/tr/news/_posts/2020-03-31-ruby-2-6-6-released.md
+++ b/tr/news/_posts/2020-03-31-ruby-2-6-6-released.md
@@ -12,7 +12,7 @@ Ruby 2.6.6 yayınlandı.
 Bu yayın güvenlik düzeltmeleri içermektedir.
 Ayrıntılar için lütfen aşağıdaki konuları inceleyin.
 
-* [CVE-2020-16255: CVE-2020-10663: JSON'da Güvensiz Nesne Oluşturma Zaafiyeti (Ek düzeltme)]({% link tr/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10663: JSON'da Güvensiz Nesne Oluşturma Zaafiyeti (Ek düzeltme)]({% link tr/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
 * [CVE-2020-10933: Soket kütüphanesinde heap teşhir zaafiyeti]({% link tr/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
 
 Ayrıntılar için [işleme logları](https://github.com/ruby/ruby/compare/v2_6_5...v2_6_6)na bakın.


### PR DESCRIPTION
Typo.