### PR TITLE
Remove reference to book list as link is broken

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -123,7 +123,7 @@ Here is a list of popular tools used by Rubyists:
 ### Further Reading
 
 [Ruby-doc.org][34] maintains a comprehensive list of English
-documentation sources. There are also plenty of [books about Ruby][35].
+documentation sources.
 If you have questions about Ruby the
 [mailing list](/en/community/mailing-lists/) is a great place to start.
 
@@ -162,7 +162,6 @@ If you have questions about Ruby the
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org
-[35]: http://www.ruby-doc.org/bookstore
 [36]: https://netbeans.org/
 [37]: http://www.sublimetext.com/
 [38]: https://learncodethehardway.org/ruby/

--- a/en/documentation/quickstart/4/index.md
+++ b/en/documentation/quickstart/4/index.md
@@ -146,11 +146,3 @@ you wanting to learn more.
 If so, please head on over to our [Documentation](/en/documentation/)
 area, which rounds up links to manuals and tutorials, all freely
 available online.
-
-Or, if you’d really like to dig into a book, check the [book list][1]
-(off-site link) for titles available for sale online or at your local
-bookseller.
-
-
-
-[1]: http://www.ruby-doc.org/bookstore


### PR DESCRIPTION
The link to the book list in the quickstart guide (http://books.ruby-doc.com/bookstore/) no longer works.