### PR TITLE
Fix regexp string in Ruby 3.2.0 news

### DIFF
--- a/en/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
+++ b/en/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
@@ -81,7 +81,7 @@ Note that `Regexp.timeout` is a global configuration. If you want to use differe
 Regexp.timeout = 1.0
 
 # This regexp has no timeout
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # never interrupted
 ```

--- a/en/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
+++ b/en/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
@@ -84,7 +84,7 @@ Note that `Regexp.timeout` is a global configuration. If you want to use differe
 Regexp.timeout = 1.0
 
 # This regexp has no timeout
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # never interrupted
 ```

--- a/es/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
+++ b/es/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
@@ -127,7 +127,7 @@ de `Regexp.new`.
 Regexp.timeout = 1.0
 
 # Esta regexp no tiene tiempo límite
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # nunca se interrumpe
 ```

--- a/es/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
+++ b/es/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
@@ -131,7 +131,7 @@ de `Regexp.new`.
 Regexp.timeout = 1.0
 
 # Esta regexp no tiene tiempo límite
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # nunca se interrumpe
 ```

--- a/ja/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
+++ b/ja/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
@@ -80,7 +80,7 @@ Regexp.timeout = 1.0
 Regexp.timeout = 1.0
 
 # This regexp has no timeout
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # never interrupted
 ```

--- a/ja/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
+++ b/ja/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
@@ -83,7 +83,7 @@ Regexp.timeout = 1.0
 Regexp.timeout = 1.0
 
 # This regexp has no timeout
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # never interrupted
 ```

--- a/zh_cn/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
+++ b/zh_cn/news/_posts/2022-11-11-ruby-3-2-0-preview3-released.md
@@ -84,7 +84,7 @@ Regexp.timeout = 1.0
 Regexp.timeout = 1.0
 
 # 这个 Regexp 没有超时设置
-long_time_re = Regexp.new("^a*b?a*()\1$", timeout: Float::INFINITY)
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
 
 long_time_re =~ "a" * 50000 + "x" # 不会被中断
 ```


### PR DESCRIPTION
Replace double quote to single quote to fix regexp pattern ("\1" and '\1' are different):

```ruby
Regexp.new("^a*b?a*()\1$")
#=> /^a*b?a*()\x01$/

Regexp.new('^a*b?a*()\1$')
#=> /^a*b?a*()\1$/
```