### PR TITLE
Remove snapshot-ruby_2_6

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -15,12 +15,10 @@ stable:
 # optional
 security_maintenance:
 
-  - 2.6.10
-
 # optional
 eol:
 
-  - 2.5.9
+  - 2.6.10
 
 stable_snapshots:
 

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -45,13 +45,6 @@ stable_snapshots:
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.zip
     version: '2.7'
 
-  - branch: ruby_2_6
-    url:
-      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_6.zip
-    version: '2.6'
-
 nightly_snapshot:
 
   url:


### PR DESCRIPTION
Remove snapshot-ruby_2_6 (see https://github.com/ruby/actions/commit/d6222b5dd743c9035a8f576d4b6ad73304cb6bc8 ),
and move 2.6.10 to eol section because <https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-6-10-released/> says that Ruby 2.6 reaches EOL.