### PR TITLE
Japanese translation of "CVE-2021-41816: Buffer Overrun in CGI.escape_html"

### DIFF
--- a/ja/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
+++ b/ja/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
@@ -8,9 +8,6 @@ tags: security
 lang: ja
 ---
 
-A buffer overrun vulnerability was discovered in CGI.escape_html.
-This vulnerability has been assigned the CVE identifier [CVE-2021-41816](https://nvd.nist.gov/vuln/detail/CVE-2021-41816).
-We strongly recommend upgrading Ruby.
 CGI.escape_html 内のバッファオーバーランの脆弱性が発見されました。
 この脆弱性は、[CVE-2021-41816](https://nvd.nist.gov/vuln/detail/CVE-2021-41816)として登録されています。
 Ruby をアップグレードすることを強く推奨します。

--- a/ja/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
+++ b/ja/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "CVE-2021-41816: CGI.escape_html 内のバッファオーバーラン"
+author: "mame"
+translator: "jinroq"
+date: 2021-11-24 12:00:00 +0000
+tags: security
+lang: ja
+---
+
+A buffer overrun vulnerability was discovered in CGI.escape_html.
+This vulnerability has been assigned the CVE identifier [CVE-2021-41816](https://nvd.nist.gov/vuln/detail/CVE-2021-41816).
+We strongly recommend upgrading Ruby.
+CGI.escape_html 内のバッファオーバーランの脆弱性が発見されました。
+この脆弱性は、[CVE-2021-41816](https://nvd.nist.gov/vuln/detail/CVE-2021-41816)として登録されています。
+Ruby をアップグレードすることを強く推奨します。
+
+## 詳細
+
+`long` 型が 4 バイトかかるプラットフォーム（典型的なものは Windows）で非常に大きな文字列（700 MB 以上）を `CGI.escape_html` に渡すと、バッファオーバーフローを引き起こす脆弱性があります。
+
+cgi gem をバージョン 0.3.1, 0.2.1, 0.1.1 もしくはこれら以上のバージョンに更新してください。`gem update cgi` を使用して更新できます。bundler を使用している場合は、 `Gemfile` に `gem "cgi", "> = 0.3.1"` を追加してください。
+または、Rubyを 2.7.5 または 3.0.3 に更新してください。
+
+この問題は Ruby 2.7 以降で発見されたので、Ruby 2.6 でバンドルされている cgi バージョンには脆弱性はありません。
+
+## 影響を受けるバージョン
+
+* cgi gem 0.1.0 以前（Ruby 2.7.5 より前にバンドルされている Ruby 2.7 系列）
+* cgi gem 0.2.0 以前（Ruby 3.0.3 より前にバンドルされている Ruby 3.0 系列）
+* cgi gem 0.3.0 以前
+
+## クレジット
+
+この脆弱性情報は、[chamal](https://hackerone.com/chamal) 氏によって報告されました。
+
+## 更新履歴
+
+* 2021-11-24 21:00:00 (JST) 初版


### PR DESCRIPTION
Translate [https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md) to ja.