### PR TITLE
Remove abuse enabling language pt. 3

### DIFF
--- a/en/conduct/index.md
+++ b/en/conduct/index.md
@@ -19,4 +19,5 @@ commit comments, etc.).
  * Participants will be tolerant of opposing views.
  * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
  * When interpreting the words and actions of others, participants should always assume good intentions.
+ * Participants will do their best to not start or advance political or otherwise divisive conversations.
  * Behaviour which can be reasonably considered harassment will not be tolerated.


### PR DESCRIPTION
I joined the Ruby-Talk mailing list a few months ago. It is a very
slowly moving medium, mostly focused on a show-and-tell and newbie
questions. This list is used by two groups of people, hobbyists and
professionals. I am rather a member of a second group and in my
messages I tried to be as civil as possible. But hobbyists may not
share that trait with us, not due to a malice, but rather due to
a fact, that... many of them are young.

I am generalizing somewhat, I know. I am a hobbyist too and Ruby is
one of the most fun environments I have gotten to know. I just tried
to describe my observation. And if I'm right in my observation,
removing the young people may ultimately result in Ruby community
slowly withering out and dying.

In my life experience I have gotten to know two methods of governance.
One is to "encourage" everyone to act civil, other is to "enforce"
everyone to do so. While I understand that it's not binary and
sometimes you need to "enforce", I am a strong proponent of the
"encouragement" stance whenever possible for a single reason that it
produces less tensions.

Politics are heated. That's a fact. Everyone has their own opinion
and each opinion is the best. You can't encourage the other side that
their opinion is wrong, but you will still attempt to. Why is that so?
We all live in different worlds, we all have different observations.
We read different media, we care about different things. It doesn't
matter - it will probably never end up in an agreement but will
devolve into lengthy and lengthy conversations, most of which will be
ultimately fruitless.

The conversation in question we had was exactly an example of that,
about 50 posts of a heated debate (which is a lot of traffic for this
ML). Do we want such debates to take place on Ruby-Talk or other core
Ruby communities? 

In this PR I suggest reverting both #2690 and #2691 and introducing
a clause:

```
 * Participants will do their best to not start or advance political or otherwise divisive conversations.
```

It is intentionally worded in a non-enforcing way. Sometimes a really
pushing problem happens. But this point will make sure that members of
the community will consider to back off from absolutely trying to show
their opinion.

Here I would also want to take an opportunity to appologize to
@jacobherrington if he felt that he was personally attacked by my
actions - that was not my intention. I happen to disagree with some of
your opinions, agree with some. But let's leave it at that. If everyone
agreed with everyone else, the world would be extremely boring. At
least we can all agree that Ruby is cool.

References: #2693, #2695.