### PR TITLE
Translate 2022 Fukuoka Ruby Award Competition (id)

### DIFF
--- a/id/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
+++ b/id/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "2022 Fukuoka Ruby Award Competition - Peserta akan dinilai oleh Matz"
+author: "Fukuoka Ruby"
+translator: "meisyal"
+date: 2021-08-03 00:00:00 +0000
+lang: id
+---
+
+Penggemar Ruby terhormat,
+
+Pemerintah Fukuoka, Jepang, bersama dengan "Matz" Matsumoto ingin mengundang
+Anda untuk mengikuti kompetisi Ruby berikut. Jika Anda pernah mengembangkan
+sebuah program Ruby yang menarik, sangat disarankan untuk mengikuti kompetisi
+ini.
+
+2022 Fukuoka Ruby Award Competition - Hadiah Utama - 1 Juta Yen!
+
+Batas akhir pendaftaran: 3 Desember 2021
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz dan sebuah grup panelis akan memilih pemenang kompetisi ini. Hadiah utama
+dari kompetisi ini adalah 1 juta Yen. Hadiah pemenang sebelumnya meliputi
+*Rhomobile* (USA) dan APEC *Climate Center* (Korea).
+
+Program-program yang dimasukkan dalam kompetisi ini tidak harus sepenuhnya
+ditulis dalam bahasa Ruby, namun program harus mengambil kelebihan dari
+karakteristik unik yang diberikan oleh Ruby.
+
+Program harus telah dikembangkan atau diperbarui selama setahun terakhir.
+Mohon kunjungi laman Fukuoka berikut untuk mendaftar.
+
+[http://www.digitalfukuoka.jp/events/242](http://www.digitalfukuoka.jp/events/242)
+
+Silakan kirim formulir pengajuan ke award@f-ruby.com
+
+"Matz akan mengetes dan mengulas kode Anda sepenuhnya, sehingga ini sangat
+berarti untuk mengajukan! Kompetisi ini gratis untuk diikuti."
+
+Terima kasih.


### PR DESCRIPTION
The changes are basically the title. Please, help to review the translation.

Thank you.