### PR TITLE
Remove macos-latest from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.7]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It is relatively slow comparing to Ubuntu, which blocks update of the
site.
I don't think it is reasonable to run the test on CI.
Instead, a rapid update is important, especially, for security release.