### PR TITLE
Add Remote Ruby podcasts

### DIFF
--- a/en/community/podcasts/index.md
+++ b/en/community/podcasts/index.md
@@ -14,6 +14,10 @@ Listen to news, interviews, and discussions about Ruby and its community.
 : The Ruby on Rails Podcast, a weekly conversation about Ruby on Rails,
   open source software, and the programming profession.
 
+[Remote Ruby][remote_ruby]
+: Virtual meetup turned podcast, Remote Ruby celebrates and highlights
+  the Ruby community in an informal setting.
+
 ### Getting Involved
 
 Podcast hosts are always looking for guests. If you have some Ruby
@@ -21,5 +25,6 @@ wisdom to share, get in touch with the creators of these shows.
 
 You can also start your own Ruby podcast and get added to this list!
 
+[remote_ruby]: https://remoteruby.transistor.fm/
 [rorpodcast]: http://5by5.tv/rubyonrails
 [rogues]: https://devchat.tv/ruby-rogues


### PR DESCRIPTION
After 154 episodes released, I think it is safe to include Remote Ruby
in this list. There is a ton of great Ruby-based content being created
on the podcast and they were even included in the podcast panel
at RubyConf 2021.