### PR TITLE
Translate 2.4.10, 2.5.8, 2.6.6 & 2.7.1 posts (ja)

### DIFF
--- a/ja/news/_posts/2020-03-31-ruby-2-4-10-released.md
+++ b/ja/news/_posts/2020-03-31-ruby-2-4-10-released.md
@@ -1,0 +1,56 @@
+---
+layout: news_post
+title: "Ruby 2.4.10 リリース"
+author: "usa"
+translator: "wktk"
+date: 2020-03-31 12:00:00 +0000
+lang: ja
+---
+
+Ruby 2.4.10 がリリースされました。
+
+このリリースには以下の脆弱性修正が含まれています。
+
+* [CVE-2020-10663: JSON における安全でないオブジェクトの生成の脆弱性について（追加の修正）]({% link ja/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+
+Ruby 2.4 系列は、現在、セキュリティメンテナンスフェーズにあります。
+このフェーズ中は、重大なセキュリティ上の問題への対応のみが行われます。
+現在の予定では、2020 年 3 月末頃を目処に、2.4 系列のセキュリティメンテナンスならびに公式サポートは終了する見込みです。
+従って、以後 2.4 系列からの新たな公式リリースは行われません。
+現在 2.4 系列を利用しているユーザーの皆さんは、なるべく早く、2.7 系列等のより新しいバージョン系列の Ruby への移行を行ってください。
+
+## ダウンロード
+
+{% assign release = site.data.releases | where: "version", "2.4.10" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## リリースコメント
+
+リリースに協力してくれた皆様、また、脆弱性情報を報告してくれた皆様に感謝します。

--- a/ja/news/_posts/2020-03-31-ruby-2-5-8-released.md
+++ b/ja/news/_posts/2020-03-31-ruby-2-5-8-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.5.8 リリース"
+author: "usa"
+translator: "wktk"
+date: 2020-03-31 12:00:00 +0000
+lang: ja
+---
+
+Ruby 2.5.8 がリリースされました。
+
+このリリースには以下の脆弱性修正が含まれています。
+
+* [CVE-2020-10663: JSON における安全でないオブジェクトの生成の脆弱性について（追加の修正）]({% link ja/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10933: socketライブラリのヒープ暴露脆弱性について]({% link ja/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
+
+詳細は [commit log](https://github.com/ruby/ruby/compare/v2_5_7...v2_5_8) を参照してください。
+
+## ダウンロード
+
+{% assign release = site.data.releases | where: "version", "2.5.8" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## リリースコメント
+
+リリースに協力してくれた皆様、また、脆弱性情報を報告してくれた皆様に感謝します。

--- a/ja/news/_posts/2020-03-31-ruby-2-6-6-released.md
+++ b/ja/news/_posts/2020-03-31-ruby-2-6-6-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.6.6 リリース"
+author: "nagachika"
+translator: "wktk"
+date: 2020-03-31 12:00:00 +0000
+lang: ja
+---
+
+Ruby 2.6.6 がリリースされました。
+
+このリリースには以下の脆弱性修正が含まれています。
+
+* [CVE-2020-10663: JSON における安全でないオブジェクトの生成の脆弱性について（追加の修正）]({% link ja/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10933: socketライブラリのヒープ暴露脆弱性について]({% link ja/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
+
+詳細は [commit log](https://github.com/ruby/ruby/compare/v2_6_5...v2_6_6) を参照してください。
+
+## ダウンロード
+
+{% assign release = site.data.releases | where: "version", "2.6.6" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## リリースコメント
+
+このリリースにあたり、多くのコミッター、開発者、バグ報告をしてくれたユーザーの皆様に感謝を申し上げます。

--- a/ja/news/_posts/2020-03-31-ruby-2-7-1-released.md
+++ b/ja/news/_posts/2020-03-31-ruby-2-7-1-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.7.1 リリース"
+author: "naruse"
+translator: "wktk"
+date: 2020-03-31 12:00:00 +0000
+lang: ja
+---
+
+Ruby 2.7.1 がリリースされました。
+
+このリリースには以下の脆弱性修正が含まれています。
+
+* [CVE-2020-10663: JSON における安全でないオブジェクトの生成の脆弱性について（追加の修正）]({% link ja/news/_posts/2020-03-19-json-dos-cve-2020-10663.md %})
+* [CVE-2020-10933: socketライブラリのヒープ暴露脆弱性について]({% link ja/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md %})
+
+詳細は [commit log](https://github.com/ruby/ruby/compare/v2_7_0...v2_7_1) を参照してください。
+
+## ダウンロード
+
+{% assign release = site.data.releases | where: "version", "2.7.1" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## リリースコメント
+
+このリリースにあたり、多くのコミッター、開発者、バグ報告をしてくれたユーザーの皆様に感謝を申し上げます。


### PR DESCRIPTION
Added Japanese posts for the release news published in 2020-03-31 as they didn't exist.