### PR TITLE
Fixes broken build from source link

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -367,7 +367,7 @@ By default, this will install Ruby into `/usr/local`.
 To change, pass the `--prefix=DIR` option to the `./configure` script.
 
 You can find more information about building from source in the
-[Ruby README file][readme].
+[Building Ruby instructions][readme].
 
 Using the third-party tools or package managers might be a better idea,
 though, because the installed Ruby won't be managed by any tools.
@@ -389,7 +389,7 @@ though, because the installed Ruby won't be managed by any tools.
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /en/downloads/
 [installers]: /en/documentation/installation/#installers
-[readme]: https://github.com/ruby/ruby#how-to-compile-and-install
+[readme]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/es/documentation/installation/index.md
+++ b/es/documentation/installation/index.md
@@ -346,8 +346,8 @@ $ sudo make install
 Por defecto este comando va a instala Ruby en `/usr/local`. Para cambiar esto
 usa la opción `--prefix=DIR` con el script `./configure`.
 
-Puedes encontrar más información acerca de compilar desde fuente en el
-[archivo Ruby README][readme].
+Puedes encontrar más información acerca de cómo compilar el código fuente en las
+[Instrucciones de compilación de Ruby][readme].
 
 Usar herramientas de terceros o gestores de paquetes puede ser una mejor idea,
 ya que las versiones instaladas de esta manera no serán manejadas

--- a/es/documentation/installation/index.md
+++ b/es/documentation/installation/index.md
@@ -369,7 +369,7 @@ por ninguna otra herramienta.
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /en/downloads/
 [installers]: /en/documentation/installation/#installers
-[readme]: https://github.com/ruby/ruby#how-to-compile-and-install
+[readme]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/id/documentation/installation/index.md
+++ b/id/documentation/installation/index.md
@@ -348,5 +348,5 @@ diatur oleh alat bantu apapun.
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /id/downloads/
 [installers]: /id/documentation/installation/#installers
-[readme]: https://github.com/ruby/ruby#how-to-compile-and-install
+[readme]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about

--- a/id/documentation/installation/index.md
+++ b/id/documentation/installation/index.md
@@ -324,7 +324,7 @@ Secara otomatis, ini akan memasang Ruby pada `/usr/local`.
 Untuk mengubahnya, tambahkan opsi `--prefix=DIR` di dalam skrip `./configure`.
 
 Anda dapat menemukan informasi lebih lanjut terkait membangun dari kode
-sumber pada [Ruby README file][readme].
+sumber pada [instruksi membangun Ruby][readme].
 
 Meskipun begitu, menggunakan alat bantu pihak ketiga atau *package manager*
 mungkin adalah solusi yang terbaik, karena Ruby yang terpasang tidak akan

--- a/ko/documentation/installation/index.md
+++ b/ko/documentation/installation/index.md
@@ -346,7 +346,7 @@ $ sudo make install
 [terminal]: https://ko.wikipedia.org/wiki/%EB%8B%A8%EB%A7%90_%EC%97%90%EB%AE%AC%EB%A0%88%EC%9D%B4%ED%84%B0_%EB%AA%A9%EB%A1%9D
 [download]: /ko/downloads/
 [installers]: /ko/documentation/installation/#installers
-[readme]: https://github.com/ruby/ruby#how-to-compile-and-install
+[readme]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
 [wsl]: https://docs.microsoft.com/ko-kr/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/ko/documentation/installation/index.md
+++ b/ko/documentation/installation/index.md
@@ -323,7 +323,7 @@ $ sudo make install
 기본적으로, 이 명령어는 Ruby를 `/usr/local`에 설치합니다.
 변경하시려면 `./configure` 스크립트에 `--prefix=DIR` 옵션을 넘기세요.
 
-[Ruby README 파일][readme]에서 소스로부터 Ruby를 설치하는 법에 관련된
+[Ruby 빌드하기 문서][readme]에서 소스로부터 Ruby를 설치하는 법에 관련된
 추가 정보를 얻을 수 있습니다.
 
 서드파티 도구나 패키지 관리자를 사용하시는 것이 더 좋습니다.

--- a/tr/documentation/installation/index.md
+++ b/tr/documentation/installation/index.md
@@ -344,7 +344,7 @@ Varsayılan olarak, bu, Ruby'yi `/usr/local` içine kuracaktır. Değiştirmek i
 `./configure` betiğine `--prefix=DIR` seçeneğini geçirin.
 
 Kaynaktan inşa etme hakkında daha fazla bilgiyi
-[Ruby README dosyası][readme]nda bulabilirsiniz.
+[Ruby oluşturma talimatları][readme]nda bulabilirsiniz.
 
 Üçüncü taraf araçlar ya da paket yöneticileri kullanmak daha iyi bir fikir
 olabilir, çünkü kurulan Ruby herhangi bir araç tarafından yönetilmeyecektir.

--- a/tr/documentation/installation/index.md
+++ b/tr/documentation/installation/index.md
@@ -366,7 +366,7 @@ olabilir, çünkü kurulan Ruby herhangi bir araç tarafından yönetilmeyecekti
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /tr/downloads/
 [installers]: /tr/documentation/installation/#installers
-[readme]: https://github.com/ruby/ruby#how-to-compile-and-install
+[readme]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby


### PR DESCRIPTION
Resolves issue #2864. 

This change fixes a broken link on the `en`, `es`, `id`, `ko`, and `tr` Installation pages. I've updated the link text for the English version, but am unable to translate for the other languages.

The links now point to https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md instead of the broken https://github.com/ruby/ruby#how-to-compile-and-install

Translations:
- [x] `en`
- [x] `es`
- [x] `id`
- [x] `ko`
- [x] `tr`