### PR TITLE
MJIT now uses forked process, not forked Ruby process

### DIFF
--- a/en/news/_posts/2022-12-25-ruby-3-2-0-released.md
+++ b/en/news/_posts/2022-12-25-ruby-3-2-0-released.md
@@ -240,7 +240,7 @@ sum = ary[0] + ary[1]
 ### MJIT
 
 * The MJIT compiler is re-implemented in Ruby as `ruby_vm/mjit/compiler`.
-* MJIT compiler is executed under a forked Ruby process instead of
+* MJIT compiler is executed under a forked process instead of
   doing it in a native thread called MJIT worker. [[Feature #18968]]
     * As a result, Microsoft Visual Studio (MSWIN) is no longer supported.
 * MinGW is no longer supported. [[Feature #18824]]

--- a/ja/news/_posts/2022-12-25-ruby-3-2-0-released.md
+++ b/ja/news/_posts/2022-12-25-ruby-3-2-0-released.md
@@ -231,7 +231,7 @@ sum = ary[0] + ary[1]
 
 * MJIT コンパイラが `ruby_vm/mjit/compiler` として Ruby で再実装されました。
 * MJIT コンパイラは MJIT ワーカーによって呼ばれた native スレッドの代わりに
-  fork された Ruby プロセス によって実行されるようになりました。 [[Feature #18968]]
+  fork されたプロセスによって実行されるようになりました。 [[Feature #18968]]
     * そのため、Microsoft Visual Studio (MSWIN) はサポート対象外となりました
 * MinGW はサポート対象外となりました [[Feature #18824]]
 * `--mjit-min-calls` は `--mjit-call-threshold` にリネームされました


### PR DESCRIPTION
/cc @k0kubun 