### PR TITLE
Fix missing sentence in ja installation documents

### DIFF
--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -10,7 +10,7 @@ Rubyでプログラミングする際に役立つドキュメントを紹介し�
 
 ### マニュアル
 
-各環境にRubyをインストールする方法は、 [ダウンロード](/ja/downloads) 及び [インストールガイド](/ja/installation) で解説しています。
+各環境にRubyをインストールする方法は、 [ダウンロード](downloads) 及び [インストールガイド](installation) で解説しています。
 
 また、現在有志の手により[リファレンスマニュアルの整備][rurema-wiki]が進行中です。
 成果物を[&lt;URL:https://docs.ruby-lang.org/ja/&gt;][doc-r-l-o]から閲覧できます。
@@ -166,3 +166,5 @@ Posted by Shugo Maeda on 26 May 2006
 [39]: http://kapeli.com/dash
 [atom]: https://atom.io/
 [vscode]: https://code.visualstudio.com/
+[downloads]: /ja/downloads/
+[installation]: /ja/documentation/installation/

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -240,6 +240,8 @@ $ sudo make install
 デフォルトでは、Ruby は `/usr/local` にインストールされます。
 これを変更するには、`--prefix=DIR` オプションを `./configure` スクリプト実行時に付けてください。
 
+ソースからのビルドに関する詳しい情報は [Building Ruby instructions][building-ruby] で見ることができます。
+
 しかしながら、サードパーティ製ツールかパッケージマネージャを使う方が良い考えです。
 何故なら、ソースからインストールされた Ruby はどのツールからも管理されないからです。
 
@@ -255,3 +257,4 @@ $ sudo make install
 [opensolaris-pkg]: http://opensolaris.org/os/project/pkg/
 [gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/
 [homebrew]: http://brew.sh/
+[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md


### PR DESCRIPTION
## what
In japanese document, this sentence (from en) is missing.

> You can find more information about building from source in the Ruby README file.

https://www.ruby-lang.org/en/documentation/installation/