### PR TITLE
Update broken Ruby Central Grants link on /conferences

### DIFF
--- a/bg/community/conferences/index.md
+++ b/bg/community/conferences/index.md
@@ -65,7 +65,7 @@ Central и [Skills Matter][14], и през 2007 г. с помощта на Ruby
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -78,7 +78,7 @@ O’Reilly), and Canada on Rails.
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/fr/community/conferences/index.md
+++ b/fr/community/conferences/index.md
@@ -74,7 +74,7 @@ O’Reilly) et enfin *Canada on Rails*.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [8]: http://conferences.oreillynet.com/os2006/
 [9]: http://www.rubyonrails.org

--- a/id/community/conferences/index.md
+++ b/id/community/conferences/index.md
@@ -85,7 +85,7 @@ on Rails.
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/it/community/conferences/index.md
+++ b/it/community/conferences/index.md
@@ -96,7 +96,7 @@ e in 2007 da Ruby Central e O’Reilly), e infine Canada on Rails.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/

--- a/pt/community/conferences/index.md
+++ b/pt/community/conferences/index.md
@@ -79,7 +79,7 @@ O’Reilly) e, para finalizar a Canada on Rails.
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[5]: http://rubycentral.org/community/grant
+[5]: https://rubycentral.org/grants
 [6]: http://www.svforum.org
 [8]: http://windycityrails.org
 [9]: http://conferences.oreillynet.com/os2006/

--- a/ru/community/conferences/index.md
+++ b/ru/community/conferences/index.md
@@ -67,7 +67,7 @@ O’Reilly), и Canada on Rails.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/

--- a/tr/community/conferences/index.md
+++ b/tr/community/conferences/index.md
@@ -61,7 +61,7 @@ Ayrıca Ruby Central'in [RailsConf][12]'u, [RailsConf Avrupa][13] (2006'da Ruby 
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/
 [11]: http://www.rubyonrails.org

--- a/vi/community/conferences/index.md
+++ b/vi/community/conferences/index.md
@@ -88,7 +88,7 @@ và Canada on Rails.
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/

--- a/zh_cn/community/conferences/index.md
+++ b/zh_cn/community/conferences/index.md
@@ -65,7 +65,7 @@ Ruby 相关的内容都在逐年增加。许多研讨会都以 [Ruby on Rails][1
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
 [5]: http://www.osdc.com.au/
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/

--- a/zh_tw/community/conferences/index.md
+++ b/zh_tw/community/conferences/index.md
@@ -77,7 +77,7 @@ lang: zh_tw
 [2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[6]: http://rubycentral.org/community/grant
+[6]: https://rubycentral.org/grants
 [7]: http://www.svforum.org
 [9]: http://windycityrails.org
 [10]: http://conferences.oreillynet.com/os2006/


### PR DESCRIPTION
The link to grants by Ruby Central was broken, so updating the link to the new URL.