### PR TITLE
Fix broken link in /ja/documentation/ (ja)

### DIFF
--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -10,7 +10,7 @@ Rubyでプログラミングする際に役立つドキュメントを紹介し�
 
 ### マニュアル
 
-各環境にRubyをインストールする方法は、 [ダウンロード](downloads) 及び [インストールガイド](installation) で解説しています。
+各環境にRubyをインストールする方法は、 [ダウンロード][downloads] 及び [インストールガイド][installation] で解説しています。
 
 また、現在有志の手により[リファレンスマニュアルの整備][rurema-wiki]が進行中です。
 成果物を[&lt;URL:https://docs.ruby-lang.org/ja/&gt;][doc-r-l-o]から閲覧できます。


### PR DESCRIPTION
`[ダウンロード](downloads)` generates a link to `/ja/documentation/downloads`.
`[ダウンロード][downloads]` or `[ダウンロード](/ja/downloads)` is correct.