### PR TITLE
Remove links to rubylearning.com

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -45,10 +45,6 @@ ruby -v
 : Идвате от друг език? Независимо дали е C, C++, Java, Perl, PHP или
   Python, тази страница е за вас!
 
-[Learning Ruby][6]
-: Обширно ръководство за начинаещи, което дава солидна основа за
-  концепциите и конструкциите в Ruby.
-
 [Ruby Essentials][7]
 : Ruby Essentials е безплатна on-line книга, предоставяща лесен начин за
   научаването на Ruby.
@@ -132,7 +128,6 @@ ruby -v
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -27,11 +27,6 @@ the [installation guide](installation/) for help on installing Ruby.
   through stories, wit, and comics. Originally created by *why the lucky
   stiff*, this guide remains a classic for Ruby learners.
 
-[Learning Ruby][6]
-: A thorough collection of Ruby study notes for those who are new to the
-  language and in search of a solid introduction to Ruby’s concepts and
-  constructs.
-
 [Ruby Essentials][7]
 : A free on-line book designed to provide a concise
   and easy to follow guide to learning Ruby.
@@ -132,7 +127,6 @@ If you have questions about Ruby the
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -30,11 +30,6 @@ como instalar Ruby.
   *por qué la tenaz suerte*, esta guía sigue siendo un clásico para
   quienes aprenden Ruby.
 
-[Aprendiendo Ruby][6] (en inglés)
-: Una completa colección de notas de estudio para aquellos que son nuevos
-  en el lenguaje y que buscan una introducción solida a los conceptos
-  de Ruby y sus construcciones.
-
 [Lo esencial de Ruby][7] (en inglés)
 : Lo esencial de Ruby es un libro en línea libre, diseñado para dar una
   guía concisa y fácil de seguir para aprender Ruby.
@@ -146,7 +141,6 @@ comenzar.
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -71,11 +71,6 @@ pour les nombreuses façons d'obtenir Ruby.
   vous n’avez aucunes notions de programmation, commencez par là. Une
   traduction française est [disponible en PDF][7]
 
-[*Learning Ruby*][9]
-: Un ensemble cohérent de notes introductives sur la structure et la
-  logique qui prévalent en Ruby. Tout à fait indiqué pour se
-  familiariser avec le langage Ruby, ses us et coutumes, ses astuces.
-
 [*Ruby Essentials*][10]
 : Un *ebook* gratuit qui se veut synthétique et facile d’accès.
 
@@ -133,7 +128,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [5]: https://poignant.guide
 [6]: http://pine.fm/LearnToProgram/
 [7]: http://www.ruby-doc.org/docs/ApprendreProgrammer/Apprendre_%E0_Programmer.pdf
-[9]: http://rubylearning.com/
 [10]: http://www.techotopia.com/index.php/Ruby_Essentials
 [11]: http://www.meshplex.org/wiki/Ruby/Ruby_on_Rails_programming_tutorials
 [12]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -28,11 +28,6 @@ dapat membaca [panduan instalasi](installation/) untuk memasang Ruby.
   melalui cerita, humor cerdas, dan komik. Awalnya dibuat oleh *why the lucky
   stiff*, panduan ini tetap klasik untuk pelajar Ruby.
 
-[Learning Ruby][6]
-: Sebuah koleksi menyeluruh dari catatan pelajaran Ruby bagi mereka yang baru ke
-  bahasa Ruby dan sedang mencari pengenalan konsep dan konstruksi
-  Ruby.
-
 [Ruby Essentials][7]
 : Ruby Essentials adalah buku *online* gratis yang dirancang untuk memberikan
   panduan singkat dan mudah diikuti untuk belajar Ruby.
@@ -131,7 +126,6 @@ adalah tempat yang baik untuk memulai.
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/id/news/_posts/2008-04-30-berpindah-ke-ruby-1-9-2.md
+++ b/id/news/_posts/2008-04-30-berpindah-ke-ruby-1-9-2.md
@@ -14,14 +14,10 @@ yang dia miliki dan akan menunjukkan kepada siapapun tentang manfaat
 resource dalam Ruby yang masih belum terlalu memikat hingga saat ini.
 Presentasi Bruce menjelaskan banyak hal dari perubahan penunjuk.
 
