### PR TITLE
Set basename and ext attrs of archives directly

### DIFF
--- a/_plugins/news.rb
+++ b/_plugins/news.rb
@@ -16,11 +16,12 @@ module Jekyll
                 else
                   File.join(lang, "news")
                 end
-        @name = "index.html"
+
+        @basename = "index"
+        @ext      = ".html"
+        @name     = "index.html"
 
         @lang = lang
-
-        process(@name)
         @data ||= {}
 
         data["lang"]  = lang


### PR DESCRIPTION
Since the `@name` attribute for all generated archive pages are the same `"index.html"`, the `@basename` and `@ext` attributes are also technically the same values for all instances.
Therefore, set those attributes directly instead of computing strings via series of method calls.

/cc @stomar 