### PR TITLE
Link to docs.ruby-lang.org for pattern matching docs

### DIFF
--- a/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -381,7 +381,7 @@ willkommen.
 
 * Musterabgleiche (`case`/`in`) sind nicht länger experimentell.
   * Siehe die
-    [Pattern-Matching-Dokumentation](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc)
+    [Pattern-Matching-Dokumentation](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html)
     für weitere Informationen.
 * Die Besonderheiten von `$SAFE` wurden vollständig entfernt. Es
   handelt sich nun um eine normale globale Variable.

--- a/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -287,7 +287,7 @@ TypeProf is experimental and not so mature yet; only a subset of the Ruby langua
     ```
 
 * Pattern matching (`case`/`in`) is no longer experimental.
-  * See the [pattern matching documentation](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc) for details.
+  * See the [pattern matching documentation](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html) for details.
 * The `$SAFE` feature was completely removed; now it is a normal global variable.
 * The order of backtraces had been reversed with Ruby 2.5; this change has been reverted.  Now backtraces behave like in Ruby 2.4: an error message and the line number where the exception occurs are printed first, and its callers are printed later.
 * Some standard libraries are updated.

--- a/es/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/es/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -376,7 +376,7 @@ Toda retroalimentación es bienvenida.
     ```
 
 * El reconocimiento de patrones (`case`/`in`) ya no es experimental.
-  * Ver detalles en el [documento del reconocimiento de patrones](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc).
+  * Ver detalles en el [documento del reconocimiento de patrones](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html).
 
 * La característica `$SAFE` se eliminó por completo; ahora es una variable
   global normal.

--- a/ja/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/ja/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -287,7 +287,7 @@ end
     ```
 
 * パターンマッチ(`case`/`in`)が実験的な機能ではなくなりました。
-  * 詳しくは[ドキュメント](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc)を見てください。
+  * 詳しくは[ドキュメント](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html)を見てください。
 * `$SAFE` の機能が完全に削除され、ただのグローバル変数となりました。
 * バックトレースの順序は2.5で逆転しましたが、3.0ではこれを取りやめることになりました。例外が起きた行が先に表示され、呼び出し元が後に表示されるように戻ります。
 * いくつかの標準ライブラリがアップデートされました。

--- a/zh_cn/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/zh_cn/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -287,7 +287,7 @@ TypeProf 目前是实验特性，还不够成熟。只有 Ruby 语言的一个�
     ```
 
 * 模式匹配 (`case`/`in`) 不再是实验性特性。
-  * 详见[模式匹配文档](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc)。
+  * 详见[模式匹配文档](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html)。
 * `$SAFE` 特性被彻底移除，现在它就是一个普通的全部常量。
 * backtrace 的顺序在 Ruby 2.5 中被颠倒，现在倒了回来。现在其行为和 2.4 一致，先打印错误信息，再以此打印其调用者。
 * 一些标准库被升级

--- a/zh_tw/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/zh_tw/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -284,7 +284,7 @@ TypeProf 仍是實驗性質功能尚未成熟，只支援 Ruby 的部分語法�
     ```
 
 * 模式匹配（`case`/`in`）不再是實驗性質。
-  * 參見[模式匹配文件](https://github.com/ruby/ruby/blob/ruby_3_0/doc/syntax/pattern_matching.rdoc)來了解更多。
+  * 參見[模式匹配文件](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html)來了解更多。
 * 完全移除了 `$SAFE` 功能，現在只是個單純的全域變數。
 * 錯誤訊息的順序在 Ruby 2.5 被顛倒了，現在又改回來了。現在錯誤訊息和 Ruby 2.4 一樣：先顯示錯誤訊息行號，再來才是所有的呼叫者。
 * 更新了某些標準函式庫


### PR DESCRIPTION
Prefer links to docs.ruby-lang.org over raw blobs on GitHub.