### PR TITLE
Set `img { max-width: 100%; }` for all devices

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -185,6 +185,10 @@ iframe {
   width: 100%;
 }
 
+#main img {
+  max-width: 100%;
+}
+
 #content-wrapper {
   width: 70%;
   display: table-cell;

--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -34,8 +34,6 @@
 
   #content-wrapper { padding: 0 24px; }
 
-  #main img { max-width: 100%; }
-
   #home-page-layout #intro {
     padding-right: 24px;
     padding-left: 24px;


### PR DESCRIPTION
Hi, congrats for [Ruby 3.2.0 preview](https://www.ruby-lang.org/en/news/2022/04/03/ruby-3-2-0-preview1-released/) released! 🎉 

I notice an image overflow on large screen devices in the article above.
So, this pull request aims to fix the image width CSS.

The following screenshots are taken on an 810-width device (e.g., iPad):

|Before|After|
|-|-|
|<img width="840" alt="image" src="https://user-images.githubusercontent.com/473530/161453451-396c9830-a44e-47f4-9574-eea0f77f3342.png">|<img width="841" alt="image" src="https://user-images.githubusercontent.com/473530/161453472-690010f6-baeb-4fa2-a153-6f5bc2ae465a.png">|

Feel free to close the pull request if I'm misguided. Thanks.