### PR TITLE
Add rubybib.org link to sidebar (id)

### DIFF
--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -43,6 +43,9 @@ sidebar:
       url: /id/documentation/
     # books:
     #   text: Buku-buku
+    rubybib:
+      text: Penelitian Akademis
+      url: https://rubybib.org/
     libraries:
       text: Pustaka
       url: /id/libraries/


### PR DESCRIPTION
This link exists in the sidebar of English page. Please, check these lines https://github.com/ruby/www.ruby-lang.org/blob/a01b16b43453dbfa1def51860631bb154068597a/_data/locales/en.yml#L47-L49

cc: @kuntoaji 