### PR TITLE
Translate 2022 Fukuoka Ruby Award (ko)

### DIFF
--- a/ko/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
+++ b/ko/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
@@ -1,0 +1,32 @@
+---
+layout: news_post
+title: "2022 Fukuoka Ruby Award Competition - Entries to be judged by Matz"
+author: "Fukuoka Ruby"
+translator:
+date: 2021-08-03 00:00:00 +0000
+lang: en
+---
+
+Dear Ruby Enthusiasts,
+
+The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to invite you to enter the following Ruby competition. If you have developed an interesting Ruby program, please be encouraged to apply.
+
+2022 Fukuoka Ruby Award Competition - Grand Prize - 1 Million Yen!
+
+Entry Deadline: December 3, 2021
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
+
+Programs entered in the competition do not have to be written entirely in Ruby but should take advantage of the unique characteristics of Ruby.
+
+The program must have been developed or updated in the past year or so. Please visit the following Fukuoka website to enter.
+
+[http://www.digitalfukuoka.jp/events/242](http://www.digitalfukuoka.jp/events/242)
+
+Please email the application form to award@f-ruby.com
+
+"Matz will be testing and reviewing your source code thoroughly, so it's very meaningful to apply! The competition is free to enter."
+
+Thanks！

--- a/ko/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
+++ b/ko/news/_posts/2021-08-03-fukuoka-ruby-award-2022.md
@@ -1,32 +1,37 @@
 ---
 layout: news_post
-title: "2022 Fukuoka Ruby Award Competition - Entries to be judged by Matz"
+title: "2022 후쿠오카 Ruby 경진대회 - Matz가 심사합니다"
 author: "Fukuoka Ruby"
-translator:
+translator: "yous"
 date: 2021-08-03 00:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Dear Ruby Enthusiasts,
+루비스트 여러분께,
 
-The Government of Fukuoka, Japan together with "Matz" Matsumoto would like to invite you to enter the following Ruby competition. If you have developed an interesting Ruby program, please be encouraged to apply.
+일본 후쿠오카 현은 'Matz' 마츠모토 씨와 함께 여러분을 Ruby 경진대회에 초대합니다.
+흥미로운 Ruby 프로그램을 개발하셨다면 한번 지원해보세요.
 
-2022 Fukuoka Ruby Award Competition - Grand Prize - 1 Million Yen!
+2022 후쿠오카 Ruby 경진대회 - 대상 - 백만 엔!
 
-Entry Deadline: December 3, 2021
+접수 마감: 2021년 12월 3일
 
 ![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
 
-Matz and a group of panelists will select the winners of the Fukuoka Competition. The grand prize for the Fukuoka Competition is 1 million yen. Past grand prize winners include Rhomobile (USA) and APEC Climate Center (Korea).
+Matz를 포함한 패널들이 후쿠오카 경진대회의 우승자를 선택합니다.
+후쿠오카 경진대회의 대상 수상자에게는 백만 엔의 상금이 주어집니다.
+이전 우승자로는 Rhomobile(미국)과 APEC 기후 센터(한국)가 있습니다.
 
-Programs entered in the competition do not have to be written entirely in Ruby but should take advantage of the unique characteristics of Ruby.
+대회에 참가하는 프로그램이 완전히 Ruby로 작성될 필요는 없지만,
+Ruby의 특징을 활용해야 합니다.
 
-The program must have been developed or updated in the past year or so. Please visit the following Fukuoka website to enter.
+프로그램은 지난 1년 동안 개발되거나 업데이트된 것만이 유효합니다.
+참가를 원하신다면 다음 후쿠오카 웹사이트를 방문하세요.
 
 [http://www.digitalfukuoka.jp/events/242](http://www.digitalfukuoka.jp/events/242)
 
-Please email the application form to award@f-ruby.com
+지원서는 award@f-ruby.com으로 보내주세요.
 
-"Matz will be testing and reviewing your source code thoroughly, so it's very meaningful to apply! The competition is free to enter."
+"Matz는 코드를 주의깊게 테스트하고 읽어볼 것이므로, 지원할 만한 충분한 가치가 있을 것입니다! 대회 참가는 무료입니다."
 
-Thanks！
+감사합니다!


### PR DESCRIPTION
The actual diff: ef6aac39842429ac0ded7c163a0c19f1f8ed46f0