### PR TITLE
Fix title and link to translated posts (id)

### DIFF
--- a/id/news/_posts/2021-04-05-ruby-2-5-9-released.md
+++ b/id/news/_posts/2021-04-05-ruby-2-5-9-released.md
@@ -13,7 +13,7 @@ Rilis ini mencakup beberapa perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk lebih detail.
 
 * [CVE-2020-25613: Potensi Kerentanan HTTP Request Smuggling pada WEBrick]({%link id/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md %})
-* [CVE-2021-28965: XML round-trip vulnerability in REXML]({% link en/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
+* [CVE-2021-28965: Kerentanan XML round-trip pada REXML]({% link id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
 
 Lihat [commit logs](https://github.com/ruby/ruby/compare/v2_5_8...v2_5_9) untuk
 detail.

--- a/id/news/_posts/2021-04-05-ruby-2-6-7-released.md
+++ b/id/news/_posts/2021-04-05-ruby-2-6-7-released.md
@@ -13,7 +13,7 @@ Rilis ini memuat perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk lebih detail.
 
 * [CVE-2020-25613: Potensi Kerentanan HTTP Request Smuggling pada WEBrick]({%link id/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md %})
-* [CVE-2021-28965: XML round-trip vulnerability in REXML]({% link id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
+* [CVE-2021-28965: Kerentanan XML round-trip pada REXML]({% link id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
 
 Lihat [commit logs](https://github.com/ruby/ruby/compare/v2_6_6...v2_6_7) untuk
 detail.
@@ -66,4 +66,4 @@ Banyak *committer*, pengembang, dan pengguna yang telah menyediakan laporan
 *bug* membantu kami membuat rilis ini. Terima kasih atas kontribusinya.
 
 Perawatan Ruby 2.6, termasuk rilis ini, didasarkan pada "Agreement for the Ruby
-stable version" dari Ruby Associaction.
+stable version" dari Ruby Association.

--- a/id/news/_posts/2021-04-05-ruby-2-7-3-released.md
+++ b/id/news/_posts/2021-04-05-ruby-2-7-3-released.md
@@ -13,7 +13,7 @@ Rilis ini mencakup perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk lebih detail.
 
 * [CVE-2021-28965: Kerentanan XML round-trip pada REXML]({% link id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
-* [CVE-2021-28966: Path traversal in Tempfile on Windows]({% link en/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md %})
+* [CVE-2021-28966: Path traversal pada Tempfile di Windows]({% link id/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md %})
 
 Cek [commit logs](https://github.com/ruby/ruby/compare/v2_7_2...v2_7_3) untuk
 detail.

--- a/id/news/_posts/2021-04-05-ruby-3-0-1-released.md
+++ b/id/news/_posts/2021-04-05-ruby-3-0-1-released.md
@@ -13,7 +13,7 @@ Rilis ini memuat perbaikan keamanan.
 Mohon cek topik-topik di bawah ini untuk lebih detail.
 
 * [CVE-2021-28965: Kerentanan XML round-trip pada REXML]({% link id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md %})
-* [CVE-2021-28966: Path traversal in Tempfile on Windows]({% link en/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md %})
+* [CVE-2021-28966: Path traversal pada Tempfile di Windows]({% link id/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md %})
 
 Lihat [commit logs](https://github.com/ruby/ruby/compare/v3_0_0...v3_0_1)
 untuk detail.


### PR DESCRIPTION
Some Ruby released news posts contain links to another post. Previously, the post wasn't translated to Bahasa Indonesia. It's been translated now. So, this PR fixes that by changing title and link to translated posts.