### PR TITLE
Fix affected versions in CVE-2021-28965 post (en, translations)

### DIFF
--- a/en/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/en/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -30,9 +30,9 @@ If you are using Ruby 2.5.8 or prior:
 ## Affected versions
 
 * Ruby 2.5.8 or prior (You can <strong>NOT</strong> use `gem upgrade rexml` for this version.)
-* Ruby 2.6.7 or prior
+* Ruby 2.6.6 or prior
 * Ruby 2.7.2 or prior
-* Ruby 3.0.1 or prior
+* Ruby 3.0.0
 * REXML gem 3.2.4 or prior
 
 ## Credits

--- a/es/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/es/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -43,9 +43,9 @@ posterior tan pronto como sea posible.
 
 * Ruby 2.5.8 o anterior (<strong>NO</strong> podrá usar `gem upgrade rexml`
   con estas versiones.)
-* Ruby 2.6.7 o anterior
+* Ruby 2.6.6 o anterior
 * Ruby 2.7.2 o anterior
-* Ruby 3.0.1 o anterior
+* Ruby 3.0.0
 * REXML gem 3.2.4 o anterior
 
 ## Creditos

--- a/tr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/tr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -34,9 +34,9 @@ Eğer Ruby 2.5.8 ya da öncesini kullanıyorsanız:
 ## Etkilenen sürümler
 
 * Ruby 2.5.8 ya da öncesi (Bu sürüm için `gem upgrade rexml` komutunu <strong>kullanamazsınız</strong>.)
-* Ruby 2.6.7 ya da öncesi
+* Ruby 2.6.6 ya da öncesi
 * Ruby 2.7.2 ya da öncesi
-* Ruby 3.0.1 ya da öncesi
+* Ruby 3.0.0
 * REXML gem'i 3.2.4 ya da öncesi
 
 ## Teşekkürler


### PR DESCRIPTION
Based on:

* https://github.com/ruby/www.ruby-lang.org/commit/2ce4400c601b6a85c3aeee36150af5d1286e5ae6#diff-253f742b67a565c0bb13e89dcc5e3779f23c0614bf793573c64484435426d04fR12-R16
* https://github.com/ruby/www.ruby-lang.org/commit/2ce4400c601b6a85c3aeee36150af5d1286e5ae6#diff-5bf8497136463de04c1c4ce73fb76e3244e0ab58a8c9dc8536253b1337a241f1R12-R15