### PR TITLE
Update Ruby c extension link

### DIFF
--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -81,7 +81,7 @@ deutschsprachigen Artikeln. Für weitergehende Fragen steht eine große
 [8]: http://www.approximity.com/rubybuch2/
 [9]: http://www.ruby-doc.org/core
 [10]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [12]: http://www.rubydoc.info/
 [13]: http://ruby-doc.org
 [14]: http://wiki.ruby-portal.de

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -141,7 +141,7 @@ If you have questions about Ruby the
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -72,6 +72,6 @@ correo](/es/community/mailing-lists/) es un buen lugar para comenzar.
 [7]: http://www.ruby-doc.org/core
 [8]: https://ruby.github.io/rdoc/
 [9]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [11]: http://ruby-doc.org
 [12]: http://www.ruby-doc.org/bookstore

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -143,7 +143,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [16]: http://www.ruby-doc.org/core
 [17]: https://ruby.github.io/rdoc/
 [18]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [20]: http://rubydoc.info/
 [21]: http://rubydocs.org/
 [22]: http://ruby-doc.org

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -140,7 +140,7 @@ adalah tempat yang baik untuk memulai.
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -144,7 +144,7 @@ lang: ko
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -154,7 +154,7 @@ olacaktır.
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -151,7 +151,7 @@ là một nơi tuyệt vời.
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -117,7 +117,7 @@ lang: zh_tw
 [13]: http://www.ruby-doc.org/core
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
-[extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[extensions]: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html
 [16]: http://www.rubydoc.info/
 [17]: http://rubydocs.org/
 [18]: http://apidock.com/


### PR DESCRIPTION
The link was pointing to an old location, updating to the new location.

Closes Issues #2516