### PR TITLE
Fix rexml gem update command in CVE-2021-28965 post (translations)

### DIFF
--- a/fr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/fr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -29,7 +29,7 @@ Si vous utilisez Ruby 2.5.8 ou inférieure :
 
 ## Versions concernées
 
-- Ruby 2.5.8 ou inférieure (vous <strong>NE POUVEZ PAS</strong> utiliser `gem upgrade rexml` pour ces versions.)
+- Ruby 2.5.8 ou inférieure (vous <strong>NE POUVEZ PAS</strong> utiliser `gem update rexml` pour ces versions.)
 - Ruby 2.6.7 ou inférieure
 - Ruby 2.7.2 ou inférieure
 - Ruby 3.0.1 ou inférieure

--- a/id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/id/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -36,7 +36,7 @@ Jika Anda sedang menggunakan Ruby 2.5.8 atau sebelumnya:
 
 ## Versi terimbas
 
-* Ruby 2.5.8 atau sebelumnya (Anda <strong>tidak dapat</strong> menjalankan `gem upgrade rexml` pada versi ini.)
+* Ruby 2.5.8 atau sebelumnya (Anda <strong>tidak dapat</strong> menjalankan `gem update rexml` pada versi ini.)
 * Ruby 2.6.6 atau sebelumnya
 * Ruby 2.7.2 atau sebelumnya
 * Ruby 3.0.0

--- a/ru/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/ru/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -29,7 +29,7 @@ lang: ru
 
 ## Уязвимые версии
 
-* Ruby 2.5.8 и ниже (Команда `gem upgrade rexml` вам <strong>НЕ</strong> поможет на этой версии.)
+* Ruby 2.5.8 и ниже (Команда `gem update rexml` вам <strong>НЕ</strong> поможет на этой версии.)
 * Ruby 2.6.6 и ниже
 * Ruby 2.7.2 и ниже
 * Ruby 3.0.0

--- a/tr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
+++ b/tr/news/_posts/2021-04-05-xml-round-trip-vulnerability-in-rexml-cve-2021-28965.md
@@ -33,7 +33,7 @@ Eğer Ruby 2.5.8 ya da öncesini kullanıyorsanız:
 
 ## Etkilenen sürümler
 
-* Ruby 2.5.8 ya da öncesi (Bu sürüm için `gem upgrade rexml` komutunu <strong>kullanamazsınız</strong>.)
+* Ruby 2.5.8 ya da öncesi (Bu sürüm için `gem update rexml` komutunu <strong>kullanamazsınız</strong>.)
 * Ruby 2.6.6 ya da öncesi
 * Ruby 2.7.2 ya da öncesi
 * Ruby 3.0.0


### PR DESCRIPTION
The previous fix was in PR #2748. But, it only covered the English version of CVE-2021-28965 post. This PR contains the same fix for other languages that have not been applied to.