### PR TITLE
[Data] Use unquoted value for date elements in _releases.yml

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -22,7 +22,7 @@
 # 2.7 series
 
 - version: 2.7.1
-  date: '2020-03-31'
+  date: 2020-03-31
   post: "/en/news/2020/03/31/ruby-2-7-1-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2
@@ -209,7 +209,7 @@
 # 2.6 series
 
 - version: 2.6.6
-  date: '2020-03-31'
+  date: 2020-03-31
   post: "/en/news/2020/03/31/ruby-2-6-6-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2
@@ -409,7 +409,7 @@
 # 2.5 series
 
 - version: 2.5.8
-  date: '2020-03-31'
+  date: 2020-03-31
   post: "/en/news/2020/03/31/ruby-2-5-8-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2
@@ -595,7 +595,7 @@
 # 2.4 series
 
 - version: 2.4.10
-  date: '2020-03-31'
+  date: 2020-03-31
   post: "/en/news/2020/03/31/ruby-2-4-10-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2


### PR DESCRIPTION
Unlike all other entries in [`releases.yml`](https://github.com/ruby/www.ruby-lang.org/blob/master/_data/releases.yml), the multiple releases of 2020-03-31 have been added to the file, I suppose not intentionally, with a quoted date.

This results in:

1. `YAML.load` not parsing the date automatically anymore for these specific elements, meaning we have to call `Date.parse` explicitly.
2. Inconsistency with the rest of the data.

```ruby
YAML.load_file('_data/releases.yml')

=> [{"version"=>"2.7.1",
  "date"=>"2020-03-31",
  "post"=>"/en/news/2020/03/31/ruby-2-7-1-released/",
  # ...
 },
 {"version"=>"2.7.0",
  "date"=>#<Date: 2019-12-25 ((2458843j,0s,0n),+0s,2299161j)>,
  "post"=>"/en/news/2019/12/25/ruby-2-7-0-released/",
  # ...
 },
 {"version"=>"2.7.0-rc2",
  "date"=>#<Date: 2019-12-21 ((2458839j,0s,0n),+0s,2299161j)>,
  "post"=>"/en/news/2019/12/21/ruby-2-7-0-rc2-released/"
  # ...
 }
 # ...
```

This PR changes all the quoted date occurrences to the unquoted string.