### PR TITLE
Add notice to vulnerabilities list with link to en version

### DIFF
--- a/de/security/index.md
+++ b/de/security/index.md
@@ -20,6 +20,11 @@ Distributoren, PaaS-Plattformen).
 
 ## Bekannte Schwachstellen
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Hier eine Liste kürzlich bekannt gewordener Probleme:
 
 {% include security_posts.html %}

--- a/en/security/index.md
+++ b/en/security/index.md
@@ -33,6 +33,15 @@ The members must be individual people, mailing lists are not permitted.
 
 ## Known issues
 
+{% comment %}
+Translations should include the following notice:
+
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+{% endcomment %}
+
 Here are recent issues:
 
 {% include security_posts.html %}

--- a/es/security/index.md
+++ b/es/security/index.md
@@ -27,6 +27,11 @@ Los miembros de la lista de correo son personas que proveen Ruby (contribuyentes
 
 ## Problemas conocidos
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 A continuación una lista de los problemas conocidos más recientes:
 
 {% include security_posts.html %}

--- a/fr/security/index.md
+++ b/fr/security/index.md
@@ -17,6 +17,11 @@ création d\'un patch résolvant la vulnérabilité.
 
 ## Alertes passées
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 {% include security_posts.html %}
 
 See [the English page](/en/security/) for prior security related posts.

--- a/id/security/index.md
+++ b/id/security/index.md
@@ -32,6 +32,11 @@ distributor, dan PaaS *platformer*).
 
 ## Isu-isu yang diketahui
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Berikut adalah isu-isu terkini:
 
 {% include security_posts.html %}

--- a/it/security/index.md
+++ b/it/security/index.md
@@ -16,6 +16,11 @@ essere stati risolti.
 
 ## Problemi conosciuti
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Ecco i problemi più recenti.
 
 {% include security_posts.html %}

--- a/ja/security/index.md
+++ b/ja/security/index.md
@@ -21,6 +21,11 @@ security@ruby-lang.org は非公開 ML で、報告された問題が確認さ�
 
 ## 既知のセキュリティ問題
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 新しいものから順に並べています。
 
 {% include security_posts.html %}

--- a/ko/security/index.md
+++ b/ko/security/index.md
@@ -19,6 +19,11 @@ security@ruby-lang.org ([the PGP public key](/security.asc))로 메일을 보내
 
 ## 알려진 취약점
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 다음과 같은 보안 취약점이 보고된 바 있습니다.
 
 {% include security_posts.html %}

--- a/pl/security/index.md
+++ b/pl/security/index.md
@@ -18,6 +18,11 @@ Członkami listy mailingowej są ludzie, którzy dostarczają Rubiego
 
 ## Znane problemy
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Tutaj są ostatnie problemy.
 
 {% include security_posts.html %}

--- a/pt/security/index.md
+++ b/pt/security/index.md
@@ -21,6 +21,11 @@ pessoas individuais, outras listas de e-mail não são permitidas.
 
 ## Problemas conhecidos
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Estes são os problemas recentes:
 
 {% include security_posts.html %}

--- a/ru/security/index.md
+++ b/ru/security/index.md
@@ -16,6 +16,11 @@ security@ruby-lang.org ([публичный ключ PGP](/security.asc)). Да�
 
 ## Известные проблемы
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Ниже перечислены недавние проблемы.
 
 {% include security_posts.html %}

--- a/tr/security/index.md
+++ b/tr/security/index.md
@@ -33,6 +33,11 @@ diğer Ruby gerçeklemelerinin sahipleri, dağıtıcılar, PaaS platformcuları)
 
 ## Bilinen sorunlar
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 İşte son sorunlar:
 
 {% include security_posts.html %}

--- a/vi/security/index.md
+++ b/vi/security/index.md
@@ -16,6 +16,11 @@ sau khi vá xong lỗi.
 
 ## Những lỗi được biết
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 Sau đây là những lỗi mới nhất:
 
 {% include security_posts.html %}

--- a/zh_cn/security/index.md
+++ b/zh_cn/security/index.md
@@ -21,6 +21,11 @@ lang: zh_cn
 
 ## 已知漏洞
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 以下是最近发现的一些漏洞。
 
 {% include security_posts.html %}

--- a/zh_tw/security/index.md
+++ b/zh_tw/security/index.md
@@ -19,6 +19,11 @@ lang: zh_tw
 
 ## 已知風險
 
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
 以下是近期風險：
 
 {% include security_posts.html %}


### PR DESCRIPTION
The list of known issues on the security page is incomplete for many translations. The notice on top of the list now points this out and also links to the comprehensive list on the English version of the security page.

The notices should be translated.

Closes #2668.