### PR TITLE
Translate CVE-2022-28739 news post (id)

### DIFF
--- a/id/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md
+++ b/id/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md
@@ -1,0 +1,40 @@
+---
+layout: news_post
+title: "CVE-2022-28739: Buffer overrun pada konversi String-to-Float"
+author: "mame"
+translator: "meisyal"
+date: 2022-04-12 12:00:00 +0000
+tags: security
+lang: id
+---
+
+Sebuah kerentanan *buffer-overrun* telah ditemukan pada algoritma konversi dari
+sebuah *String* ke *Float*. Kerentanan ini telah ditetapkan dengan penanda CVE
+[CVE-2022-28739](https://nvd.nist.gov/vuln/detail/CVE-2022-28739).
+Kami sangat merekomendasikan untuk memperbarui Ruby.
+
+## Detail
+
+Disebabkan oleh sebuah *bug* pada fungsi internal yang mengonversi sebuah *String*
+ke *Float*, beberapa metode konversi, seperti `Kernel#Float` dan `String#to_f`,
+bisa menyebabkan *buffer over-read*. Konsekuensi khas dari kerentanan ini
+adalah berhentinya sebuah proses karena *segmentation fault*. Tetapi, dalam
+keadaan terbatas, kerentanan ini bisa dieksploitasi menjadi *illegal memory read*.
+
+Mohon perbarui Ruby ke 2.6.10, 2.7.6, 3.0.4, atau 3.1.2.
+
+## Versi terimbas
+
+* ruby 2.6.9 atau sebelumnya
+* ruby 2.7.5 atau sebelumnya
+* ruby 3.0.3 atau sebelumnya
+* ruby 3.1.1 atau sebelumnya
+
+## Rujukan
+
+Terima kasih kepada [piao](https://hackerone.com/piao?type=user) yang telah
+menemukan kerentanan ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2022-04-12 12:00:00 (UTC)


### PR DESCRIPTION
This PR contains the translation of "CVE-2022-28739: Buffer overrun in String-to-Float conversion" in Bahasa Indonesia.