### PR TITLE
Fix the image URL of en ruby-3-0-0

### DIFF
--- a/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -11,7 +11,7 @@ We are pleased to announce the release of Ruby {{ release.version }}. From 2015 
 
 {% assign release = site.data.releases | where: "version", "3.0.0" | first %}
 
-<img src='https://i.imgur.com/mqOkcWi.png' alt='Optcarrot 3000 frames' width='100%' />
+<img src='https://cache.ruby-lang.org/pub/media/ruby3x3.png' alt='Optcarrot 3000 frames' width='100%' />
 
 With [Optcarrot benchmark](https://github.com/mame/optcarrot), which measures single thread performance based on NES's game emulation workload, it achieved 3x faster performance than Ruby 2.0! <details>These were measured at the environment written in https://benchmark-driver.github.io/hardware.html. [8c510e4095](http://github.com/ruby/ruby/commit/8c510e4095) was used as Ruby 3.0. It may not be 3x faster depending on your environment or benchmark.</details>
 


### PR DESCRIPTION
ja is already correct.