### PR TITLE
Translate http-request-smuggling-cve-2020-25613 (ko)

### DIFF
--- a/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
+++ b/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
@@ -1,6 +1,6 @@
 ---
 layout: news_post
-title: "CVE-2020-25613: WEBrick의 잠재적인 HTTP 요청 밀수 취약점"
+title: "CVE-2020-25613: WEBrick의 잠재적인 HTTP 요청 스머글링 취약점"
 author: "mame"
 translator: "shia"
 date: 2020-09-29 06:30:00 +0000
@@ -8,7 +8,7 @@ tags: security
 lang: ko
 ---
 
-WEBrick에서 잠재적인 HTTP 요청 밀수 취약점이 보고되었습니다.
+WEBrick에서 잠재적인 HTTP 요청 스머글링 취약점이 보고되었습니다.
 이 취약점에 [CVE-2020-25613](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613)이 할당되었습니다.
 webrick 젬을 업그레이드하는 것을 강력히 권장합니다.
 

--- a/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
+++ b/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
@@ -1,32 +1,36 @@
 ---
 layout: news_post
-title: "CVE-2020-25613: Potential HTTP Request Smuggling Vulnerability in WEBrick"
+title: "CVE-2020-25613: WEBrick의 잠재적인 HTTP 요청 밀수 취약점"
 author: "mame"
-translator:
+translator: "shia"
 date: 2020-09-29 06:30:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-A potential HTTP request smuggling vulnerability in WEBrick was reported. This vulnerability has been assigned the CVE idenfitifer [CVE-2020-25613](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613). We strongly recommend upgrading the webrick gem.
+WEBrick에서 잠재적인 HTTP 요청 밀수 취약점이 보고되었습니다.
+이 취약점에 [CVE-2020-25613](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613)이 할당되었습니다.
+webrick 젬을 업그레이드하는 것을 강력히 권장합니다.
 
-## Details
+## 세부 내용
 
-WEBrick was too tolerant against an invalid Transfer-Encoding header. This may lead to inconsistent interpretation between WEBrick and some HTTP proxy servers, which may allow the attacker to "smuggle" a request. See [CWE-444](https://cwe.mitre.org/data/definitions/444.html) in detail.
+WEBrick은 유효하지 않은 Transfer-Encoding 헤더에 너무 관대했습니다.
+이는 WEBrick과 몇몇 HTTP 프록시 서버들 사이에서 해석 불일치를 유발해 공격자가 어떤 요청을 몰래 끼워넣을 수 있도록 합니다.
+자세한 설명은 [CWE-444](https://cwe.mitre.org/data/definitions/444.html)를 참고하세요.
 
-Please update the webrick gem to version 1.6.1 or later.  You can use `gem update webrick` to update it.  If you are using bundler, please add `gem "webrick", ">= 1.6.1"` to your `Gemfile`.
+webrick 젬을 1.6.1 이상으로 업그레이드하기 바랍니다. 업그레이드하려면 `gem update webrick` 명령을 사용하세요. 만약 번들러를 사용하고 있다면 `Gemfile`에 `gem "webrick", ">= 1.6.1"`을 추가하세요.
 
-## Affected versions
+## 해당 버전
 
-* webrick gem 1.6.0 or prior
-* bundled versions of webrick in ruby 2.7.1 or prior
-* bundled versions of webrick in ruby 2.6.6 or prior
-* bundled versions of webrick in ruby 2.5.8 or prior
+* webrick 젬 1.6.0 이하
+* 루비 2.7 버전대: 2.7.1 이하의 루비에 포함된 webrick
+* 루비 2.6 버전대: 2.6.6 이하의 루비에 포함된 webrick
+* 루비 2.5 버전대: 2.5.8 이하의 루비에 포함된 webrick
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [piao](https://hackerone.com/piao) for discovering this issue.
+이 문제를 발견해 준 [piao](https://hackerone.com/piao)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2020-09-29 06:30:00 (UTC)
+* 2020-09-29 06:30:00 (UTC) 최초 공개

--- a/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
+++ b/ko/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
@@ -1,0 +1,32 @@
+---
+layout: news_post
+title: "CVE-2020-25613: Potential HTTP Request Smuggling Vulnerability in WEBrick"
+author: "mame"
+translator:
+date: 2020-09-29 06:30:00 +0000
+tags: security
+lang: en
+---
+
+A potential HTTP request smuggling vulnerability in WEBrick was reported. This vulnerability has been assigned the CVE idenfitifer [CVE-2020-25613](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613). We strongly recommend upgrading the webrick gem.
+
+## Details
+
+WEBrick was too tolerant against an invalid Transfer-Encoding header. This may lead to inconsistent interpretation between WEBrick and some HTTP proxy servers, which may allow the attacker to "smuggle" a request. See [CWE-444](https://cwe.mitre.org/data/definitions/444.html) in detail.
+
+Please update the webrick gem to version 1.6.1 or later.  You can use `gem update webrick` to update it.  If you are using bundler, please add `gem "webrick", ">= 1.6.1"` to your `Gemfile`.
+
+## Affected versions
+
+* webrick gem 1.6.0 or prior
+* bundled versions of webrick in ruby 2.7.1 or prior
+* bundled versions of webrick in ruby 2.6.6 or prior
+* bundled versions of webrick in ruby 2.5.8 or prior
+
+## Credits
+
+Thanks to [piao](https://hackerone.com/piao) for discovering this issue.
+
+## History
+
+* Originally published at 2020-09-29 06:30:00 (UTC)


### PR DESCRIPTION
Origin post https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
actual diff 642851dd1a694d4e2a472374c7b7b4eacf7893b9