### PR TITLE
Fix: Incorrect description (en, ja)

### DIFF
--- a/en/news/_posts/2021-12-25-ruby-3-1-0-released.md
+++ b/en/news/_posts/2021-12-25-ruby-3-1-0-released.md
@@ -61,7 +61,7 @@ test.rb:1:in `<main>': undefined method `time' for 1:Integer (NoMethodError)
 Did you mean?  times
 ```
 
-Currently, only `NameError` is supported.
+Currently, only `NoMethodError` is supported.
 
 This gem is enabled by default. You can disable it by using a command-line option `--disable-error_highlight`. See [the repository](https://github.com/ruby/error_highlight) in detail.
 

--- a/ja/news/_posts/2021-12-25-ruby-3-1-0-released.md
+++ b/ja/news/_posts/2021-12-25-ruby-3-1-0-released.md
@@ -60,7 +60,7 @@ test.rb:1:in `<main>': undefined method `time' for 1:Integer (NoMethodError)
 Did you mean?  times
 ```
 
-現在のところ、位置が表示されるのは`NameError`のみです。
+現在のところ、位置が表示されるのは`NoMethodError`のみです。
 
 このgemはデフォルトで有効になっています。`--disable-error_highlight`コマンドラインオプションを指定することで無効化できます。詳しくは[ruby/error_highlightリポジトリ](https://github.com/ruby/error_highlight)を見てください。
 


### PR DESCRIPTION
error_highlight is shown in NoMethodError, not NameError.