### PR TITLE
Translate "CVE-2021-28966: Path traversal in Tempfile on Windows" (ja)

### DIFF
--- a/ja/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md
+++ b/ja/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md
@@ -1,0 +1,36 @@
+---
+layout: news_post
+title: "CVE-2021-28966: Windows 版 Tempfile 内のパストラバーサルについて"
+author: "mame"
+translator: "jinroq"
+date: 2021-04-05 12:00:00 +0000
+tags: security
+lang: ja
+---
+
+Windows 版 Ruby にバンドルされている tmpdir ライブラリには、意図しないディレクトリを作成してしまう脆弱性が発見されました。
+また、Windows 版 Ruby にバンドルされている tempfile ライブラリは、内部で tmpdir を使用しているため同様の脆弱性があります。
+この脆弱性は [CVE-2021-28966](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28966) として登録されています。
+
+## 詳細
+
+tmpdir ライブラリで導入された `Dir.mktmpdir` メソッドは、第一引数に作成するディレクトリ名のプレフィックスとサフィックスを受け取ることができます。
+プレフィックスには相対ディレクトリ指定子 `"..\\"` を含めることができるため、このメソッドは任意のディレクトリを対象にすることができます。
+したがって、スクリプトが外部入力をプレフィックスとして受け取り、対象のディレクトリに不適切なアクセス許可がある、もしくは、ruby プロセスに不適切な権限がある場合に、攻撃者は任意のディレクトリに対してディレクトリやファイルを作成することができます。
+
+同じ脆弱性が [CVE-2018-6914](https://www.ruby-lang.org/en/news/2018/03/28/unintentional-file-and-directory-creation-with-directory-traversal-cve-2018-6914/) として登録されていますが、Windows 版の対応が不十分でした。
+
+影響を受けるバージョンの Ruby を利用している全ユーザーは、すぐにアップグレードする必要があります。
+
+## 影響を受けるバージョン
+
+* Ruby 2.7.2 以前
+* Ruby 3.0.0
+
+## クレジット
+
+この脆弱性情報は [Bugdiscloseguys](https://hackerone.com/bugdiscloseguys) 氏によって報告されました。
+
+## 更新履歴
+
+* 2021-04-05 21:00:00 (JST) 初版


### PR DESCRIPTION
Translate [https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2021-04-05-tempfile-path-traversal-on-windows-cve-2021-28966.md) to ja.