### PR TITLE
Fix syntax highlighted code blocks in lists (de, es)

### DIFF
--- a/de/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/de/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -44,13 +44,13 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-{% highlight ruby %}
+```ruby
 case JSON.parse('{...}', symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age
   ...
 end
-{% endhighlight %}
+```
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.
@@ -89,12 +89,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   vermieden und das korrekte Verhalten in Ruby 3 sichergestellt
   werden.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(key: 42); end; foo({key: 42})   # Warnung
   def foo(**kw);    end; foo({key: 42})   # Warnung
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn bei einem Methodenaufruf Schlüsselwortargumente an eine
   Methode, die auch Schlüsselwortargumente akzeptiert, übergeben
@@ -105,12 +105,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   Schlüsselwortargumentliste, um die Warnung zu vermeiden und
   korrektes Verhalten in Ruby 3 sicherzustellen.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h, **kw); end; foo(key: 42)      # Warnung
   def foo(h, key: 42); end; foo(key: 42)   # Warnung
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn eine Methode bestimmte Schlüsselwortargumente, nicht aber den
   doppelten Auflösungsoperator verwendet, und ein Hash oder eine
@@ -120,11 +120,11 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   Verhalten in Ruby 3 den aufrufenden Code so ändern, dass zwei
   einzelne Hashes übergeben werden.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # Warnung
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # Warnung
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn eine Methode keine Schlüsselwortargumente akzeptiert, aber mit
   solchen aufgerufen wird, werden solche Schlüsselwortargumente
@@ -132,30 +132,30 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   interpretiert. Dieses Verhalten wird auch in Ruby 3 weiterhin
   beibehalten.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(opt={});  end; foo( key: 42 )   # OK
-  {% endhighlight %}
+  ```
 
 * Schlüsselwortargumente mit anderen Schlüsseln als Symbolen sind
   zulässig, wenn die Methode beliebige Schlüsselwortargumente
   akzeptiert. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  {% endhighlight %}
+  ```
 
 * <code>**nil</code> kann genutzt werden, um in einer
   Methodendefinition ausdrücklich festzulegen, dass die Methode keine
   Schlüsselwörter akzeptiert. Der Aufruf einer solchen Methode mit
   Schlüsselwortargumenten erzeugt einen ArgumentError. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  {% endhighlight %}
+  ```
 
 * Die Übergabe einess leeren doppelten Auflösungsoperators an eine
   Methode, die keine Schlüsselwortargumente akzeptiert, führt nicht
@@ -165,12 +165,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   doppelten Auflösungsoperator, um ein Hash als Positionsargument zu
   übergeben. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} und Warnung
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  {% endhighlight %}
+  ```
 
 ## Sonstige bemerkenswerte neue Funktionen
 
