### PR TITLE
Fix mixed content error on Fukuoka Ruby Award

### DIFF
--- a/de/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/de/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -18,7 +18,7 @@ Fukuoka Ruby Award 2017 — Großer Preis — 1 Million Yen!
 
 Einsendeschluss: 27. Dezember 2016
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz und eine Gruppe Juroren werden die Preisträger gemeinsam
 auswählen; der Große Preis ist mit einer Million Yen (ca. 8.700 €)

--- a/de/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/de/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -18,7 +18,7 @@ Fukuoka Ruby Award 2018 — Großer Preis — 1 Million Yen!
 
 Einsendeschluss: 31. Januar 2018
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz und eine Gruppe Juroren werden die Preisträger gemeinsam
 auswählen; der Große Preis ist mit einer Million Yen (ca. 7.300 €)

--- a/de/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/de/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -18,7 +18,7 @@ Fukuoka Ruby Award 2019 — Großer Preis — 1 Million Yen!
 
 Einsendeschluss: 31. Januar 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz und eine Gruppe Juroren werden die Preisträger gemeinsam
 auswählen; der Große Preis ist mit einer Million Yen (ca. 7.800 €)

--- a/de/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/de/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -18,7 +18,7 @@ Fukuoka Ruby Award 2020 — Großer Preis — 1 Million Yen!
 
 Einsendeschluss: 11. Dezember 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz und eine Gruppe Juroren werden die Preisträger gemeinsam
 auswählen; der Große Preis ist mit einer Million Yen (ca. 8.200 €)

--- a/de/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/de/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -18,7 +18,7 @@ Fukuoka Ruby Award 2021 — Großer Preis — 1 Million Yen!
 
 Einsendeschluss: 4. Dezember 2020
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz und eine Gruppe Juroren werden die Preisträger gemeinsam
 auswählen; der Große Preis ist mit einer Million Yen (ca. 8.100 €)

--- a/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/en/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -17,7 +17,7 @@ interesting Ruby program, please be encouraged to apply.
 
 Entry Deadline: December 27, 2016
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz and a group of panelists will select the winners of the Fukuoka Competition.
 The grand prize for the Fukuoka Competition is 1 million yen.

--- a/en/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/en/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -17,7 +17,7 @@ an interesting Ruby program, please be encouraged to apply.
 
 Entry Deadline: January 31, 2018
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz and a group of panelists will select the winners of the
 Fukuoka Competition. The grand prize for the Fukuoka Competition

--- a/en/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/en/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -15,7 +15,7 @@ The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to in
 
 Entry Deadline: January 31, 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
 

--- a/en/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/en/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -15,7 +15,7 @@ The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to in
 
 Entry Deadline: December 11, 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
 

--- a/en/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/en/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -15,7 +15,7 @@ The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to in
 
 Entry Deadline: December 4, 2020
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
 

--- a/es/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/es/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -17,7 +17,7 @@ programa interesante en Ruby, anímate a aplicar.
 
 Fecha límite: Diciembre 27, 2016
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz y un grupo de panelistas eligirán a los ganadores de la Fukuoka Competition.
 El gran premio para Fukuoka Competition es de un millón de yens.

--- a/es/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/es/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -17,7 +17,7 @@ Fukuoka Ruby Award 2019 - Premio Mayor - 1 Millon de Yenes!
 
 Fecha límite para participar: Enero 31, 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz y un grupo de panelistas elegirán los ganadores de la Competencia Fukuoka.  El premio mayor de la Competencia Fukuoka es 1 millon de yenes.  Los ganadores del premio mayor anteriores incluyen a Rhomobile (USA) y al Centro Climático APEC (Korea).
 

--- a/es/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/es/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -17,7 +17,7 @@ Premios para la Competencia Fukuoka 2020 - Premio Mayor - 1 Millon Yenes!
 
 Fecha límite: 11 de diciembre de 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz y un grupo de panelistas seleccionarán los ganadores de la Competencia
 Fukuoka.  El premio mayor de la Compentencia Fukuoka es de 1 millón de yenes.

--- a/es/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/es/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -17,7 +17,7 @@ Concurso Galardon Ruby Fukuoka 2020 - Premio Mayor - 1 Millon Yenes!
 
 Fecha límite: 4 de diciembre de 2020
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 
 Matz y un grupo de panelistas seleccionarán los ganadores del Concurso

--- a/id/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/id/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -18,7 +18,7 @@ kompetisi ini.
 
 Batas akhir masuk: 27 Desember 2016
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz dan sebuah grup dari panelis akan memilih pemenang kompetisi ini.
 Hadiah utama kompetisi ini adalah 1 juta yen.

--- a/id/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/id/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -18,7 +18,7 @@ kompetisi ini.
 
 Batas akhir masuk: 31 Januari 2018
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz dan sebuah grup dari panelis akan memilih pemenang kompetisi ini.
 Hadiah utama dari kompetisi ini adalah 1 juta Yen. Hadiah pemenang sebelumnya

--- a/id/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/id/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -17,7 +17,7 @@ sebuah program Ruby yang menarik, dianjurkan untuk mengikuti kompetisi ini.
 
 Batas akhir pendaftaran: 31 Januari 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz dan sebuah grup panelis akan memilih pemenang kompetisi ini. Hadiah utama
 dari kompetisi ini adalah 1 juta Yen. Hadiah pemenang sebelumnya termasuk

--- a/id/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/id/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -17,7 +17,7 @@ sebuah program Ruby yang menarik, dianjurkan untuk mengikuti kompetisi ini.
 
 Batas akhir pendaftaran: 11 Desember 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz dan sebuah grup panelis akan memilih pemenang kompetisi ini. Hadiah utama
 dari kompetisi ini adalah 1 juta Yen. Hadiah pemenang sebelumnya termasuk

--- a/ko/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/ko/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -15,7 +15,7 @@ lang: ko
 
 접수 마감: 2016년 12월 27일
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다.
 후쿠오카 경진대회의 대상에게는 백만 엔의 상금이 주어집니다.

--- a/ko/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/ko/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -15,7 +15,7 @@ lang: ko
 
 접수 마감: 2018년 1월 31일
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다.
 후쿠오카 경진대회의 대상에게는 백만 엔의 상금이 주어집니다.

--- a/ko/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/ko/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -15,7 +15,7 @@ lang: ko
 
 접수 마감: 2019년 1월 31일
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다. 후쿠오카 경진대회의 대상에게는 백만 엔의 상금이 주어집니다. 이전 이 대회의 우승자로는 Rhomobile(미국)과 APEC 기후 센터(한국)가 있습니다.
 

--- a/ko/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/ko/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -16,7 +16,7 @@ lang: ko
 
 접수 마감: 2019년 12월 11일
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다.
 후쿠오카 경진대회의 대상에게는 백만 엔의 상금이 주어집니다.

--- a/ko/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/ko/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -16,7 +16,7 @@ lang: ko
 
 접수 마감: 2020년 12월 4일
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다.
 후쿠오카 경진대회의 대상에게는 백만 엔의 상금이 주어집니다.

--- a/pt/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/pt/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -17,7 +17,7 @@ programa Ruby interessante, por favor sinta-se encorajado a participar.
 
 Prazo de inscrição: 27 de dezembro de 2016
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz e um grupo de palestrantes selecionarão os vencedores da _Fukuoka Competition_.
 O grande prêmio para a Fukuoka Competition é um milhão de ienes.

--- a/pt/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/pt/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -17,7 +17,7 @@ Fukuoka Ruby Award 2018 - Grande Prêmio - 1 milhão de ienes!
 
 Prazo de Inscrição: 31 de janeiro de 2018
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz e um grupo de painelista selecionarão os vencededores da
 Fukuoka Competition. O grande prêmio da Fukuoka Competition

--- a/pt/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/pt/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -15,7 +15,7 @@ Competição Fukuoka Ruby Award 2019 - Grande Prêmio - 1 Milhão de Ienes!
 
 Data máxima para aplicação: 31 de Janeiro de 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz e um grupo de jurados selecionarão os vencedores da competição de Fukuoka. O grande prêmio para essa competição é 1 milhão de ienes. Fora o grande prêmio, outras premiações incluem Rhomobile (EUA) and APEC Climate Center (Coréia).
 

--- a/pt/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/pt/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -15,7 +15,7 @@ O governo de Fukuoka, Japão, juntamente com "Matz" Matsumoto gostariam de lhe c
 
 Prazo para inscrição: 11 de dezembro de 2019
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz e um grupo de painelistas selecionarão os(as) vencedores(as) da Fukuoka Competition. O grande prêmio da Fukuoka Competition será 1 milhão de ienes. Ganhedores anteriores incluem Rhomobile (USA) e APEC Climate Center (Korea).
 

--- a/ru/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/ru/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -15,7 +15,7 @@ lang: ru
 
 Крайний Срок Подачи Заявок: 11 Декабря 2019 Года
 
-![Фукуока Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Фукуока Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz и группа участников дискуссии выберут победителей конкурса Фукуоки. Главный приз конкурса от Фукуоки - 1 миллион иен. Прошлые обладатели призов: Rhomobile (США) и Климатический Центр APEC (Корея).
 

--- a/ru/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/ru/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -15,7 +15,7 @@ lang: ru
 
 Последний день подачи заявки на участие: 4 декабря 2020 года.
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz и группа участников дискуссии выберут победителей соревнования Фукуоки. Главный приз в соревновании Фукуоки - 1 миллион иен. Среди предыдущих обладателей главного приза Rhomobile (США) и APEC Climate Center (Корея).
 

--- a/tr/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/tr/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -16,7 +16,7 @@ Eğer ilginç bir Ruby programı geliştirdiyseniz, lütfen başvurun.
 
 Son Başvuru Tarihi: 11 Aralık 2019
 
-![Fukuoka Ruby Ödülü](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Ödülü](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz ve bir grup oturum katılımcısı Fukuoka Yarışmasının kazananlarını belirleyecek.
 Fukuoka Yarışması için büyük ödül 1 milyon yen'dir.

--- a/tr/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
+++ b/tr/news/_posts/2020-07-16-fukuoka-ruby-award-2021.md
@@ -16,7 +16,7 @@ Eğer ilginç bir Ruby programı geliştirdiyseniz, lütfen başvurun.
 
 Son Başvuru Tarihi: 4 Aralık 2020
 
-![Fukuoka Ruby Ödülü](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Ödülü](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz ve bir grup oturum katılımcısı Fukuoka Yarışmasının kazananlarını belirleyecek.
 Fukuoka Yarışması için büyük ödül 1 milyon yen'dir.

--- a/zh_cn/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/zh_cn/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -15,7 +15,7 @@ lang: zh_cn
 
 截止日期：2019 年 1 月 31 日
 
-![福冈 Ruby 竞赛](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![福冈 Ruby 竞赛](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 本次福冈竞赛由松本行弘与其他专家评选获胜者。本次福冈竞赛大奖是一百万日元。
 历届获奖者包括 Rhomobile（美国） 和 APEC Climate Center（韩国）

--- a/zh_cn/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/zh_cn/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -15,7 +15,7 @@ lang: zh_cn
 
 截止日期：2019 年 12 月 11 日
 
-![福冈 Ruby 竞赛](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![福冈 Ruby 竞赛](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 本次福冈竞赛由松本行弘与其他专家评选获胜者。本次福冈竞赛大奖是一百万日元。
 历届获奖者包括 Rhomobile（美国） 和 APEC Climate Center（韩国）

--- a/zh_tw/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/zh_tw/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -15,7 +15,7 @@ lang: zh_tw
 
 截止日期：2016 年 12 月 27 日。
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz 與評審委員小組會選出本次大賽的優勝者。福岡 Ruby 大賽的最大獎是壹百萬日圓。過去的優勝者有來自美國的 Rhomobile 公司以及韓國釜山的亞太經貿氣候中心。
 

--- a/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/zh_tw/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -15,7 +15,7 @@ lang: zh_tw
 
 截止日期：2018 年 1 月 31 日。
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz 與評審委員小組會選出本次大賽的優勝者。福岡 Ruby 大賽的最大獎是壹百萬日圓。過去的優勝者有來自美國的 Rhomobile 公司以及韓國釜山的亞太經貿氣候中心。
 

--- a/zh_tw/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/zh_tw/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -15,7 +15,7 @@ lang: zh_tw
 
 截止日期：2019 年 1 月 31 日。
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz 與評審委員小組會選出本次大賽的優勝者。福岡 Ruby 大賽的最大獎是壹百萬日圓。過去的優勝者有來自美國的 Rhomobile 公司以及韓國釜山的亞太經貿氣候中心。
 

--- a/zh_tw/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/zh_tw/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -15,7 +15,7 @@ lang: zh_tw
 
 截止日期：2019 年 12 月 11 日。
 
-![Fukuoka Ruby Award](http://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
 Matz 與評審委員小組會選出本次大賽的優勝者。福岡 Ruby 大賽的最大獎是壹百萬日圓。過去的優勝者有來自美國的 Rhomobile 公司以及韓國釜山的亞太經貿氣候中心。
 


### PR DESCRIPTION
The image linked is using http instead of https which is causing a mixed content error, which now results in a "Content not secure" near the padlock on modern browsers.

I noticed this in multiple places so fixed them all.