### PR TITLE
Restrict Jekyll to < 4.2.0 and update gem bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "~> 2.7.2"
 
 gem "rake"
-gem "jekyll", "~> 4.0"
+gem "jekyll", "~> 4.0", "< 4.2.0"
 gem "rouge"
 
 gem "unicorn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.13.1)
+    ffi (1.14.2)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.5)
@@ -34,7 +34,7 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.3.1)
+    json (2.5.1)
     kgio (2.11.3)
     kramdown (2.3.0)
       rexml
@@ -44,7 +44,7 @@ GEM
       jekyll (>= 2.0)
       rack (>= 1.6, < 3.0)
     liquid (4.0.3)
-    listen (3.3.1)
+    listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -52,7 +52,7 @@ GEM
     minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    paint (2.2.0)
+    paint (2.2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
@@ -63,12 +63,12 @@ GEM
     rack-ssl (1.4.1)
       rack
     raindrops (0.19.1)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.4)
-    rouge (3.25.0)
+    rouge (3.26.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -80,7 +80,7 @@ GEM
     tidy_ffi (1.0.1)
       ffi (~> 1.2)
     unicode-display_width (1.7.0)
-    unicorn (5.7.0)
+    unicorn (5.8.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     validate-website (1.10.0)
@@ -99,7 +99,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.0)
+  jekyll (~> 4.0, < 4.2.0)
   lanyon
   minitest
   rack-protection
@@ -115,4 +115,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
Using Jekyll 4.2.0 breaks the sidebars on the yearly and monthly news archive pages: they are the same as on the news/ page, listing "Archives by Year" (without any entries) and "Syndicate".