@@ -186,39 +186,39 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   domänenspezifische Sprachen praktisch sein.
   [#14799](https://bugs.ruby-lang.org/issues/14799)
 
-  {% highlight ruby %}
+  ```ruby
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  {% endhighlight %}
+  ```
 
 * `Enumerable#tally` wird hinzugefügt. Die Methode zählt das Vorkommen
   jedes Elements.
 
-  {% highlight ruby %}
+  ```ruby
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  {% endhighlight %}
+  ```
 
 * Es ist jetzt zulässig, eine private Methode auf `self` aufzurufen.
   [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) [[Feature #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  {% highlight ruby %}
+  ```ruby
   def foo
   end
   private :foo
   self.foo
-  {% endhighlight %}
+  ```
 
 * `Enumerator::Lazy#eager` wird hinzugefügt. Diese Methode generiert
   einen nicht verzögertern Enumerator (_non-lazy enumerator_) aus
   einem verzögerten Enumerator (_lazy enumerator_). [[Feature #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  {% highlight ruby %}
+  ```ruby
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  {% endhighlight %}
+  ```
 
 ## Performanzverbesserungen
 

--- a/de/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/de/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -48,7 +48,7 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-{% highlight ruby %}
+```ruby
 require "json"
 
 json = <<END
@@ -63,7 +63,7 @@ case JSON.parse(json, symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age #=> 2
 end
-{% endhighlight %}
+```
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.
@@ -101,12 +101,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   vermieden und das korrekte Verhalten in Ruby 3 sichergestellt
   werden.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(key: 42); end; foo({key: 42})   # Warnung
   def foo(**kw);    end; foo({key: 42})   # Warnung
   def foo(key: 42); end; foo(**{key: 42}) # OK
   def foo(**kw);    end; foo(**{key: 42}) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn bei einem Methodenaufruf Schlüsselwortargumente an eine
   Methode, die auch Schlüsselwortargumente akzeptiert, übergeben
@@ -117,12 +117,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   Schlüsselwortargumentliste, um die Warnung zu vermeiden und
   korrektes Verhalten in Ruby 3 sicherzustellen.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h, **kw); end; foo(key: 42)      # Warnung
   def foo(h, key: 42); end; foo(key: 42)   # Warnung
   def foo(h, **kw); end; foo({key: 42})    # OK
   def foo(h, key: 42); end; foo({key: 42}) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn eine Methode bestimmte Schlüsselwortargumente, nicht aber den
   doppelten Auflösungsoperator verwendet, und ein Hash oder eine
@@ -132,11 +132,11 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   Verhalten in Ruby 3 den aufrufenden Code so ändern, dass zwei
   einzelne Hashes übergeben werden.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h={}, key: 42); end; foo("key" => 43, key: 42)   # Warnung
   def foo(h={}, key: 42); end; foo({"key" => 43, key: 42}) # Warnung
   def foo(h={}, key: 42); end; foo({"key" => 43}, key: 42) # OK
-  {% endhighlight %}
+  ```
 
 * Wenn eine Methode keine Schlüsselwortargumente akzeptiert, aber mit
   solchen aufgerufen wird, werden solche Schlüsselwortargumente
@@ -144,30 +144,30 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   interpretiert. Dieses Verhalten wird auch in Ruby 3 weiterhin
   beibehalten.
 
-  {% highlight ruby %}
+  ```ruby
   def foo(opt={});  end; foo( key: 42 )   # OK
-  {% endhighlight %}
+  ```
 
 * Schlüsselwortargumente mit anderen Schlüsseln als Symbolen sind
   zulässig, wenn die Methode beliebige Schlüsselwortargumente
   akzeptiert. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   def foo(**kw); p kw; end; foo("str" => 1) #=> {"str"=>1}
-  {% endhighlight %}
+  ```
 
 * <code>**nil</code> kann genutzt werden, um in einer
   Methodendefinition ausdrücklich festzulegen, dass die Methode keine
   Schlüsselwörter akzeptiert. Der Aufruf einer solchen Methode mit
   Schlüsselwortargumenten erzeugt einen ArgumentError. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   def foo(h, **nil); end; foo(key: 1)       # ArgumentError
   def foo(h, **nil); end; foo(**{key: 1})   # ArgumentError
   def foo(h, **nil); end; foo("str" => 1)   # ArgumentError
   def foo(h, **nil); end; foo({key: 1})     # OK
   def foo(h, **nil); end; foo({"str" => 1}) # OK
-  {% endhighlight %}
+  ```
 
 * Die Übergabe einess leeren doppelten Auflösungsoperators an eine
   Methode, die keine Schlüsselwortargumente akzeptiert, führt nicht
@@ -177,12 +177,12 @@ werden. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
   doppelten Auflösungsoperator, um ein Hash als Positionsargument zu
   übergeben. [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183)
 
-  {% highlight ruby %}
+  ```ruby
   h = {}; def foo(*a) a end; foo(**h) # []
   h = {}; def foo(a) a end; foo(**h)  # {} und Warnung
   h = {}; def foo(*a) a end; foo(h)   # [{}]
   h = {}; def foo(a) a end; foo(h)    # {}
-  {% endhighlight %}
+  ```
 
 HINWEIS: Es ist darauf hingewiesen worden, dass die vielen Warnungen über
 die Inkompatibilität von Schlüsselwortargumenten störend sind. Derzeit
@@ -207,40 +207,40 @@ jedoch bis zur offiziellen Veröffentlichung nachgeholt.
   domänenspezifische Sprachen praktisch sein.
   [#14799](https://bugs.ruby-lang.org/issues/14799)
 
-  {% highlight ruby %}
+  ```ruby
   ary[..3]  # identical to ary[0..3]
   rel.where(sales: ..100)
-  {% endhighlight %}
+  ```
 
 * `Enumerable#tally` wird hinzugefügt. Die Methode zählt das Vorkommen
   jedes Elements.
 
-  {% highlight ruby %}
+  ```ruby
   ["a", "b", "c", "b"].tally
   #=> {"a"=>1, "b"=>2, "c"=>1}
-  {% endhighlight %}
+  ```
 
 * Es ist jetzt zulässig, eine private Methode auf `self` aufzurufen.
   [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297)
   [[Feature #16123]](https://bugs.ruby-lang.org/issues/16123)
 
-  {% highlight ruby %}
+  ```ruby
   def foo
   end
   private :foo
   self.foo
-  {% endhighlight %}
+  ```
 
 * `Enumerator::Lazy#eager` wird hinzugefügt. Diese Methode generiert
   einen nicht verzögertern Enumerator (_non-lazy enumerator_) aus
   einem verzögerten Enumerator (_lazy enumerator_). [[Feature #15901]](https://bugs.ruby-lang.org/issues/15901)
 
-  {% highlight ruby %}
+  ```ruby
   a = %w(foo bar baz)
   e = a.lazy.map {|x| x.upcase }.map {|x| x + "!" }.eager
   p e.class               #=> Enumerator
   p e.map {|x| x + "?" }  #=> ["FOO!?", "BAR!?", "BAZ!?"]
-  {% endhighlight %}
+  ```
 
 ## Performanzverbesserungen
 

--- a/de/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/de/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -50,7 +50,7 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-{% highlight ruby %}
+```ruby
 require "json"
 
 json = <<END
@@ -65,7 +65,7 @@ case JSON.parse(json, symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age #=> 2
 end
-{% endhighlight %}
+```
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.

--- a/de/news/_posts/2019-12-21-ruby-2-7-0-rc2-released.md
+++ b/de/news/_posts/2019-12-21-ruby-2-7-0-rc2-released.md
@@ -33,7 +33,7 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-{% highlight ruby %}
+```ruby
 require "json"
 
 json = <<END
@@ -48,7 +48,7 @@ case JSON.parse(json, symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age #=> 2
 end
-{% endhighlight %}
+```
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.

--- a/de/news/_posts/2019-12-25-ruby-2-7-0-released.md
+++ b/de/news/_posts/2019-12-25-ruby-2-7-0-released.md
@@ -27,7 +27,7 @@ Programmiersprache Ruby eingeführt. [#14912](https://bugs.ruby-lang.org/issues/
 Ein Musterabgleich untersucht das übergebene Objekt und weist seinen
 Wert dann zu, wenn er auf ein bestimmtes Muster passt.
 
-{% highlight ruby %}
+```ruby
 require "json"
 
 json = <<END
@@ -42,7 +42,7 @@ case JSON.parse(json, symbolize_names: true)
 in {name: "Alice", children: [{name: "Bob", age: age}]}
   p age #=> 2
 end
-{% endhighlight %}
+```
 
 Weitere Details können Sie der Präsentation [Musterabgleiche - Neue Funktion in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7)
 entnehmen.

--- a/es/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
+++ b/es/news/_posts/2019-10-22-ruby-2-7-0-preview2-released.md
@@ -186,13 +186,17 @@ argumentos posicionales, y tal conversión se eliminará en Ruby 3.
   específicos para un domino (DSL).
   [[Característica #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-      ary[..3]  # identico a ary[0..3]
-      rel.where(ventas: ..100)
+  ```ruby
+  ary[..3]  # identico a ary[0..3]
+  rel.where(ventas: ..100)
+  ```
 
 * Se añade `Enumerable#tally`.  Que cuenta las ocurrencias de cada elemento.
 
-      ["a", "b", "c", "b"].tally
-      #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```ruby
+  ["a", "b", "c", "b"].tally
+  #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```
 
 * Ahora se permite llamar un método privado con`self`.
   [[Característica #11297]](https://bugs.ruby-lang.org/issues/11297),

--- a/es/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
+++ b/es/news/_posts/2019-11-23-ruby-2-7-0-preview3-released.md
@@ -207,13 +207,17 @@ la versión oficial.
   específicos para un domino (DSL).
   [[Característica #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-      ary[..3]  # identico a ary[0..3]
-      rel.where(ventas: ..100)
+  ```ruby
+  ary[..3]  # identico a ary[0..3]
+  rel.where(ventas: ..100)
+  ```
 
 * Se añade `Enumerable#tally`.  Que cuenta las ocurrencias de cada elemento.
 
-      ["a", "b", "c", "b"].tally
-      #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```ruby
+  ["a", "b", "c", "b"].tally
+  #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```
 
 * Ahora se permite llamar un método privado con`self`.
   [[Característica #11297]](https://bugs.ruby-lang.org/issues/11297),

--- a/es/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
+++ b/es/news/_posts/2019-12-17-ruby-2-7-0-rc1-released.md
@@ -208,13 +208,17 @@ la versión oficial.
   específicos para un domino (DSL).
   [[Característica #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-      ary[..3]  # identico a ary[0..3]
-      rel.where(ventas: ..100)
+  ```ruby
+  ary[..3]  # identico a ary[0..3]
+  rel.where(ventas: ..100)
+  ```
 
 * Se añade `Enumerable#tally`.  Que cuenta las ocurrencias de cada elemento.
 
-      ["a", "b", "c", "b"].tally
-      #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```ruby
+  ["a", "b", "c", "b"].tally
+  #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```
 
 * Ahora se permite llamar un método privado con`self`.
   [[Característica #11297]](https://bugs.ruby-lang.org/issues/11297),

--- a/es/news/_posts/2019-12-21-ruby-2-7-0-rc2-released.md
+++ b/es/news/_posts/2019-12-21-ruby-2-7-0-rc2-released.md
@@ -208,13 +208,17 @@ la versión oficial.
   específicos para un domino (DSL).
   [[Característica #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-      ary[..3]  # identico a ary[0..3]
-      rel.where(ventas: ..100)
+  ```ruby
+  ary[..3]  # identico a ary[0..3]
+  rel.where(ventas: ..100)
+  ```
 
 * Se añade `Enumerable#tally`.  Que cuenta las ocurrencias de cada elemento.
 
-      ["a", "b", "c", "b"].tally
-      #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```ruby
+  ["a", "b", "c", "b"].tally
+  #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```
 
 * Ahora se permite llamar un método privado con un literal `self` como
   receptor.

--- a/es/news/_posts/2019-12-25-ruby-2-7-0-released.md
+++ b/es/news/_posts/2019-12-25-ruby-2-7-0-released.md
@@ -191,13 +191,17 @@ un argumento en la línea de ordenes `-W:no-deprecated`  o añada
   específicos para un domino (DSL).
   [[Característica #14799]](https://bugs.ruby-lang.org/issues/14799)
 
-      ary[..3]  # identico a ary[0..3]
-      rel.where(ventas: ..100)
+  ```ruby
+  ary[..3]  # identico a ary[0..3]
+  rel.where(ventas: ..100)
+  ```
 
 * Se añade `Enumerable#tally`.  Que cuenta las ocurrencias de cada elemento.
 
-      ["a", "b", "c", "b"].tally
-      #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```ruby
+  ["a", "b", "c", "b"].tally
+  #=> {"a"=>1, "b"=>2, "c"=>1}
+  ```
 
 * Ahora se permite llamar un método privado con un literal `self` como
   receptor.


### PR DESCRIPTION
Refer to commit [6494161](https://github.com/ruby/www.ruby-lang.org/commit/6494161bd6304e357b49bdf220ee01fddc2777b1).