### PR TITLE
Use ruby installer package id in winget install command.

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -226,7 +226,7 @@ On Windows, you can use the [Windows Package Manager CLI](https://github.com/mic
 to install Ruby:
 
 {% highlight sh %}
-> winget install Ruby
+> winget install RubyInstallerTeam.Ruby
 {% endhighlight %}
 
 ### Chocolatey package manager for Windows

--- a/tr/documentation/installation/index.md
+++ b/tr/documentation/installation/index.md
@@ -218,7 +218,7 @@ yol olabilir.
 Windows'ta Ruby'yi kurmak için [Windows Paket Yöneticisi CLI](https://github.com/microsoft/winget-cli)'ını kullanabilirsiniz:
 
 {% highlight sh %}
-> winget install Ruby
+> winget install RubyInstallerTeam.Ruby
 {% endhighlight %}
 
 ### Diğer Dağıtımlar


### PR DESCRIPTION
This resolves #2844 to make the `winget install` example use the id `RubyInstallerTeam.Ruby` instead of the keyword `Rudy`.