### PR TITLE
Remove duplicate Ruby Essentials mention

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -33,7 +33,7 @@ the [installation guide](installation/) for help on installing Ruby.
   constructs.
 
 [Ruby Essentials][7]
-: Ruby Essentials is a free on-line book designed to provide a concise
+: A free on-line book designed to provide a concise
   and easy to follow guide to learning Ruby.
 
 [Learn to Program][8]


### PR DESCRIPTION
Generally speaking, when you define something, you shouldn't mention the thing you're defining. Mentioning Ruby Essentials twice like this doesn't add anything to the writing, and in fact detracts from it.