### PR TITLE
Update rouge to 3.25.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "~> 2.7.2"
 
 gem "rake"
 gem "jekyll", "~> 4.0"
-gem "rouge", "< 3.24.0"
+gem "rouge"
 
 gem "unicorn"
 gem "lanyon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.4)
-    rouge (3.23.0)
+    rouge (3.25.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -106,7 +106,7 @@ DEPENDENCIES
   rack-rewrite
   rack-ssl
   rake
-  rouge (< 3.24.0)
+  rouge
   spidr (~> 0.6)
   unicorn
   validate-website (~> 1.6)


### PR DESCRIPTION
Remove restriction to rouge < 3.24.0 and update rouge.

The bug in rouge 3.24.0 concerning syntax highlighting of
regular expressions has been fixed in version 3.25.0, see

* https://github.com/rouge-ruby/rouge/issues/1618
* https://github.com/rouge-ruby/rouge/pull/1624