### PR TITLE
Fix cgi gem version in CVE-2021-41816 news post (translations)

### DIFF
--- a/en/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
+++ b/en/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
@@ -16,7 +16,7 @@ We strongly recommend upgrading Ruby.
 
 A security vulnerability that causes buffer overflow when you pass a very large string (> 700 MB) to `CGI.escape_html` on a platform where `long` type takes 4 bytes, typically, Windows.
 
-Please update the cgi gem to version 0.3.1, 0.2,1, and 0.1,1 or later. You can use `gem update cgi` to update it. If you are using bundler, please add `gem "cgi", ">= 0.3.1"` to your `Gemfile`.
+Please update the cgi gem to version 0.3.1, 0.2.1, and 0.1.1 or later. You can use `gem update cgi` to update it. If you are using bundler, please add `gem "cgi", ">= 0.3.1"` to your `Gemfile`.
 Alternatively, please update Ruby to 2.7.5 or 3.0.3.
 
 This issue has been introduced since Ruby 2.7, so the cgi version bundled with Ruby 2.6 is not vulnerable.

--- a/es/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
+++ b/es/news/_posts/2021-11-24-buffer-overrun-in-cgi-escape_html-cve-2021-41816.md
@@ -20,7 +20,7 @@ Una vulnerabilidad de seguridad que causa desbordamientos de búfer cuando
 el usuario pasa una cadenas muy grande (> 700MB) a `CGI.escape_html` en
 una plataforma donde el tipo `long` emplee 4 bytes, tipicamente, Windows.
 
-Por favor actualice la gema cgi a la versión 0.3.1, 0.2,1, y 0.1,1 o posterior.
+Por favor actualice la gema cgi a la versión 0.3.1, 0.2.1, y 0.1.1 o posterior.
 Puede usar `gem update cgi` para actualizarla. Si está usando bundler,
 por favor añada `gem "cgi", ">= 0.3.1"` a su archivo `Gemfile`.
 Alternativamente, por favor actualice Ruby a 2.7.5 o a 3.0.3.


### PR DESCRIPTION
I found there were some typos in `cgi` gem versions which patched CVE-2021-41816. The versions were previously written like `0.2,1` and `0.1,1`. The minor version and patch version are separated with comma. The correct versions should be `0.2.1` and `0.1.1`.