### PR TITLE
Add snapshot-ruby_3_2 and update snapshot-master version to 3.3

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -23,6 +23,13 @@ eol:
 
 stable_snapshots:
 
+  - branch: ruby_3_2
+    url:
+      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_3_2.tar.gz
+      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_3_2.tar.xz
+      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_3_2.zip
+    version: '3.2'
+
   - branch: ruby_3_1
     url:
       gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_3_1.tar.gz
@@ -50,4 +57,4 @@ nightly_snapshot:
     gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.gz
     xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.xz
     zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.zip
-  version: '3.2'
+  version: '3.3'


### PR DESCRIPTION
- snapshot-ruby_3_2 exists since https://github.com/ruby/actions/actions/runs/3779445717
- snapshot-master is 3.3 since https://github.com/ruby/actions/actions/runs/3779519324