### PR TITLE
Translate "CVE-2020-25613: Potential HTTP Request Smuggling Vulnerability in WEBrick" (ja)

### DIFF
--- a/ja/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
+++ b/ja/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
@@ -1,0 +1,38 @@
+---
+layout: news_post
+title: "CVE-2020-25613: WEBrick 内の潜在的な HTTP リクエストスマグリングの脆弱性について "
+author: "mame"
+translator: "jinroq"
+date: 2020-09-29 06:30:00 +0000
+tags: security
+lang: ja
+---
+
+WEBrick 内で潜在的な HTTP リクエストスマグリングの脆弱性が発見されました。
+この脆弱性は [CVE-2020-25613](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613) として登録されています。
+webrick gem をアップグレードすることを強く推奨します。
+
+## 詳細
+
+WEBrick は、無効な Transfer-Encoding ヘッダーに対して寛容すぎました。
+これは WEBrick と一部の HTTP プロキシサーバー間で一貫性のない解釈が発生し、攻撃者が HTTP リクエストを”スマグリング（smuggle）”する可能性があります。
+詳細は [CWE-444](https://cwe.mitre.org/data/definitions/444.html) を参照してください。
+
+webric gem を 1.6.1 以降に更新してください。
+`gem update webrick` を実行すれば更新できます。
+bundler を使用している場合は、`Gemfile` に `gem "webrick", ">= 1.6.1"` を追加してください。
+
+## 影響を受けるバージョン
+
+* webrick gem 1.6.0 以前
+* Ruby 2.7.1 以前のバージョンでバンドルされた webrick
+* Ruby 2.6.6 以前のバージョンでバンドルされた webrick
+* Ruby 2.5.8 以前のバージョンでバンドルされた webrick
+
+## クレジット
+
+この脆弱性情報は [piao](https://hackerone.com/piao) 氏によって報告されました。
+
+## 更新履歴
+
+* 2020-09-29 15:30:00 (JST) 初版


### PR DESCRIPTION
Translate [https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md) to ja.