### PR TITLE
Added links for each closed Ruby 3.1.1 issue

### DIFF
--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -12,7 +12,7 @@ Ruby 3.1.1 has been released.
 This is the first TEENY version release of the stable 3.1 series.
 
 * [error_highlight does not work for -e option](https://bugs.ruby-lang.org/issues/18434)
-* [YJIT breaks Rails collection caching](https://bugs.ruby-lang.org/issues/18453)
+* [Fix YJIT passing method arguments in the wrong order when keyword argument and default arguments are mixed. Breaks Rails collection caching](https://bugs.ruby-lang.org/issues/18453)
 * [Segmentation fault when missing Warning#warn method](https://bugs.ruby-lang.org/issues/18458)
 * [Fix Pathname dot directory globbing](https://bugs.ruby-lang.org/issues/18436)
 * [Fix default --jit-max-cache in ruby --help](https://bugs.ruby-lang.org/issues/18469)

--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -11,7 +11,28 @@ Ruby 3.1.1 has been released.
 
 This is the first TEENY version release of the stable 3.1 series.
 
-See the [commit logs](https://github.com/ruby/ruby/compare/v3_1_0...v3_1_1) for details.
+* [error_highlight does not work for -e option](https://bugs.ruby-lang.org/issues/18434)
+* [YJIT breaks Rails collection caching](https://bugs.ruby-lang.org/issues/18453)
+* [Segmentation fault when missing Warning#warn method](https://bugs.ruby-lang.org/issues/18458)
+* [Fix Pathname dot directory globbing](https://bugs.ruby-lang.org/issues/18436)
+* [Backport c764e368bd9c0487e6cc97f8a62e0e0e99a0d7c5](https://bugs.ruby-lang.org/issues/18469)
+* [3.1.0-dev `include` cause Module to be marked as initialized](https://bugs.ruby-lang.org/issues/18292)
+* [Tutorial Link for Optionparser is broken](https://bugs.ruby-lang.org/issues/18468)
+* [Yielding an element for Enumerator in another thread dumps core](https://bugs.ruby-lang.org/issues/18475)
+* [Segmentation fault with ruby 3.1.0 in `active_decorator`](https://bugs.ruby-lang.org/issues/18489)
+* [Fiber内でProcess.daemonをするとSegmentation faultが起こる](https://bugs.ruby-lang.org/issues/18497)
+* [0 << (2\*\*40) is NoMemoryError but 0 << (2\*\*80) is 0](https://bugs.ruby-lang.org/issues/18517)
+* [IO read/write/wait hook bug fixes.](https://bugs.ruby-lang.org/issues/18443)
+* [Memory leak on aliasing method to itself](https://bugs.ruby-lang.org/issues/18516)
+* [error: use of undeclared identifier 'MAP_ANONYMOUS'](https://bugs.ruby-lang.org/issues/18556)
+* [\[BUG\] try to mark T_NONE object in RubyVM::InstructionSequence. load_from_binary](https://bugs.ruby-lang.org/issues/18501)
+* [throw_data passed to rescue through require](https://bugs.ruby-lang.org/issues/18562)
+* [Please Backport 77fe1fca0abb56f7f07725c0a3803d53a315c853 from the ipaddr gem to Ruby 3.1](https://bugs.ruby-lang.org/issues/18570)
+* [Fixed path for ipaddr.rb](https://github.com/ruby/ruby/pull/5533)
+* [Merge RubyGems-3.3.7 and Bundler-2.3.7](https://github.com/ruby/ruby/pull/5543)
+* [Hash#shift を繰り返していると ruby が無応答になる。](https://bugs.ruby-lang.org/issues/18578)
+
+See the [commit logs](https://github.com/ruby/ruby/compare/v3_1_0...v3_1_1) for further details.
 
 ## Download
 

--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -30,7 +30,7 @@ This is the first TEENY version release of the stable 3.1 series.
 * [Please Backport 77fe1fca0abb56f7f07725c0a3803d53a315c853 from the ipaddr gem to Ruby 3.1](https://bugs.ruby-lang.org/issues/18570)
 * [Fixed path for ipaddr.rb](https://github.com/ruby/ruby/pull/5533)
 * [Merge RubyGems-3.3.7 and Bundler-2.3.7](https://github.com/ruby/ruby/pull/5543)
-* [Hash#shift を繰り返していると ruby が無応答になる。](https://bugs.ruby-lang.org/issues/18578)
+* [Hang when repeating Hash#shift against a empty Hash](https://bugs.ruby-lang.org/issues/18578)
 
 See the [commit logs](https://github.com/ruby/ruby/compare/v3_1_0...v3_1_1) for further details.
 

--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -15,7 +15,7 @@ This is the first TEENY version release of the stable 3.1 series.
 * [YJIT breaks Rails collection caching](https://bugs.ruby-lang.org/issues/18453)
 * [Segmentation fault when missing Warning#warn method](https://bugs.ruby-lang.org/issues/18458)
 * [Fix Pathname dot directory globbing](https://bugs.ruby-lang.org/issues/18436)
-* [Backport c764e368bd9c0487e6cc97f8a62e0e0e99a0d7c5](https://bugs.ruby-lang.org/issues/18469)
+* [Fix default --jit-max-cache in ruby --help](https://bugs.ruby-lang.org/issues/18469)
 * [3.1.0-dev `include` cause Module to be marked as initialized](https://bugs.ruby-lang.org/issues/18292)
 * [Tutorial Link for Optionparser is broken](https://bugs.ruby-lang.org/issues/18468)
 * [Yielding an element for Enumerator in another thread dumps core](https://bugs.ruby-lang.org/issues/18475)

--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -20,7 +20,7 @@ This is the first TEENY version release of the stable 3.1 series.
 * [Tutorial Link for Optionparser is broken](https://bugs.ruby-lang.org/issues/18468)
 * [Yielding an element for Enumerator in another thread dumps core](https://bugs.ruby-lang.org/issues/18475)
 * [Segmentation fault with ruby 3.1.0 in `active_decorator`](https://bugs.ruby-lang.org/issues/18489)
-* [Fiber内でProcess.daemonをするとSegmentation faultが起こる](https://bugs.ruby-lang.org/issues/18497)
+* [Segfault on use of Process.daemon in a Fiber](https://bugs.ruby-lang.org/issues/18497)
 * [0 << (2\*\*40) is NoMemoryError but 0 << (2\*\*80) is 0](https://bugs.ruby-lang.org/issues/18517)
 * [IO read/write/wait hook bug fixes.](https://bugs.ruby-lang.org/issues/18443)
 * [Memory leak on aliasing method to itself](https://bugs.ruby-lang.org/issues/18516)

--- a/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
+++ b/en/news/_posts/2022-02-18-ruby-3-1-1-released.md
@@ -27,7 +27,7 @@ This is the first TEENY version release of the stable 3.1 series.
 * [error: use of undeclared identifier 'MAP_ANONYMOUS'](https://bugs.ruby-lang.org/issues/18556)
 * [\[BUG\] try to mark T_NONE object in RubyVM::InstructionSequence. load_from_binary](https://bugs.ruby-lang.org/issues/18501)
 * [throw_data passed to rescue through require](https://bugs.ruby-lang.org/issues/18562)
-* [Please Backport 77fe1fca0abb56f7f07725c0a3803d53a315c853 from the ipaddr gem to Ruby 3.1](https://bugs.ruby-lang.org/issues/18570)
+* [Fix `IpAddr#to_range` on frozen `IpAddr` instances.](https://bugs.ruby-lang.org/issues/18570)
 * [Fixed path for ipaddr.rb](https://github.com/ruby/ruby/pull/5533)
 * [Merge RubyGems-3.3.7 and Bundler-2.3.7](https://github.com/ruby/ruby/pull/5543)
 * [Hang when repeating Hash#shift against a empty Hash](https://bugs.ruby-lang.org/issues/18578)


### PR DESCRIPTION
* Add links to each Bug ID referenced in the commits between Ruby 3.1.0 and 3.1.1.