-Berikut [interview dengan Bruce][3] oleh Satish Talim dari
-[RubyLearning.com][3] baru-baru ini.
-
-Sumber: [Ruby Inside: Migrating to Ruby 1.9][4]
+Sumber: [Ruby Inside: Migrating to Ruby 1.9][3]
 
 
 
 [1]: http://codefluency.com/articles/2008/04/13/migrating-to-ruby-1-9/
 [2]: http://scotlandonrails.com/
-[3]: http://rubylearning.com/blog/2008/04/18/ruby-interview-bruce-williams-of-fiveruns/
-[4]: http://www.rubyinside.com/migrating-to-ruby-19-876.html
+[3]: http://www.rubyinside.com/migrating-to-ruby-19-876.html

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -36,11 +36,6 @@ potrà venire comodo quando vorrai programmare in Ruby.
   programmazione? Sia che sia C, C++, Java, Perl PHP o Python, questo
   articolo è quello che fa per te.
 
-[Learning Ruby][6]
-: Una raccolta di appunti riguardanti Ruby per coloro che non conoscono
-  il linguaggio e sono alla ricerca di una solida introduzione ai
-  concetti e ai costrutti di Ruby. \[in inglese\]
-
 [Ruby Essentials][7]
 : Ruby Essentials è un libro gratuito online, pensato per essere una
   concisa guida facile da seguire per imparare Ruby. \[in inglese\]
@@ -131,7 +126,6 @@ iniziare.
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -31,10 +31,6 @@ Ruby를 배울 수 있는 매뉴얼과 튜토리얼, 코딩할 때 도움이 되
   책입니다. *Why the Lucky Stiff*의 저작물로 Ruby를 배우는 사람을 위한
   고전입니다.
 
-[Learning Ruby][6] (영문)
-: 새로 언어를 배우는 사람이나 Ruby의 개념과 구조를 검색하려는 사람들을 위한
-  Ruby 스터디 노트들입니다.
-
 [Ruby Essentials][7] (영문)
 : Ruby 에센셜은 간결하고 따라 하기 쉬운 가이드를 제공하도록 디자인된 무료
   온라인 책입니다.
@@ -135,7 +131,6 @@ Ruby를 코딩할 때 운영체제의 기본 편집기를 사용할 수 있습�
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -35,11 +35,6 @@ Znajdziesz tutaj odnośniki do podręczników, tutoriali i materiałów
   od tego czy jest to C, C++, Java, Perl, PHP lub Python, ten artykuł z
   pewnością Ci pomoże!
 
-[Learning Ruby][6]
-: Przekrojowa kolekcja notatek o Rubim dla nowych w stosunku
-  do języka, a także poszukujących solidnego wprowadzenia do koncepcji
-  i konstrukcji Rubiego.
-
 [Ruby Essentials][7]
 : Ruby Essentials to darmowa książka zaprojektowana by dostarczać
   zwięzłe i łatwe do naśladowania porady do nauki Rubiego.
@@ -135,7 +130,6 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -48,11 +48,6 @@ diversas maneiras de obter o Ruby.
 : Chegou ao Ruby por outra linguagem? Quer seja C, C++, Java, Perl,
   PHP ou Python, este artigo é para você!
 
-[Learning Ruby][6]
-: Uma coleção completa de estudos e notas sobre Ruby, para os
-  principiantes na linguagem e à procura de uma introdução sólida aos
-  conceitos e construtores de Ruby.
-
 [Ruby Essentials][7]
 : Ruby Essentials é um livro digital gratuito projetado para prover um
   guia conciso e fácil de seguir para o aprendiz de Ruby.
@@ -143,7 +138,6 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: http://why.carlosbrando.com/
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://aprendaaprogramar.rubyonrails.com.br/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -47,10 +47,6 @@ ruby -v
 : Пришли в мир Ruby из другого языка? Будь это C, C++, Java, Perl, PHP
   или Python – этот раздел вам поможет!
 
