### PR TITLE
Translate CVE-2022-28738 news post (id)

### DIFF
--- a/id/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
+++ b/id/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "CVE-2022-28738: Double free pada Regexp compilation"
+author: "mame"
+translator: "meisyal"
+date: 2022-04-12 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Sebuah kerentanan *double-free* ditemukan pada *Regexp compilation*.
+Kerentanan ini telah ditetapkan dengan penanda CVE
+[CVE-2022-28738](https://nvd.nist.gov/vuln/detail/CVE-2022-28738).
+Kami sangat merekomendasikan Anda untuk memperbarui Ruby.
+
+## Detail
+
+Disebabkan oleh sebuah *bug* pada *Regexp compilation*, pembuatan sebuah objek
+*Regexp* dengan suatu *string* yang dikemas sedemikian rupa dapat menyebabkan
+memori yang sama dibebaskan dua kali. Ini dikenal dengan kerentanan "double free".
+Perhatikan bahwa, secara umum, praktik untuk membuat dan menggunakan sebuah
+objek *Regexp* dari masukan yang tidak bisa dipercaya dianggap tidak aman.
+Namun, pada kasus ini, dengan mengikuti sebuah penilaian yang komprehensif, kami
+memperlakukan kasus ini sebagai sebuah kerentanan.
+
+Mohon perbarui Ruby ke 3.0.4 atau 3.1.2.
+
+## Versi terimbas
+
+* ruby 3.0.3 atau sebelumnya
+* ruby 3.1.1 atau sebelumnya
+
+Perhatikan bahwa rangkaian ruby 2.6 dan 2.7 tidak terimbas.
+
+## Rujukan
+
+Terima kasih kepada [piao](https://hackerone.com/piao?type=user) yang telah
+menemukan kerentanan ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2022-04-12 12:00:00 (UTC)

--- a/id/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
+++ b/id/news/_posts/2022-04-12-double-free-in-regexp-compilation-cve-2022-28738.md
@@ -16,7 +16,7 @@ Kami sangat merekomendasikan Anda untuk memperbarui Ruby.
 ## Detail
 
 Disebabkan oleh sebuah *bug* pada *Regexp compilation*, pembuatan sebuah objek
-*Regexp* dengan suatu *string* yang dikemas sedemikian rupa dapat menyebabkan
+*Regexp* dengan suatu *string* yang dikemas sedemikian rupa sehingga menyebabkan
 memori yang sama dibebaskan dua kali. Ini dikenal dengan kerentanan "double free".
 Perhatikan bahwa, secara umum, praktik untuk membuat dan menggunakan sebuah
 objek *Regexp* dari masukan yang tidak bisa dipercaya dianggap tidak aman.


### PR DESCRIPTION
This PR contains the translation of "CVE-2022-28738: Double free in Regexp compilation" post in Bahasa Indonesia. Please, review the translation.