### PR TITLE
Add `Slack` section to ja

### DIFF
--- a/ja/community/index.md
+++ b/ja/community/index.md
@@ -40,6 +40,10 @@ Rubyコミュニティに興味があるのなら、ぜひ以下のコミュニ�
 * Libera Chatの[#ruby](https://web.libera.chat/#ruby)
   * Rubyの利用者の交流、質問のためのチャンネルです。(英語)
 
+## Slack
+
+* Slack上には[ruby-jp](https://ruby-jp.github.io/)コミュニティがあります。3000人を超えるユーザーと100を超えるチャンネルが存在し、初歩的な質問からCRubyについての高度な質問まで、多種多様な質問と回答が飛び交っています。
+
 ## メーリングリスト
 
 * [メーリングリスト](/ja/community/mailing-lists/) のページを参照してください。


### PR DESCRIPTION
We mention Discord community in en page, so I think it's fine to mention Slack community.
Modifying the expression is welcome.