### PR TITLE
Update link to TryRuby

### DIFF
--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Започнете</strong> лесно е!
     try_ruby:
       text: Пробвайте Ruby! (в браузъра)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby в 20 минути
       url: /bg/documentation/quickstart/

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -30,7 +30,7 @@ sidebar:
     text: <strong>Der Einstieg</strong> ist einfach!
     try_ruby:
       text: Teste Ruby! (im Browser)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby in 20 Minuten
       url: /de/documentation/quickstart/

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -30,7 +30,7 @@ sidebar:
     text: <strong>Get Started</strong>, it's easy!
     try_ruby:
       text: Try Ruby! (in your browser)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby in Twenty Minutes
       url: /en/documentation/quickstart/

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Iníciate</strong>, ¡es fácil!
     try_ruby:
       text: ¡Prueba Ruby! (en tu navegador)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby en 20 Minutos
       url: /es/documentation/quickstart/

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -30,7 +30,7 @@ sidebar:
     text: <strong>Lancez-vous</strong>, c’est facile !
     try_ruby:
       text: Essayez Ruby !
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Apprenez Ruby en vingt minutes
       url: /fr/documentation/quickstart/

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Coba Sekarang</strong>, sangat mudah!
     try_ruby:
       text: Try Ruby! (langsung di browser Anda)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Menguasai Ruby dalam 20 Menit
       url: /id/documentation/quickstart/

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Per iniziare</strong>, è facile!
     try_ruby:
       text: Prova Ruby! (nel tuo browser)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby in venti minuti
       url: /it/documentation/quickstart/

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -32,7 +32,7 @@ sidebar:
     text: <strong>はじめよう!</strong>
     try_ruby:
       text: 試してみる! (ブラウザから)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: 20分ではじめるRuby
       url: /ja/documentation/quickstart/

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>시작하기</strong>
     try_ruby:
       text: Try Ruby!
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: 20분 가이드
       url: /ko/documentation/quickstart/

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Zacznij</strong>, to proste!
     try_ruby:
       text: Wypróbuj Ruby! (w twojej przeglądarce)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby w 20 Minut
       url: /pl/documentation/quickstart/

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Primeiros passos</strong>, é fácil!
     try_ruby:
       text: Try Ruby! (in your browser)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby em Vinte Minutos
       url: /pt/documentation/quickstart/

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Начните сейчас</strong>, это легко!
     try_ruby:
       text: Попробуйте Ruby! (в своем браузере)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby за двадцать минут
       url: /ru/documentation/quickstart/

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -30,7 +30,7 @@ sidebar:
     text: <strong>Başlamak</strong>, çok kolay!
     try_ruby:
       text: Ruby'yi Deneyin! (tarayıcınızda)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Yirmi Dakikada Ruby
       url: /tr/documentation/quickstart/

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>Nhập môn</strong>, quá dễ!
     try_ruby:
       text: Thử Ruby! (trong trình duyệt)
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: Ruby trong 20 phút
       url: /vi/documentation/quickstart/

--- a/_data/locales/zh_cn.yml
+++ b/_data/locales/zh_cn.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>试用</strong>，其实很简单！
     try_ruby:
       text: 在浏览器中试用 Ruby（英文）
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: 20 分钟体验 Ruby
       url: /zh_cn/documentation/quickstart/

--- a/_data/locales/zh_tw.yml
+++ b/_data/locales/zh_tw.yml
@@ -29,7 +29,7 @@ sidebar:
     text: <strong>上手入門</strong>，一點都不難!
     try_ruby:
       text: 在瀏覽器中試用 Ruby!
-      url: https://ruby.github.io/TryRuby/
+      url: https://try.ruby-lang.org/
     quickstart:
       text: 20 分鐘 Ruby 體驗
       url: /zh_tw/documentation/quickstart/

--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -129,7 +129,7 @@ ruby -v
 Ако имате въпроси относно Ruby, [пощенският списък](/bg/community/mailing-lists/)
 е чудесно място да ги зададете.
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -73,7 +73,7 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [3]: https://poignant.guide
 [4]: http://www.moccasoft.de/papers/ruby_tutorial
 [5]: http://pine.fm/LearnToProgram/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -129,7 +129,7 @@ If you have questions about Ruby the
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -64,7 +64,7 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://pine.fm/LearnToProgram/
 [3]: http://www.ruby-doc.org/docs/ProgrammingRuby/
 [4]: http://pragmaticprogrammer.com/titles/ruby/index.html

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -129,7 +129,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 
 
 [2]: http://jeveuxapprendreruby.fr/
-[3]: https://ruby.github.io/TryRuby/
+[3]: https://try.ruby-lang.org/
 [4]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://pine.fm/LearnToProgram/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -128,7 +128,7 @@ adalah tempat yang baik untuk memulai.
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -128,7 +128,7 @@ iniziare.
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -129,7 +129,7 @@ lang: ko
 영어가 되신다면 [메일링 리스트](/ko/community/mailing-lists/)를 사용하실 수도
 있습니다.
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -132,7 +132,7 @@ angielskim).
 
 Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -140,7 +140,7 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: http://why.carlosbrando.com/
 [6]: http://rubylearning.com/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -138,7 +138,7 @@ ruby -v
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -142,7 +142,7 @@ olacaktır.
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -139,7 +139,7 @@ là một nơi tuyệt vời.
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -110,7 +110,7 @@ ruby -v
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -105,7 +105,7 @@ lang: zh_tw
 
 
 
-[1]: https://ruby.github.io/TryRuby/
+[1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
 [6]: http://rubylearning.com/


### PR DESCRIPTION
The link was changed in the [repository](https://github.com/ruby/TryRuby). I suggest to update it.