### PR TITLE
Fix 3.0.0 posts (en, de)

### DIFF
--- a/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -388,15 +388,15 @@ willkommen.
 * Einige Standardbibliotheken wurden aktualisiert.
   * RubyGems 3.2.3
   * Bundler 2.2.3
-  * IRB 1.2.6
-  * Reline 0.1.5
-  * Pysch 3.3.0
-  * JSON 2.5.0
+  * IRB 1.3.0
+  * Reline 0.2.0
+  * Psych 3.3.0
+  * JSON 2.5.1
   * BigDecimal 3.0.0
   * CSV 3.1.9
-  * Date 3.1.1
+  * Date 3.1.0
   * Digest 3.0.0
-  * Fiddle 1.0.5
+  * Fiddle 1.0.6
   * StringIO 3.0.0
   * StringScanner 3.0.0
   * etc.

--- a/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -7,7 +7,7 @@ date: 2020-12-25 00:00:00 +0000
 lang: en
 ---
 
-We are pleased to announce the release of Ruby {{ release.version }}. From 2015 we developed hard toward Ruby 3, whose goal is performance, concurrency, and Typing. Especially about performance, Matz stated "Ruby3 will be 3 times faster than Ruby2" a.k.a. [Ruby 3x3](https://blog.heroku.com/ruby-3-by-3).
+We are pleased to announce the release of Ruby 3.0.0. From 2015 we developed hard toward Ruby 3, whose goal is performance, concurrency, and Typing. Especially about performance, Matz stated "Ruby3 will be 3 times faster than Ruby2" a.k.a. [Ruby 3x3](https://blog.heroku.com/ruby-3-by-3).
 
 {% assign release = site.data.releases | where: "version", "3.0.0" | first %}
 


### PR DESCRIPTION
- `{{release.version}}` not expand, directly mention version for now
- Fix standard lib versions in 3.0.0 post (de)