### PR TITLE
Translate CVE-2021-41816: Buffer Overrun in CGI.escape_html (id)

### DIFF
--- a/id/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
+++ b/id/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
@@ -1,0 +1,44 @@
+---
+layout: news_post
+title: "CVE-2021-41816: Buffer Overrun pada CGI.escape_html"
+author: "mame"
+translator: "meisyal"
+date: 2021-11-24 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Sebuah kerentanan *buffer overrun* telah ditemukan pada CGI.escape_html.
+Kerentanan ini telah ditetapkan dengan penanda CVE
+[CVE-2021-41816](https://nvd.nist.gov/vuln/detail/CVE-2021-41816).
+Kami sangat merekomendasikan Anda untuk memperbarui Ruby.
+
+## Detail
+
+Sebuah kerentanan keamanan menyebabkan *buffer overflow* ketika Anda
+mengirimkan sebuah *string* yang sangat besar (> 700 MB) ke `CGI.escape.html`
+pada sebuah *platform* yang mana tipe `long` menerima 4 *bytes*, biasanya,
+Windows.
+
+Mohon perbarui *cgi gem* ke versi 0.3.1, 0.2.1, dan 0.1.1 atau setelahnya.
+Anda dapat menggunakan `gem update cgi` untuk memperbarui. Jika Anda menggunakan
+*bundler*, mohon tambahkan `gem "cgi", ">= 0.3.1"` pada `Gemfile`. Alternatif
+lain, perbarui Ruby ke 2.7.5 atau 3.0.3.
+
+Kerentanan ini muncul sejak Ruby 2.7, sehingga versi *cgi* yang di-*bundle*
+dengan Ruby 2.6 tidak rentan.
+
+## Versi terimbas
+
+* *cgi gem* 0.1.0 atau sebelumnya (yang di-*bundle* dengan rangkaian Ruby 2.7 sebelum Ruby 2.7.5)
+* *cgi gem* 0.2.0 atau sebelumnya (yang di-*bundle* dengan rangkaian Ruby 3.0 sebelum Ruby 3.0.3)
+* *cgi gem* 0.3.0 atau sebelumnya
+
+## Rujukan
+
+Terima kasih kepada [chamal](https://hackerone.com/chamal) yang telah
+menemukan kerentanan ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2021-11-24 12:00:00 (UTC)


### PR DESCRIPTION
Please, help to review this translation.

Thank you.