### PR TITLE
Fix generated news archive pages for Jekyll 4.2.0 and update bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "~> 2.7.2"
 
 gem "rake"
-gem "jekyll", "~> 4.0", "< 4.2.0"
+gem "jekyll", "~> 4.0"
 gem "rouge"
 
 gem "unicorn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,21 +15,21 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    jekyll (4.1.1)
+    jekyll (4.2.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.1)
+      kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
       mercenary (~> 0.4.0)
       pathutil (~> 0.9)
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
-      terminal-table (~> 1.8)
+      terminal-table (~> 2.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -75,7 +75,7 @@ GEM
     slop (4.8.2)
     spidr (0.6.1)
       nokogiri (~> 1.3)
-    terminal-table (1.8.0)
+    terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     tidy_ffi (1.0.1)
       ffi (~> 1.2)
@@ -99,7 +99,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.0, < 4.2.0)
+  jekyll (~> 4.0)
   lanyon
   minitest
   rack-protection

--- a/_plugins/news.rb
+++ b/_plugins/news.rb
@@ -6,12 +6,15 @@ module Jekyll
   module News
     class ArchivePage < Page
 
-      def initialize(site, base, layout, lang, posts)
+      def initialize(site, base, subdir, layout, lang, posts)
         @site = site
         @base = base
-
         @lang = lang
-        @dir  = File.join(@lang, news_dir)
+        @dir  = if subdir
+                  File.join(@lang, news_dir, subdir)
+                else
+                  File.join(@lang, news_dir)
+                end
         @name = "index.html"
 
         @locales = @site.data["locales"][@lang]["news"] ||
@@ -47,11 +50,11 @@ module Jekyll
       LAYOUT = "news_archive_month.html"
 
       def initialize(site, base, lang, year, month, posts)
-        super(site, base, LAYOUT, lang, posts)
-
         @year  = year
         @month = month
-        @dir   = File.join(@dir, @year.to_s, "%.2d" % @month)
+        subdir = File.join(@year.to_s, "%.2d" % @month)
+
+        super(site, base, subdir, LAYOUT, lang, posts)
 
         title = @locales["monthly_archive_title"]
 
@@ -65,10 +68,10 @@ module Jekyll
       LAYOUT = "news_archive_year.html"
 
       def initialize(site, base, lang, year, posts)
-        super(site, base, LAYOUT, lang, posts)
-
         @year = year
-        @dir  = File.join(@dir, @year.to_s)
+        subdir = @year.to_s
+
+        super(site, base, subdir, LAYOUT, lang, posts)
 
         title = @locales["yearly_archive_title"]
         month_link_text = @locales["monthly_archive_link"]
@@ -94,7 +97,8 @@ module Jekyll
       MAX_POSTS = 10
 
       def initialize(site, base, lang, posts)
-        super(site, base, LAYOUT, lang, posts)
+        subdir = nil
+        super(site, base, subdir, LAYOUT, lang, posts)
 
         title = @locales["recent_news"]
         year_link_text = @locales["yearly_archive_link"]


### PR DESCRIPTION
Before this change, with Jekyll 4.2.0 all news archive pages used `news.html` as layout, also the yearly and monthly archive pages, leading to wrong sidebars that list "Archives by Year" (without any entries) and "Syndicate".

The reason is that `Page#relative_path` is a memoized value and Jekyll 4.2.0 changes when `relative_path` is first called during generation of the archive pages.

Other than before it is now called from `read_yaml`, see

https://github.com/jekyll/jekyll/commit/26086409bff1d9f903ef723c6d4225c519c01e5c

`YearlyArchive` and `MonthlyArchive` call `ArchivePage#new` (via `super`), which uses `read_yaml`, so that from then on `relative_path` is set and will not change anymore.  Therefore the reassignments of `@dir` in YearlyArchive and MonthlyArchive after the `super` calls have no effect on `relative_path`. Hence *all* archive pages have their relative path set to `<lang>/news/index.html`.  Then for rendering, apparently the content of the page under the relative path is used (i.e. the `news.html` layout) instead of the in fact correctly set `content` of the respective archive page (i.e. `news_archive_year.html` or `news_archive_month.html`).

This issue is fixed by not changing `@dir` after calling `super`.