### PR TITLE
Tk is not bundled anymore

### DIFF
--- a/en/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
+++ b/en/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
@@ -26,7 +26,7 @@ Unlike Java, in Ruby,...
 * You don’t need to compile your code. You just run it directly.
 * There are several different popular third-party GUI toolkits. Ruby
   users can try [WxRuby][1], [FXRuby][2], [Ruby-GNOME2][3],
-  [Qt][4], or the bundled-in Ruby Tk for example.
+  [Qt][4], or [Ruby Tk](https://github.com/ruby/tk) for example.
 * You use the `end` keyword after defining things like classes, instead
   of having to put braces around blocks of code.
 * You have `require` instead of `import`.

--- a/tr/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
+++ b/tr/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
@@ -26,7 +26,7 @@ Ruby’de Java’dan farklı olarak,...
 
 * Kodunuzu derlemeye gerek yoktur, direk olarak çalıştırırsınız.
 * Ruby kullanıcıları değişik GUI araçları kullanabilir [WxRuby][1],
-  [FXRuby][2], [Ruby-GNOME2][3], [Qt][4], ya da Ruby içinde yüklü gelen Tk
+  [FXRuby][2], [Ruby-GNOME2][3], [Qt][4], ya da [Ruby Tk](https://github.com/ruby/tk)
   bunların bazıları.
 * Sınıflar, metodlar gibi birşeyleri tanımlarken kod bloğunu süslü
   parantez içine almak yerine sonunda `end` deyimi kullanırsınız


### PR DESCRIPTION
As I know, Tk is not bundled to Ruby anymore but "To Ruby From Java" document states the opposite. This PR fixes this. I have fixed tr translation also.