### PR TITLE
Japanese translation of "CVE-2021-41819: Cookie Prefix Spoofing in CGI::Cookie.parse"

### DIFF
--- a/ja/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
+++ b/ja/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "CVE-2021-41819: CGI::Cookie.parse 内の Cookie プレフィックスの偽装"
+author: "mame"
+translator: "jinroq"
+date: 2021-11-24 12:00:00 +0000
+tags: security
+lang: ja
+---
+
+CGI :: Cookie.parse 内で Cookie プレフィックスを偽装する脆弱性が発見されました。
+この脆弱性は、[CVE-2021-41819](https://nvd.nist.gov/vuln/detail/CVE-2021-41819) として登録されています。
+Ruby をアップグレードすることを強く推奨します。
+
+## 詳細
+
+古いバージョンの `CGI :: Cookie.parse` は、Cookie 名 に URL デコード を適用していました。
+ところが、悪意を持った攻撃者はこの脆弱性を利用して Cookie 名のセキュリティプレフィックスを偽装し、脆弱なアプリケーションをだます可能性があります。
+
+この修正により、 `CGI :: Cookie.parse` は Cookie 名をデコードしなくなりました。
+使用している Cookie 名に、URL エンコードされた英数字以外の文字が含まれている場合、これは非互換であることに注意してください。
+
+これは [CVE-2020-8184](https://nvd.nist.gov/vuln/detail/CVE-2020-8184) と同じ問題です。
+
+Ruby 2.7 もしくは 3.0 を使用している場合：
+
+* cgi gem をバージョン 0.3.1, 0.2.1, 0.1.1 もしくはこれら以上のバージョンに更新してください。 `gem update cgi` を使用して更新できます。bundler を使用している場合は、 `Gemfile` に `gem "cgi", "> = 0.3.1"` を追加してください。
+* または、Ruby を 2.7.5 または 3.0.3 に更新してください。
+
+Ruby 2.6 を使用している場合：
+
+* Rubyを 2.6.9 に更新してください。 *Ruby 2.6 以前では `gem update cgi` は使用できません。*
+
+## 影響を受けるバージョン
+
+* ruby​​ 2.6.8 以前（このバージョンでは `gem update cgi` を *使用できません*。）
+* cgi gem 0.1.0 以前（Ruby 2.7.5 より前にバンドルされている Ruby 2.7 系列）
+* cgi gem 0.2.0 以前（Ruby 3.0.3 より前にバンドルされている Ruby3.0 系列）
+* cgi gem 0.3.0 以前
+
+## クレジット
+
+この脆弱性情報は、[ooooooo_q](https://hackerone.com/ooooooo_q) 氏によって報告されました。
+
+## 更新履歴
+
+* 2021-11-24 21:00:00 (JST) 初版


### PR DESCRIPTION
Translate [https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md) to ja.