### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,16 @@ jobs:
       - name: Dump environment
         run: env | sort
       - name: Checkout ruby/www.ruby-lang.org
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          architecture: x64
+          bundler-cache: true
       - name: Dump Ruby version
         run: ruby -v
-      # override the Ruby version specified in the Gemfile
-      - name: Set CUSTOM_RUBY_VERSION for Gemfile
-        run: echo ::set-env name=CUSTOM_RUBY_VERSION::$(ruby -e 'puts RUBY_VERSION')
-      - name: Dump CUSTOM_RUBY_VERSION
-        run: echo $CUSTOM_RUBY_VERSION
-      - name: Cache gem bundle
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-bundle-${{ hashFiles('Gemfile.lock') }}
-      - name: Install bundler
-        run: gem install bundler --no-document
       - name: Install gem bundle
         run: |
           bundle config set path 'vendor/bundle'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby ENV['CUSTOM_RUBY_VERSION'] || '~> 2.7.0'
 
 gem 'rake'
 gem 'jekyll', '~> 4.0'


### PR DESCRIPTION
- Remove non-existent architecture keyword
- Upgrade actions/checkout to v2
- Use [cache dependencies automatically](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically) by ruby/setup-ruby
- Remove CUSTOM_RUBY_VERSION 
- No need to install Bundler