### PR TITLE
Translate 2022-04-12 news (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md
+++ b/zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "CVE-2022-28739: String 轉換 Float 時緩衝區溢位"
+author: "mame"
+translator: "Vincent Lin"
+date: 2022-04-12 12:00:00 +0000
+tags: security
+lang: zh_tw
+---
+
+在 String 轉換 Float 的演算法中發現了一個緩衝區溢位漏洞。
+此風險的 CVE 識別號為 [CVE-2022-28739](https://nvd.nist.gov/vuln/detail/CVE-2022-28739)。
+我們強烈建議您升級 Ruby。
+
+## 風險細節
+
+由於 String 轉換 Float 所使用的內部函式有錯誤，一些轉換方法如 `Kernel#Float` 以及 `String#to_f` 會造成緩衝區過度讀取。
+典型的情況是程式會發生記憶體區段錯誤（Segmentation fault）而停止，但在少數的情況下，可能會造成非法讀取記憶體。
+
+請升級 Ruby 至 2.6.10、2.7.6、3.0.4 或 3.1.2。
+
+## 受影響版本
+
+* ruby 2.6.9 及更早版本
+* ruby 2.7.5 及更早版本
+* ruby 3.0.3 及更早版本
+* ruby 3.1.1 及更早版本
+
+## 致謝
+
+感謝 [piao](https://hackerone.com/piao?type=user) 回報此問題。
+
+## 歷史
+
+* 最初發佈於 2022-04-12 12:00:00 (UTC)

--- a/zh_tw/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
+++ b/zh_tw/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "CVE-2022-28738: Regexp 編譯時雙重釋放風險"
+author: "mame"
+translator: "Vincent Lin"
+date: 2022-04-12 12:00:00 +0000
+tags: security
+lang: zh_tw
+---
+
+在 Regexp 編譯時發現一個雙重釋放（Double free）的風險。
+此風險的 CVE 識別號為 [CVE-2022-28738](https://nvd.nist.gov/vuln/detail/CVE-2022-28738)。
+我們強烈建議您升級 Ruby。
+
+## 風險細節
+
+由於 Regexp 編譯過程中的一個錯誤，使用特定字串所生成的 Regexp 的物件，可能會造成同一個記憶體被釋放兩次，這就是所謂的「雙重釋放」漏洞。
+請注意，一般來說，建立及使用不受信任的輸入所生成的 Regexp 物件是不安全的。然而，在此次請況下，經過全面的評估，我們將其視為一個風險。
+
+請升級 Ruby 至 3.0.4 或 3.1.2。
+
+## 受影響版本
+
+* ruby 3.0.3 及更早版本
+* ruby 3.1.1 及更早版本
+
+請注意，ruby 2.6 系列以及 2.7 系列並未受到影響。
+
+## 致謝
+
+感謝 [piao](https://hackerone.com/piao?type=user) 回報此問題。
+
+## 歷史
+
+* 最初發佈於 2022-04-12 12:00:00 (UTC)

--- a/zh_tw/news/_posts/2022-04-12-ruby-2-6-10-released.md
+++ b/zh_tw/news/_posts/2022-04-12-ruby-2-6-10-released.md
@@ -1,25 +1,36 @@
 ---
 layout: news_post
-title: "Ruby 3.1.2 發布"
-author: "naruse and mame"
+title: "Ruby 2.6.10 發布"
+author: "usa and mame"
 translator: "Vincent Lin"
 date: 2022-04-12 12:00:00 +0000
 lang: zh_tw
 ---
 
-Ruby 3.1.2 已經發布了。
+Ruby 2.6.10 已經發布了。
 
-本次發布版本包含安全性修正。
+本發行版包含安全性修正。
 細節請參考下列內容。
 
-* [CVE-2022-28738: Regexp 編譯時雙重釋放風險]({%link zh_tw/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md %})
 * [CVE-2022-28739: String 轉換 Float 時緩衝區溢位]({%link zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md %})
 
-詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v3_1_1...v3_1_2)。
+此次發布也修復了一個在老舊編譯器上的編譯問題，和修復一個在 date 函式庫內的回歸問題。
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v2_6_9...v2_6_10)。
+
+在此次發布之後，Ruby 2.6 將結束維護，換句話說，這將會是 Ruby 2.6 系列的最後一個發行版本。
+即使有安全性風險，我們也不會發布 Ruby 2.6.11（假如發現許多嚴重的問題，才有可能會發布）。
+我們建議所有 Ruby 2.6 的使用者立刻開始遷移到 Ruby 3.1、3.0 或 2.7。
 
 ## 下載
 
-{% assign release = site.data.releases | where: "version", "3.1.2" | first %}
+{% assign release = site.data.releases | where: "version", "2.6.10" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
 
 * <{{ release.url.gz }}>
 

--- a/zh_tw/news/_posts/2022-04-12-ruby-2-7-6-released.md
+++ b/zh_tw/news/_posts/2022-04-12-ruby-2-7-6-released.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Ruby 2.7.6 發布"
+author: "usa and mame"
+translator: "Vincent Lin"
+date: 2022-04-12 12:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 2.7.6 已經發布了。
+
+本發行版包含安全性修正。
+細節請參考下列內容。
+
+* [CVE-2022-28739: String 轉換 Float 時緩衝區溢位]({%link zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md %})
+
+此次發布也包含了數個錯誤修復。
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v2_7_5...v2_7_6)。
+
+本次發布後，我們將結束 Ruby 2.7 的正常維護週期，進入安全性維護週期。
+這代表接下來除了安全性修正外，我們將不會移植任何錯誤修正回去 2.7 系列。
+
+在預計為期一年的安全性維護週期後，Ruby 2.7 將會停止官方支援，並進入最終階段。
+因此，我們建議您著手更新至新版本如 Ruby 3.0 或 3.1。
+
+## 下載
+
+{% assign release = site.data.releases | where: "version", "2.7.6" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 發布紀錄
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發佈，在此感謝所有人的貢獻。
+
+Ruby 2.7 的維護（包含本版本）是基於 Ruby 協會的「穩定版本協議」。

--- a/zh_tw/news/_posts/2022-04-12-ruby-3-0-4-released.md
+++ b/zh_tw/news/_posts/2022-04-12-ruby-3-0-4-released.md
@@ -1,13 +1,13 @@
 ---
 layout: news_post
-title: "Ruby 3.1.2 發布"
-author: "naruse and mame"
+title: "Ruby 3.0.4 發布"
+author: "nagachika and mame"
 translator: "Vincent Lin"
 date: 2022-04-12 12:00:00 +0000
 lang: zh_tw
 ---
 
-Ruby 3.1.2 已經發布了。
+Ruby 3.0.4 已經發布了。
 
 本次發布版本包含安全性修正。
 細節請參考下列內容。
@@ -15,11 +15,11 @@ Ruby 3.1.2 已經發布了。
 * [CVE-2022-28738: Regexp 編譯時雙重釋放風險]({%link zh_tw/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md %})
 * [CVE-2022-28739: String 轉換 Float 時緩衝區溢位]({%link zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md %})
 
-詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v3_1_1...v3_1_2)。
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v3_0_3...v3_0_4)。
 
 ## 下載
 
-{% assign release = site.data.releases | where: "version", "3.1.2" | first %}
+{% assign release = site.data.releases | where: "version", "3.0.4" | first %}
 
 * <{{ release.url.gz }}>
 

--- a/zh_tw/news/_posts/2022-04-12-ruby-3-1-2-released.md
+++ b/zh_tw/news/_posts/2022-04-12-ruby-3-1-2-released.md
@@ -1,0 +1,47 @@
+---
+layout: news_post
+title: "Ruby 3.1.2 發布"
+author: "naruse and mame"
+translator: "Vincent Lin"
+date: 2022-04-12 12:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 3.1.2 已經發布。
+
+本次發布版本包含安全性修正。
+細節請參考下列內容。
+
+* [CVE-2022-28738: Regexp 編譯時雙重釋放（Double free）]({%link en/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md %})
+* [CVE-2022-28739: String 轉換 Float 時緩衝區溢位]({%link en/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md %})
+
+詳細的變動請參閱[提交紀錄](https://github.com/ruby/ruby/compare/v3_1_1...v3_1_2)。
+
+## 下載
+
+{% assign release = site.data.releases | where: "version", "3.1.2" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 發布紀錄
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發佈，在此感謝所有人的貢獻。


### PR DESCRIPTION
Translate 2022-04-12 news (zh_tw)

- zh_tw/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md
- zh_tw/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
- zh_tw/news/_posts/2022-04-12-ruby-2-6-10-released.md
- zh_tw/news/_posts/2022-04-12-ruby-2-7-6-released.md
- zh_tw/news/_posts/2022-04-12-ruby-3-0-4-released.md
- zh_tw/news/_posts/2022-04-12-ruby-3-1-2-released.md

Thank you.