### PR TITLE
Revert changes from #2691

### DIFF
--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -16,6 +16,7 @@ community. It applies to all "collaborative space", which is defined as
 community communications channels (such as mailing lists, submitted patches,
 commit comments, etc.).
 
+ * Participants will be tolerant of opposing views.
  * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
  * Participants should speak and act with good intentions, but understand that intent and impact are not equivalent.
- * Behaviour which can be considered harassment against protected classes will not be tolerated.
+ * Behaviour which can be reasonably considered harassment will not be tolerated.


### PR DESCRIPTION
A lot of people seem to have opinions on these changes, but in case it was unclear many of the comments made in #2690 and the changes suggested in #2691 were not made in good faith (as far as I can tell).

Generally, that distinction should be made by the maintainers of this repo (cc @JuanitoFatas @hsbt @matz), but I did want to make it clear that I wasn't endorsing the suggestions made in #2690's comments (enacted in #2691), it was just my intention to treat the trolls like I would treat anyone else on GitHub (maybe that was a bad call).

I do think it is worth revisiting this document, but these changes were tongue-in-cheek jokes at my expense so I have to question the value.

More specifically:

Removing "Participants will be tolerant of opposing views." is probably too sweeping. I could definitely appreciate an argument that communicates the spirit of mutual respect without implying that others are obligated to tolerate bad actors, but this doesn't accomplish that goal. In my opinion, it has a net negative on the document.

Adding "against protected classes" does not improve the spirit or language of the document, in my opinion, and it also gives credence to similar bad faith arguments like the ones made in #2693*. In which, the author directly insults me and makes an ableist joke: "was tragically born without a sense of humor. This disability makes them a protected class."

Obviously, this is a set of guidelines and is only as useful as far as it is enforced and respected by the community. I do agree that moderation is the ultimate issue #2690 was pointing to, but the specific language changes were also important.

\* this reads like a bad faith argument wherein the author specifically uses the "against protected classes" language, in my opinion: "I am actually a firebreather as a hobby, and a wizard by self identified religious affiliation. I am claiming protections under the existing text of the Code of Conduct in the master branch and demanding this pull request be accepted."