### PR TITLE
Translate CVE-2020-10933: Heap exposure vulnerability in the socket library (id)

### DIFF
--- a/id/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md
+++ b/id/news/_posts/2020-03-31-heap-exposure-in-socket-cve-2020-10933.md
@@ -1,0 +1,40 @@
+---
+layout: news_post
+title: "CVE-2020-10933: Kerentanan tereksposnya heap pada pustaka socket"
+author: "mame"
+translator: "meisyal"
+date: 2020-03-31 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Sebuah kerentanan tereksposnya *heap* telah ditemukan pada pustaka *socket*.
+Kerentanan ini telah ditetapkan dengan penanda CVE [CVE-2020-10933](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10933).
+Kami sangat menyarankan untuk memperbarui Ruby.
+
+## Detail
+
+Ketika `BasicSocket#recv_nonblock` dan `BasicSocket#read_nonblock` dipanggil
+dengan argumen *size* dan *buffer*, kedua fungsi tersebut semula mengubah
+ukuran *buffer* ke ukuran tertentu. Pada beberapa kasus di mana operasi ini
+mengeblok, operasi mengembalikan nilai tanpa menyalin data apapun. Sehingga,
+*buffer string* sekarang akan berisi data apapun dari *heap*. Hal ini akan
+mengekspos data sensitif yang ada di dalam *interpreter*.
+
+Masalah ini hanya terjadi di Linux. Isu terjadi sejak Ruby 2.5; rangkaian
+Ruby 2.4 tidak rentan.
+
+## Versi terimbas
+
+* Rangkaian Ruby 2.5: 2.5.7 dan sebelumnya
+* Rangkaian Ruby 2.6: 2.6.5 dan sebelumnya
+* Rangkaian Ruby 2.7: 2.7.0
+* sebelum revisi *master* 61b7f86248bd121be2e83768be71ef289e8e5b90
+
+## Rujukan
+
+Terima kasih kepada Samuel Williams yang telah menemukan masalah ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2020-03-31 12:00:00 (UTC)


### PR DESCRIPTION
cc: @kuntoaji 