-[Learning Ruby][6]
-: Учебник по Ruby для тех, кто только пришел в мир Ruby и ищет
-  полноценное введение в концепты и конструкции языка.
-
 [Ruby Essentials][7]
 : Бесплатная онлайн-книга, предоставляющая краткое и легкое руководство
   для изучения Ruby.
@@ -141,7 +137,6 @@ ruby -v
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -34,11 +34,6 @@ isterseniz, [kurulum kılavuzu](installation/)nu okuyabilirsiniz.
   tarafından yazılmıştır, bu kılavuz Ruby’ye yeni başlayanlar için bir
   klasiktir.
 
-[Learning Ruby][6]
-: Dile yeni olanlar ve Ruby’nin kavramlarına ve yapısına sağlam bir
-  giriş yapmak isteyenler için Ruby öğrenci notlarından derlenmiş
-  mükemmel bir koleksiyon.
-
 [Ruby Essentials][7]
 : Ruby Essentials, Ruby öğrenmek için öz ve takip etmesi kolay şekilde
   tasarlanan ücretsiz bir çevrimiçi kitaptır.
@@ -144,7 +139,6 @@ olacaktır.
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -47,11 +47,6 @@ việc cài đặt Ruby.
 : Bạn đến với Ruby từ ngôn ngữ khác? Bất kể nó là C, C++, Java,
   Perl, PHP hay Python, bài viết này sẽ giải quyết cho bạn.
 
-[Học về Ruby][6]
-: Một bộ sưu tập toàn diện về Ruby dành cho những người mới làm
-  quen với ngôn ngữ và tìm kiếm một sự giới thiệu vững chắc về các
-  khái niệm và cấu trúc của Ruby.
-
 [Ruby Essentials][7]
 : Ruby Essentials là một cuốn sách trực tuyến miễn phí hướng dẫn học Ruby dễ
   dàng và ngắn gọn.
@@ -141,7 +136,6 @@ là một nơi tuyệt vời.
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -35,9 +35,6 @@ ruby -v
 [从其它语言转到 Ruby](/zh_cn/documentation/ruby-from-other-languages/)
 : 你是从其他语言转到 Ruby 的吗？不管是 C、C++、Java、Perl、PHP，还是 Python，这里都有介绍！
 
-[学习 Ruby][6]
-: 这里汇集了许多 Ruby 初学者的学习笔记，对 Ruby 的概念和结构有全面的介绍。
-
 [Ruby Essentials][7]
 : Ruby Essentials 是一本免费在线书籍，旨在提供简洁易懂的 Ruby 学习指南。
 
@@ -113,7 +110,6 @@ ruby -v
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -24,9 +24,6 @@ lang: zh_tw
 : 非比尋常但玩味無窮的書，透過故事、幽默與漫畫來教會你 Ruby。由 *why the lucky
   stiff* 創作，本書是學習 Ruby 的經典大作。
 
-[Learning Ruby][6]
-: 蒐集了許多 Ruby 上手的經驗談，紮實的介紹了 Ruby 的概念與如何建構 Ruby 程式。
-
 [Ruby Essentials][7]
 : 免費的線上電子書，讓你可以一步步地學習 Ruby。
 
@@ -108,7 +105,6 @@ lang: zh_tw
 [1]: https://try.ruby-lang.org/
 [2]: http://rubykoans.com/
 [5]: https://poignant.guide
-[6]: http://rubylearning.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/
 [9]: http://www.ruby-doc.org/docs/ProgrammingRuby/


### PR DESCRIPTION
* 128df64f **Remove rubylearning.com from learning resources**
  
  [rubylearning.com][1] doesn't contain Ruby learning resources anymore.
  It is an affiliate site for page builders which probably profits from
  old backlinks from ruby-lang.org:
  
  https://rubylearning.com/affiliate-disclosure/
  
  [1]: https://rubylearning.com/

* a1a7694b **Remove a dead link to rubylearning.com**
  
  The link redirects to https://rubylearning.com/.

