### PR TITLE
Remove duplicated "Find pattern is added."

### DIFF
--- a/en/news/_posts/2020-12-08-ruby-3-0-0-preview2-released.md
+++ b/en/news/_posts/2020-12-08-ruby-3-0-0-preview2-released.md
@@ -172,16 +172,6 @@ end
     ``` ruby
     def square(x) = x * x
     ```
-* Find pattern is added.
-    ``` ruby
-    case ["a", 1, "b", "c", 2, "d", "e", "f", 3]
-    in [*pre, String => x, String => y, *post]
-      p pre  #=> ["a", 1]
-      p x    #=> "b"
-      p y    #=> "c"
-      p post #=> [2, "d", "e", "f", 3]
-    end
-    ```
 * `Hash#except` is now built-in.
     ``` ruby
     h = { a: 1, b: 2, c: 3 }


### PR DESCRIPTION
Hello

This part is duplicated. It can be seen just earlier https://github.com/ruby/www.ruby-lang.org/compare/master...benoittgt:benoittgt-remove-dup-find-pattern?expand=1#diff-c6345d79a5e1d212e019adf651677f24c74206998b20198fa191701b2052e703R161-R169

Thanks for the release and the great changelog.

🎉 