### PR TITLE
[Data] Move Ruby 2.6 to EOL

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -19,12 +19,12 @@
   eol_date:
 
 - name: 2.7
-  status: normal maintenance
+  status: security maintenance
   date: 2019-12-25
-  eol_date:
+  eol_date: 2023-03-31
 
 - name: 2.6
-  status: security maintenance
+  status: eol
   date: 2018-12-25
   eol_date: 2022-03-31
 

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,17 +9,16 @@ stable:
 
   - 3.1.1
   - 3.0.3
-  - 2.7.5
 
 # optional
 security_maintenance:
 
-  - 2.6.9
+  - 2.7.5
 
 # optional
 eol:
 
-  - 2.5.9
+  - 2.6.9
 
 stable_snapshots:
 

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -43,13 +43,6 @@ stable_snapshots:
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.zip
     version: '2.7'
 
-  - branch: ruby_2_6
-    url:
-      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.zip
-    version: '2.6'
-
 nightly_snapshot:
 
   url:


### PR DESCRIPTION
As of 2022-03-31, Ruby 2.6 is EOL.
This PR marks this version as such, removes the previous 2.5 version from the list and moves 2.7 to security.