### PR TITLE
Fix annotations of GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ruby -v
       # override the Ruby version specified in the Gemfile
       - name: Set CUSTOM_RUBY_VERSION for Gemfile
-        run: echo ::set-env name=CUSTOM_RUBY_VERSION::$(ruby -e 'puts RUBY_VERSION')
+        run: echo "CUSTOM_RUBY_VERSION=$(ruby -e 'puts RUBY_VERSION')" >> $GITHUB_ENV
       - name: Dump CUSTOM_RUBY_VERSION
         run: echo $CUSTOM_RUBY_VERSION
       - name: Cache gem bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          architecture: x64
       - name: Dump Ruby version
         run: ruby -v
       # override the Ruby version specified in the Gemfile


### PR DESCRIPTION
This is the latest CI result of master branch: https://github.com/ruby/www.ruby-lang.org/actions/runs/302414072

There are two kinds of annotations:
- The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  - Fixed by 580c61c.
- Unexpected input(s) 'architecture', valid inputs are ['ruby-version', 'bundler', 'bundler-cache', 'working-directory']
  - Fixed by aec5ba2.

This is the CI result of improve-actions branch in my repo: https://github.com/yous/www.ruby-lang.org/actions/runs/303978240