### PR TITLE
Add manager options link to macos install (en)

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -165,6 +165,7 @@ $ brew install ruby
 
 This should install the latest Ruby version.
 
+Alternatively, if you want multiple different versions of ruby that you can switch between you may want to use either a **manager** such as [rbenv](#rbenv) or [RVM](#rvm).
 
 ### FreeBSD
 {: #freebsd}


### PR DESCRIPTION
This clarifies the options for MacOS, but maybe not to the extent that #2874 wants.

This adds the rvm and rbenv options so if someone comes from google they know those can use used for mac similar to https://www.ruby-lang.org/en/downloads/.

I think this would be a start and at least helps people coming there for now.