### PR TITLE
Remove CI tests for Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.7]
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
 


### PR DESCRIPTION
Tests for 2.6 fail since the Ruby version was locked to 2.7.2
in the Gemfile, see a96ca92fcb622f450dda1c385a5f01aa86ee35d4.