### PR TITLE
Fix cgi gem version in CVE-2021-41819 news post (translations)

### DIFF
--- a/en/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
+++ b/en/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
@@ -24,7 +24,7 @@ This is the same issue of [CVE-2020-8184](https://nvd.nist.gov/vuln/detail/CVE-2
 
 If you are using Ruby 2.7 or 3.0:
 
-* Please update the cgi gem to version 0.3.1, 0.2,1, and 0.1,1 or later. You can use `gem update cgi` to update it. If you are using bundler, please add `gem "cgi", ">= 0.3.1"` to your `Gemfile`.
+* Please update the cgi gem to version 0.3.1, 0.2.1, and 0.1.1 or later. You can use `gem update cgi` to update it. If you are using bundler, please add `gem "cgi", ">= 0.3.1"` to your `Gemfile`.
 * Alternatively, please update Ruby to 2.7.5 or 3.0.3.
 
 If you are using Ruby 2.6:

--- a/es/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
+++ b/es/news/_posts/2021-11-24-cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819.md
@@ -32,7 +32,7 @@ Este es el mismo incidente [CVE-2020-8184](https://nvd.nist.gov/vuln/detail/CVE-
 
 Si está usando Ruby 2.7 o 3.0:
 
-* Por favor actualice la gema cgi a la versión 0.3.1, 0.2,1, y 0.1,1
+* Por favor actualice la gema cgi a la versión 0.3.1, 0.2.1, y 0.1.1
   o posterior.  Puede usar `gem update cgi` para actualizarla. Si usa
   bundler por favor agregue `gem "cgi", ">= 0.3.1"` a su `Gemfile`.
 * De manera alternativa, por favor actualice Ruby a 2.7.5 o 3.0.3.


### PR DESCRIPTION
I found another typo of `cgi` gem versions in CVE-2021-41819 news post. The versions are written like 0.2,1 and 0.1,1. The minor version and patch version are separated with comma. The correct versions should be 0.2.1 and 0.1.1.

This PR fixes the `cgi` versions.