### PR TITLE
Fix double rendering of news archives

### DIFF
--- a/_plugins/news.rb
+++ b/_plugins/news.rb
@@ -151,8 +151,6 @@ module Jekyll
           years.values.map(&:values).flatten
         )
 
-        index.render(site.layouts, site.site_payload)
-        index.write(site.dest)
         site.pages << index
 
         years.each do |year, months|
@@ -164,8 +162,6 @@ module Jekyll
             months.values.flatten
           )
 
-          yearly_archive.render(site.layouts, site.site_payload)
-          yearly_archive.write(site.dest)
           site.pages << yearly_archive
 
           months.each do |month, posts_for_month|
@@ -178,8 +174,6 @@ module Jekyll
               posts_for_month
             )
 
-            monthly_archive.render(site.layouts, site.site_payload)
-            monthly_archive.write(site.dest)
             site.pages << monthly_archive
           end
         end


### PR DESCRIPTION
Since the generated archives are pushed into the `site.pages` array, they will be eventually *rendered* and *written* to destination like regular pages even if the generator has `priority: low`. So manually having those objects call `:render` and `:write` is redundant and contributes to increased build times.

P.S. While I did check if this change caused any difference in the files ultimately written to `./_site`, do let me know if I missed a negative side-effect from this change.

/cc @stomar 