### PR TITLE
Lock jekyll 4.2 because 4.3+ is too slow build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "~> 3.1.3"
 
 gem "rake"
-gem "jekyll", "~> 4.0"
+gem "jekyll", "~> 4.2.0"
 gem "rouge"
 
 gem "unicorn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     minitest (5.16.3)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     paint (2.3.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -100,6 +102,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,22 +15,21 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.1)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
-      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3, >= 2.3.1)
+      kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.4.0)
       pathutil (~> 0.9)
-      rouge (>= 3.0, < 5.0)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
-      terminal-table (>= 1.8, < 4.0)
-      webrick (~> 1.7)
+      terminal-table (~> 2.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -49,18 +48,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.8.0)
     minitest (5.16.3)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
     paint (2.3.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.1)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.4)
-    rack-protection (3.0.4)
+    rack-protection (3.0.5)
       rack
     rack-rewrite (1.5.1)
     rack-ssl (1.4.1)
@@ -71,18 +68,18 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (4.0.0)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     slop (4.9.3)
     spidr (0.6.1)
       nokogiri (~> 1.3)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     tidy_ffi (1.0.1)
       ffi (~> 1.2)
-    unicode-display_width (2.3.0)
+    unicode-display_width (1.8.0)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -102,10 +99,10 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
 
 DEPENDENCIES
-  jekyll (~> 4.0)
+  jekyll (~> 4.2.0)
   lanyon
   minitest
   rack-protection
@@ -118,7 +115,7 @@ DEPENDENCIES
   validate-website (~> 1.6)
 
 RUBY VERSION
-   ruby 3.1.3p185
+   ruby 3.1.4p186
 
 BUNDLED WITH
-   2.3.10
+   2.3.26


### PR DESCRIPTION
After upgrading jekyll 4.3, build time is over 20min. We should downgrade jekyll 4.2 temporally.

ref https://github.com/jekyll/jekyll/issues/9179