### PR TITLE
We dont need to run bundle install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,5 @@ jobs:
           bundler-cache: true
       - name: Dump Ruby version
         run: ruby -v
-      - name: Install gem bundle
-        run: |
-          bundle config set path 'vendor/bundle'
-          bundle install
       - name: Run tests
         run: bundle exec rake test


### PR DESCRIPTION
it is already performed by ruby/setup-ruby. See https://github.com/ruby/www.ruby-lang.org/pull/2521#discussion_r510093800.