### PR TITLE
Translate Ruby 2.6.10 released news post (id)

### DIFF
--- a/id/news/_posts/2022-04-12-ruby-2-6-10-released.md
+++ b/id/news/_posts/2022-04-12-ruby-2-6-10-released.md
@@ -1,0 +1,64 @@
+---
+layout: news_post
+title: "Ruby 2.6.10 Dirilis"
+author: "usa dan mame"
+translator: "meisyal"
+date: 2022-04-12 12:00:00 +0000
+lang: id
+---
+
+Ruby 2.6.10 telah dirilis.
+
+Rilis ini mencakup perbaikan keamanan.
+Mohon cek topik di bawah ini untuk lebih detail.
+
+* [CVE-2022-28739: Buffer overrun pada konversi String-to-Float]({%link id/news/_posts/2022-04-12-buffer-overrun-in-string-to-float-cve-2022-28739.md %})
+
+Rilis ini juga mencakup perbaikan *build* dari *compiler* lama dan perbaikan
+regresi pustaka *date*.
+Lihat [commit logs](https://github.com/ruby/ruby/compare/v2_6_9...v2_6_10)
+untuk detail.
+
+Setelah rilis ini, Ruby 2.6 akan *EOL*. Dengan kata lain, ini adalah rilis
+terakhir dari rangkaian Ruby 2.6.
+Kami tidak akan merilis Ruby 2.6.11 meskipun ada sebuah kerentanan keamanan
+ditemukan (kami bisa saja merilis jika sebuah regresi yang signifikan ditemukan).
+Kami merekomendasikan semua pengguna Ruby 2.6 untuk memulai migrasi ke Ruby 3.1,
+3.0, atau 2.7 segera.
+
+## Unduh
+
+{% assign release = site.data.releases | where: "version", "2.6.10" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Komentar Rilis
+
+Banyak *committer*, pengembang, dan pengguna yang telah menyediakan laporan
+*bug* membantu kami untuk membuat rilis ini. Terima kasih atas kontribusinya.


### PR DESCRIPTION
This PR contains the translation of "Ruby 2.6.10 Released" news post in Bahasa Indonesia.