### PR TITLE
Fix typos

### DIFF
--- a/en/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md
+++ b/en/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md
@@ -97,7 +97,7 @@ The `RubyVM::AbstractSyntaxTree::Node` class is also introduced. You can get loc
 
 * Passing `safe_level` to `ERB.new` is deprecated. `trim_mode` and `eoutvar` arguments are changed to keyword arguments. [[Feature #14256]](https://bugs.ruby-lang.org/issues/14256)
 
-* Supported Unicode version is updated to 11. It is planed to update to 12 and 12.1 in future TEENY releases of Ruby 2.6.
+* Supported Unicode version is updated to 11. It is planned to update to 12 and 12.1 in future TEENY releases of Ruby 2.6.
 
 * Merge RubyGems 3.0.0.beta3. `--ri` and `--rdoc` options were removed. Please use `--document` and `--no-document` options instead.
 

--- a/en/news/_posts/2018-12-25-ruby-2-6-0-released.md
+++ b/en/news/_posts/2018-12-25-ruby-2-6-0-released.md
@@ -79,7 +79,7 @@ The `RubyVM::AbstractSyntaxTree::Node` class is also introduced. You can get sou
 * Speed up `Proc#call` by removing the temporary allocation for `$SAFE`.
   [[Feature #14318]](https://bugs.ruby-lang.org/issues/14318)
 
-  We have observed a 1.4x peformance improvement in the `lc_fizzbuzz` benchmark that calls `Proc#call` numerous times. [[Bug #10212]](https://bugs.ruby-lang.org/issues/10212)
+  We have observed a 1.4x performance improvement in the `lc_fizzbuzz` benchmark that calls `Proc#call` numerous times. [[Bug #10212]](https://bugs.ruby-lang.org/issues/10212)
 
 * Speed up `block.call` when `block` is passed in as a block parameter. [[Feature #14330]](https://bugs.ruby-lang.org/issues/14330)
 


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `en/news/_posts/2018-12-15-ruby-2-6-0-rc2-released.md`
- 1 typo in `en/news/_posts/2018-12-25-ruby-2-6-0-released.md`



Cheers! :robot: