### PR TITLE
Remove broken europe.railsconf.org links

### DIFF
--- a/bg/community/conferences/index.md
+++ b/bg/community/conferences/index.md
@@ -53,7 +53,7 @@ Valley Ruby Conference.
 
 Ruby присъства на [O’Reilly Open Source Conference][10] (OSCON) от 2004
 г. Някои от конференциите, свързани с [Ruby on Rails][11], са: Ruby Central’s
-[RailsConf][12], [RailsConf Europe][13] (през 2006 г. с помощта на Ruby
+[RailsConf][12], RailsConf Europe (през 2006 г. с помощта на Ruby
 Central и [Skills Matter][14], и през 2007 г. с помощта на Ruby Central
 и O’Reilly), както и Canada on Rails и Scotland on Rails.
 

--- a/bg/community/conferences/index.md
+++ b/bg/community/conferences/index.md
@@ -70,5 +70,4 @@ Central и [Skills Matter][14], и през 2007 г. с помощта на Ruby
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com

--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -67,7 +67,7 @@ There has been a Ruby track at the [O’Reilly Open Source Conference][10]
 (OSCON) since 2004, and an increasing presence on the part of Ruby and
 Rubyists at other non-Ruby-specific gatherings. A number of conferences
 have also been devoted to [Ruby on Rails][11], including Ruby Central’s
-[RailsConf][12], [RailsConf Europe][13] (co-produced in 2006 by Ruby
+[RailsConf][12], RailsConf Europe (co-produced in 2006 by Ruby
 Central and [Skills Matter][14], and in 2007 by Ruby Central and
 O’Reilly), and Canada on Rails.
 

--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -83,7 +83,6 @@ O’Reilly), and Canada on Rails.
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [16]: http://steelcityruby.org/
 [19]: http://goruco.com/

--- a/fr/community/conferences/index.md
+++ b/fr/community/conferences/index.md
@@ -79,7 +79,6 @@ O’Reilly) et enfin *Canada on Rails*.
 [8]: http://conferences.oreillynet.com/os2006/
 [9]: http://www.rubyonrails.org
 [10]: http://www.railsconf.org
-[11]: http://europe.railsconf.org
 [12]: http://www.skillsmatter.com
 [13]: http://rulu.eu
 [14]: http://la-conf.org

--- a/fr/community/conferences/index.md
+++ b/fr/community/conferences/index.md
@@ -64,7 +64,7 @@ Conference*][8] (OSCON) depuis 2004. Par ailleurs, les rubyistes
 maintiennent une très forte présence dans divers regroupements non
 directement liés à Ruby. De très nombreuses conférences ont été
 consacrées à [Ruby on Rails][9], à commencer par la [RailsConf][10] de
-Ruby Central, la [RailsConf Europe][11] (co-produite en 2006 par Ruby
+Ruby Central, la RailsConf Europe (co-produite en 2006 par Ruby
 Central et [Skills Matter][12], organisée en 2007 par Ruby Central et
 O’Reilly) et enfin *Canada on Rails*.
 

--- a/id/community/conferences/index.md
+++ b/id/community/conferences/index.md
@@ -90,7 +90,6 @@ on Rails.
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [16]: http://steelcityruby.org/
 [19]: http://goruco.com/

--- a/id/community/conferences/index.md
+++ b/id/community/conferences/index.md
@@ -73,7 +73,7 @@ diadakan pada tahun 2017 di Jakarta.
 [O’Reilly Open Source Conference][10] (OSCON) telah mempunyai sesi Ruby
 sejak tahun 2004, dan juga mempunyai semakin banyak pendukung Ruby.
 Berbagai konferensi lain juga diadakan untuk [Ruby on Rails][11],
-termasuk [RailsConf][12] oleh Ruby Central, [RailsConf Europe][13]
+termasuk [RailsConf][12] oleh Ruby Central, RailsConf Europe
 (diselenggarakan bersama tahun 2006 oleh Ruby Central dan [Skills
 Matter][14], dan tahun 2007 oleh Ruby Central dan O’Reilly), dan Canada
 on Rails.

--- a/it/community/conferences/index.md
+++ b/it/community/conferences/index.md
@@ -102,7 +102,6 @@ e in 2007 da Ruby Central e O’Reilly), e infine Canada on Rails.
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [15]: http://madisonruby.org/
 [16]: http://steelcityruby.org/

--- a/ko/community/conferences/index.md
+++ b/ko/community/conferences/index.md
@@ -59,5 +59,4 @@ Canada on Rails 등등의 많은 콘퍼런스들은 [루비 온 레일즈][11]�
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com

--- a/ko/community/conferences/index.md
+++ b/ko/community/conferences/index.md
@@ -41,7 +41,7 @@ lang: ko
 
 2004년부터 [오라일리 오픈소스 콘퍼런스][10](OSCON)에 루비 트랙이 생겼고 매년
 다른 언어의 트랙에 비해 비중이 증가하는 추세입니다. Ruby Central의
-[RailsConf][12], [RailsConf Europe][13] (2006년엔 Ruby Central과
+[RailsConf][12], RailsConf Europe (2006년엔 Ruby Central과
 [Skills Matter][14]에 의해 2007년엔 Ruby Central과 오라일리에 의해 공동기획),
 Canada on Rails 등등의 많은 콘퍼런스들은 [루비 온 레일즈][11]의 헌신 덕분에
 가능했습니다.

--- a/pt/community/conferences/index.md
+++ b/pt/community/conferences/index.md
@@ -85,7 +85,6 @@ O’Reilly) e, para finalizar a Canada on Rails.
 [9]: http://conferences.oreillynet.com/os2006/
 [10]: http://www.rubyonrails.org
 [11]: http://www.railsconf.org
-[12]: http://europe.railsconf.org
 [13]: http://www.skillsmatter.com
 [14]: http://steelcityruby.org/
 [15]: http://goruco.com/

--- a/pt/community/conferences/index.md
+++ b/pt/community/conferences/index.md
@@ -67,7 +67,7 @@ Tem havido uma _track_ de Ruby na [O’Reilly Open Source Conference][9]
 Programadores Ruby em outros encontros não relacionados com Ruby. Tem
 havido também, um crescente número de conferências dedicadas a
 [Ruby on Rails][10], incluindo a [RailsConf][11] da Ruby Central, a
-[RailsConf Europe][12] (co-realizada em 2006 pela Ruby Central e pela
+RailsConf Europe (co-realizada em 2006 pela Ruby Central e pela
 [Skills Matter][13], e que em 2007 o será pela Ruby Central e
 O’Reilly) e, para finalizar a Canada on Rails.
 

--- a/ru/community/conferences/index.md
+++ b/ru/community/conferences/index.md
@@ -73,5 +73,4 @@ O’Reilly), и Canada on Rails.
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com

--- a/ru/community/conferences/index.md
+++ b/ru/community/conferences/index.md
@@ -56,7 +56,7 @@ Ruby on Rails. Событие проводится в Chicago сообществ
 С 2004 года часть конференции [O’Reilly Open Source Conference][10]
 посвящена темам Ruby. Также количество рубистов и тем о Ruby растет на
 других не Ruby-специфичных событиях. Некоторые конференции, посвященные
-[Ruby on Rails][11]: [RailsConf][12] от Ruby Central, [RailsConf Europe][13] (Ruby
+[Ruby on Rails][11]: [RailsConf][12] от Ruby Central, RailsConf Europe (Ruby
 Central и [Skills Matter][14] соучередители с 2006, и с 2007 года – Ruby Central и
 O’Reilly), и Canada on Rails.
 

--- a/tr/community/conferences/index.md
+++ b/tr/community/conferences/index.md
@@ -66,7 +66,6 @@ Ayrıca Ruby Central'in [RailsConf][12]'u, [RailsConf Avrupa][13] (2006'da Ruby 
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [16]: http://steelcityruby.org/
 [19]: http://goruco.com/

--- a/vi/community/conferences/index.md
+++ b/vi/community/conferences/index.md
@@ -76,7 +76,7 @@ một ngày.
 Có một số người quan tâm đến Ruby tại [hội thảo mã nguồn mở O’Reilly][10]
 (OSCON) từ năm 2004, và con số này không ngừng tăng lên qua các hội thảo khác.
 Một số hội thảo dành riêng cho [Ruby on Rails][11], gồm [RailsConf][12] của
-Ruby Central, [RailsConf Europe][13] (đồng tổ chức bởi Ruby Central và
+Ruby Central, RailsConf Europe (đồng tổ chức bởi Ruby Central và
 [Skills Matter][14] năm 2006, Ruby Central và O’Reilly năm 2007),
 và Canada on Rails.
 

--- a/vi/community/conferences/index.md
+++ b/vi/community/conferences/index.md
@@ -94,7 +94,6 @@ và Canada on Rails.
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [15]: http://madisonruby.org/
 [16]: http://steelcityruby.org/

--- a/zh_cn/community/conferences/index.md
+++ b/zh_cn/community/conferences/index.md
@@ -71,7 +71,6 @@ Ruby 相关的内容都在逐年增加。许多研讨会都以 [Ruby on Rails][1
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [15]: http://madisonruby.org/
 [16]: http://steelcityruby.org/

--- a/zh_cn/community/conferences/index.md
+++ b/zh_cn/community/conferences/index.md
@@ -54,7 +54,7 @@ Ruby 相关的报道，而且我们总是对 Ruby 相关的内容更感兴趣。
 
 自2004年起的 [O’Reilly Open Source Conference][10](OSCON) 研讨会包括了一整轨的 Ruby 演讲，
 Ruby 相关的内容都在逐年增加。许多研讨会都以 [Ruby on Rails][11] 为主题，包括 Ruby Central 的
-[RailsConf][12]、[RailsConf Europe][13]（RubyCentral 和 [Skills Matter][14] 在2006年共同举办，
+[RailsConf][12]、RailsConf Europe（RubyCentral 和 [Skills Matter][14] 在2006年共同举办，
 2007年由 Ruby Central 和 O’Reilly 举办）以及 Canada on Rails。
 
 

--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -60,7 +60,7 @@ lang: zh_tw
 自 2004 年起的 [O’Reilly Open Source Conference][10] (OSCON)
 研討會也包括了一整軌的 Ruby 演講，並逐年增加中。
 也有許多研討會以 [Ruby on Rails][11] 為主題，包括了 Ruby Central 的
-[RailsConf][12]、[RailsConf Europe][13]
+[RailsConf][12]、RailsConf Europe
 （2006 年由 Ruby Central 和 [Skills Matter][14] 共同舉辦，
 2007 年由 Ruby Central 和 O’Reilly 共同舉辦）以及 Canada on Rails.
 

--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -83,7 +83,6 @@ lang: zh_tw
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org
 [12]: http://www.railsconf.org
-[13]: http://europe.railsconf.org
 [14]: http://www.skillsmatter.com
 [16]: http://steelcityruby.org/
 [19]: http://goruco.com/


### PR DESCRIPTION
The URL http://europe.railsconf.org is no long there, and an alternative is not easily accessible. It looks like the global conferences are in all on spot this year as RailsConf Coach Edition.

RailsConf Europe is good to mention historically (most of the pages have context about the conference too), so I removed the link and left the mention.