### PR TITLE
Fix tag name for Ruby 3.1.0-preview1

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -24,7 +24,7 @@
 - version: 3.1.0-preview1
   date: 2021-11-09
   post: /en/news/2021/11/09/ruby-3-1-0-preview1-released/
-  tag: ruby_3_1_0_preview1
+  tag: v3_1_0_preview1
   stats:
     files_changed: 2963
     insertions: 529321


### PR DESCRIPTION
Links are broken in the release page because the release tag is `v3_1_0_preview1` and not `ruby_3_1_0_preview1`.