### PR TITLE
Link to docs.ruby-lang.org for Ractor docs

### DIFF
--- a/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/de/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -127,7 +127,7 @@ Dieses Ergebnis wurde gemesen auf Ubuntu 20.04, Intel(R) Core(TM)
 i7-6700 (4 Kerne, 8 Hardware-Threads). Es zeigt, dass die parallele
 Version 3,87-mal schneller ist als die sequentielle Version.
 
-Siehe [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md) für weitere Details.
+Siehe [doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html) für weitere Details.
 
 ### Fiber Scheduler
 

--- a/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/en/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -83,7 +83,7 @@ par  66.422010   0.015999  66.438009 ( 16.685797)
 
 The result was measured on Ubuntu 20.04, Intel(R) Core(TM) i7-6700 (4 cores, 8 hardware threads). It shows that the parallel version is 3.87 times faster than the sequential version.
 
-See [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md) for more details.
+See [doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html) for more details.
 
 ### Fiber Scheduler
 

--- a/es/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/es/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -124,7 +124,7 @@ El resultado se midió en Ubuntu 20.04, con procesador Intel(R) Core(TM) i7-6700
 (4 núcleos, 8 hilos por hardware). Muetra que la versión paralela
 es 3.87 veces más rápido que la versión secuencial.
 
-Vea más detalles en [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md).
+Vea más detalles en [doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html).
 
 
 ## Planificador (__Scheduler__) de Fibras

--- a/ja/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/ja/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -87,7 +87,7 @@ par  66.422010   0.015999  66.438009 ( 16.685797)
 結果は Ubuntu 20.04, Intel(R) Core(TM) i7-6700 (4 cores, 8 hardware threads) で実行したものになります。逐次実行したときよりも、並列化によって3.87倍の高速化していることがわかります。
 
 
-より詳細は、[doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md) をご覧ください。
+より詳細は、[doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html) をご覧ください。
 
 ### Fiber Scheduler
 

--- a/zh_cn/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/zh_cn/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -83,7 +83,7 @@ par  66.422010   0.015999  66.438009 ( 16.685797)
 
 该测试在 Ubuntu 20.04，Intel(R) Core(TM) i7-6700（4 核心 8 线程）下完成。测量显示其比起顺序执行，有约 3.87 倍的性能提升。
 
-详见 [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md)。
+详见 [doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html)。
 
 ### Fiber 调度器
 

--- a/zh_tw/news/_posts/2020-12-25-ruby-3-0-0-released.md
+++ b/zh_tw/news/_posts/2020-12-25-ruby-3-0-0-released.md
@@ -83,7 +83,7 @@ par  66.422010   0.015999  66.438009 ( 16.685797)
 
 測試在 Ubuntu 20.04、Intel(R) Core(TM) i7-6700 (4 核心、8 硬體線程）下量測。並行的版本比序行的版本快 3.87 倍。
 
-參見 [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md) 來了解更多。
+參見 [doc/ractor.md](https://docs.ruby-lang.org/en/3.0.0/doc/ractor_md.html) 來了解更多。
 
 ### Fiber Scheduler
 


### PR DESCRIPTION
Prefer links to docs.ruby-lang.org over raw blobs on GitHub.