### PR TITLE
Fix typo in 3.0.0-rc1 post (en, translations)

### DIFF
--- a/de/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
+++ b/de/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
@@ -284,7 +284,7 @@ end
   * Bundler 2.2.2
   * IRB 1.2.6
   * Reline 0.1.5
-  * Pysch 3.2.1
+  * Psych 3.2.1
   * JSON 2.4.1
   * BigDecimal 3.0.0
   * CSV 3.1.9

--- a/en/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
+++ b/en/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
@@ -228,7 +228,7 @@ end
   * Bundler 2.2.2
   * IRB 1.2.6
   * Reline 0.1.5
-  * Pysch 3.2.1
+  * Psych 3.2.1
   * JSON 2.4.1
   * BigDecimal 3.0.0
   * CSV 3.1.9

--- a/es/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
+++ b/es/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
@@ -295,7 +295,7 @@ end
   * Bundler 2.2.2
   * IRB 1.2.6
   * Reline 0.1.5
-  * Pysch 3.2.1
+  * Psych 3.2.1
   * JSON 2.4.1
   * BigDecimal 3.0.0
   * CSV 3.1.9

--- a/ja/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
+++ b/ja/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
@@ -208,7 +208,7 @@ Currently, there is a test scheduler available in [`Async::Scheduler`](https://g
   * Bundler 2.2.2
   * IRB 1.2.6
   * Reline 0.1.5
-  * Pysch 3.2.1
+  * Psych 3.2.1
   * JSON 2.4.1
   * BigDecimal 3.0.0
   * CSV 3.1.9

--- a/tr/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
+++ b/tr/news/_posts/2020-12-20-ruby-3-0-0-rc1-released.md
@@ -247,7 +247,7 @@ end
   * Bundler 2.2.2
   * IRB 1.2.6
   * Reline 0.1.5
-  * Pysch 3.2.1
+  * Psych 3.2.1
   * JSON 2.4.1
   * BigDecimal 3.0.0
   * CSV 3.1.9


### PR DESCRIPTION
`Pysch` -> `Psych`