### PR TITLE
Remove abuse enabling language pt. 2

### DIFF
--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -18,4 +18,4 @@ commit comments, etc.).
 
  * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
  * Participants should speak and act with good intentions, but understand that intent and impact are not equivalent.
- * Behaviour which can be reasonably considered harassment will not be tolerated.
+ * Behaviour which can be considered harassment against protected classes will not be tolerated.

--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -16,7 +16,6 @@ community. It applies to all "collaborative space", which is defined as
 community communications channels (such as mailing lists, submitted patches,
 commit comments, etc.).
 
- * Participants will be tolerant of opposing views.
  * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
  * Participants should speak and act with good intentions, but understand that intent and impact are not equivalent.
  * Behaviour which can be reasonably considered harassment will not be tolerated.


### PR DESCRIPTION
This is a follow-up to #2690.

The rationale is described in #2690.