### PR TITLE
Revert #2690

### DIFF
--- a/en/community/mailing-lists/ruby-talk-guidelines/index.md
+++ b/en/community/mailing-lists/ruby-talk-guidelines/index.md
@@ -9,7 +9,9 @@ You should follow these guidelines when posting to the ruby-talk mailing list.
 
 
 1. **Always** be friendly, considerate, tactful, and tasteful. We want to
-   keep this list hospitable and safe for everyone.
+   keep this list hospitable to the growing ranks of newbies, very
+   young people, and their teachers, as well as cater to fire breathing
+   wizards. :-)
 
 2. Keep your content relevant and easy to follow. Try to keep your
    content brief and to the point, but also try to include all relevant

--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -18,4 +18,4 @@ commit comments, etc.).
 
  * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
  * Participants should speak and act with good intentions, but understand that intent and impact are not equivalent.
- * Behaviour which can be considered harassment against protected classes will not be tolerated.
+ * When interpreting the words and actions of others, participants should always assume good intentions.


### PR DESCRIPTION
Unfortunately the author of #2690 was tragically born without a sense of humor. This disability makes them a protected class.

There's actually several problems with #2690. The first being that the author is ultimately trying to deal with what they feel is a failure of the moderators, without actually having a discussion with the moderators. Changing the CoC doesn't actually change their behavior - if you feel like they're doing a poor job in the first place they're going to continue to do a poor job.

Twitter is not github. That's not the correct place to state a commit message. 

Individual pieces of ruby can have their own CoCs. #2690 does nothing to change the other CoCs, which are often simply the same text as they're parts of forks or simply copied around.

Unfortunately none of the open source projects on planet earth have managed to [objectively define](https://en.wikipedia.org/wiki/I_know_it_when_I_see_it) what is ~pornography~ offensive which dovetails into the earlier comment of correctly addressing concerns.

I am actually a firebreather as a hobby, and a wizard by self identified religious affiliation. I am claiming protections under the existing text of the Code of Conduct in the master branch and demanding this pull request be accepted.