### PR TITLE
Add `chruby` introduction (ja)

### DIFF
--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -17,6 +17,7 @@ lang: ja
 
   * [rbenv](#rbenv)
   * [RVM](#rvm)
+  * [chruby](#chruby)
   * [Homebrew](#homebrew)
   * [ソースからのビルド](#building-from-source)
 
@@ -24,6 +25,7 @@ lang: ja
 
   * [rbenv](#rbenv)
   * [RVM](#rvm)
+  * [chruby](#chruby)
   * [パッケージ管理システム](#package-management-systems)
   * [ソースからのビルド](#building-from-source)
 
@@ -48,13 +50,13 @@ lang: ja
 rbenv では複数の Ruby を管理することができます。
 
 rbenv は Ruby のインストール自体はサポートしていませんが、
-ruby-build というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
+[ruby-build](https://github.com/rbenv/ruby-build) というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
 
 それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
 
 rbenv をインストールする方法は [rbenvのページ][rbenv] に記述されています。
 
-rbenv と似たツールとして、次に説明する RVM があります。
+rbenv と似たツールとして、次に説明する RVM や chruby があります。
 そちらも確認して、良い方を選んでください。
 
 
@@ -65,6 +67,18 @@ RVM は複数の Ruby のインストールと管理を行うことができま�
 このツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
 
 RVM をインストールする方法は [rvm.io][rvm] に記述されています。
+
+### chruby
+{: #chruby}
+
+chruby では複数の Ruby を管理することができます。
+
+chruby は Ruby のインストール自体はサポートしていませんが、
+[ruby-install](https://github.com/postmodern/ruby-install) や [ruby-build](https://github.com/rbenv/ruby-build) というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
+
+それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
+
+chruby をインストールする方法は [chrubyのページ][chruby] に記述されています。
 
 ### ActiveScriptRuby
 {: #activescriptruby }
@@ -238,6 +252,7 @@ $ sudo make install
 
 [rvm]: http://rvm.io/
 [rbenv]: https://github.com/rbenv/rbenv
+[chruby]: https://github.com/postmodern/chruby
 [active-script-ruby]: http://www.artonx.org/data/asr/
 [rubyinstaller]: https://rubyinstaller.org/
 [railsinstaller]: http://railsinstaller.org/


### PR DESCRIPTION
Hi! I'm a `chruby` user for a long time.
The tool looks so stable. I didn't face big issues yet, even though it does not release new version this 7 years!

<img width="719" alt="スクリーンショット 2021-04-04 21 49 11" src="https://user-images.githubusercontent.com/1180335/113509264-9c4bb000-958f-11eb-82ad-418aab748b75.png">

And other languages having the introduction section. So I would to provide `ja` introduction for it as other languages. 🙏 

```console
$ git grep -l chruby
bg/documentation/installation/index.md
en/documentation/installation/index.md
es/documentation/installation/index.md
fr/documentation/installation/index.md
id/documentation/installation/index.md
ko/documentation/installation/index.md
pt/documentation/installation/index.md
ru/documentation/installation/index.md
tr/documentation/installation/index.md
vi/documentation/installation/index.md
zh_cn/documentation/installation/index.md
zh_tw/documentation/installation/index.md
```