### PR TITLE
Replace blade.nagaokaut.ac.jp link to new archives

### DIFF
--- a/bg/about/index.md
+++ b/bg/about/index.md
@@ -202,7 +202,7 @@ Ruby притежава множество други черти, като ня�
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/bg/community/ruby-core/index.md
+++ b/bg/community/ruby-core/index.md
@@ -142,7 +142,7 @@ $ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.bran
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/de/about/index.md
+++ b/de/about/index.md
@@ -236,7 +236,7 @@ November 2001.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/de/community/ruby-core/writing-patches/index.md
+++ b/de/community/ruby-core/writing-patches/index.md
@@ -47,4 +47,4 @@ auf der Ruby-Core Mailingliste übernommen und angepasst:
 In Zukunft wechseln wir vielleicht auf einen Git-Workflow mit Pull-Requests.
 Aber bis dahin wird das Befolgen dieser Richtlinien Frustration vermeiden.
 
-[ruby-core-post]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[ruby-core-post]: https://blade.ruby-lang.org/ruby-core/25139

--- a/de/news/_posts/2002-12-07-raa-2-1-0.md
+++ b/de/news/_posts/2002-12-07-raa-2-1-0.md
@@ -47,4 +47,4 @@ NAKAMURA, Hiroshi aka NaHi and U.Nakamura aka usa.
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/58018
+[2]: https://blade.ruby-lang.org/ruby-talk/58018

--- a/de/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
+++ b/de/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
@@ -14,4 +14,4 @@ Entwicklung bemerken. Wir bitten um Euer Verständnis.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/59202
+[1]: https://blade.ruby-lang.org/ruby-talk/59202

--- a/de/news/_posts/2003-01-31-raa-2-3-0.md
+++ b/de/news/_posts/2003-01-31-raa-2-3-0.md
@@ -17,5 +17,5 @@ RAA [Ruby Application Archive][1] has been updated. (see [\[ruby-talk:63170\]][2
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/63170
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/62840
+[2]: https://blade.ruby-lang.org/ruby-talk/63170
+[3]: https://blade.ruby-lang.org/ruby-talk/62840

--- a/de/news/_posts/2003-02-21-erste-europische-ruby-konferenz.md
+++ b/de/news/_posts/2003-02-21-erste-europische-ruby-konferenz.md
@@ -19,4 +19,4 @@ seiner EMail.)
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65418
+[1]: https://blade.ruby-lang.org/ruby-talk/65418

--- a/de/news/_posts/2003-02-24-alles-gute-zum-geburtstag-ruby.md
+++ b/de/news/_posts/2003-02-24-alles-gute-zum-geburtstag-ruby.md
@@ -19,4 +19,4 @@ Weitere Informationen in der Mailingliste: [\[ruby-talk:65632\]][2].
 
 
 [1]: http://rubycentral.org
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632
+[2]: https://blade.ruby-lang.org/ruby-talk/65632

--- a/de/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
+++ b/de/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
@@ -17,7 +17,7 @@ process 3 years ago.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/88503
+[1]: https://blade.ruby-lang.org/ruby-talk/88503
 [2]: http://www.rubyconf.org
 [3]: http://www.rubyist.net/%7Ematz/slides/rc2003
 [4]: http://rcrchive.net

--- a/de/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
+++ b/de/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
@@ -17,4 +17,4 @@ guidelines for potential authors.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/123137
+[1]: https://blade.ruby-lang.org/ruby-talk/123137

--- a/de/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
+++ b/de/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
@@ -13,5 +13,5 @@ Congratulations to the recipients!
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/133197
+[1]: https://blade.ruby-lang.org/ruby-talk/133197
 [2]: http://www.rubycentral.org/grant/announce.html

--- a/de/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
+++ b/de/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
@@ -13,5 +13,5 @@ two weeks. Non-full may continue past that, but not forever. Go to the
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/154337
+[1]: https://blade.ruby-lang.org/ruby-talk/154337
 [2]: http://www.rubyconf.org

--- a/de/news/_posts/2006-06-20-the-future-of-ruby.md
+++ b/de/news/_posts/2006-06-20-the-future-of-ruby.md
@@ -19,5 +19,5 @@ information is only what we think we know at this point in that process.
 
 
 [1]: http://eigenclass.org/hiki.rb?Changes+in+Ruby+1.9
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/197229
+[2]: https://blade.ruby-lang.org/ruby-talk/197229
 [3]: http://www.rubyist.net/~matz/slides/rc2005/mgp00006.html

--- a/de/news/_posts/2006-09-12-endlich-ist-das-neue-design-da.md
+++ b/de/news/_posts/2006-09-12-endlich-ist-das-neue-design-da.md
@@ -50,7 +50,7 @@ Mailingliste][4] erstellt.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/131284
+[1]: https://blade.ruby-lang.org/ruby-talk/131284
 [2]: http://redhanded.hobix.com/redesign2005/
 [3]: http://radiantcms.org
 [4]: http://rubyforge.org/mailman/listinfo/vit-discuss/

--- a/de/news/_posts/2007-03-13-ruby-1-8-6-verffentlicht.md
+++ b/de/news/_posts/2007-03-13-ruby-1-8-6-verffentlicht.md
@@ -32,7 +32,7 @@ Patchlevel-Updates bereitgestellt.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/de/news/_posts/2007-12-25-ruby-1-9-0-verffentlicht.md
+++ b/de/news/_posts/2007-12-25-ruby-1-9-0-verffentlicht.md
@@ -28,7 +28,7 @@ Einige Änderungen sind in der [Ruby-Mine][5] beschrieben.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44387
+[1]: https://blade.ruby-lang.org/ruby-list/44387
 [2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.zip

--- a/de/news/_posts/2010-08-24-ruby-1-8-7-p302-verffentlicht.md
+++ b/de/news/_posts/2010-08-24-ruby-1-8-7-p302-verffentlicht.md
@@ -57,7 +57,7 @@ Ich empfehle allen Ruby-1.8.7-Nutzern, auf p302 zu updaten.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/de/news/2010/08/24/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/de/news/_posts/2010-08-24-xss-in-webrick-cve-2010-0541.md
+++ b/de/news/_posts/2010-08-24-xss-in-webrick-cve-2010-0541.md
@@ -69,4 +69,4 @@ Ruby-Sicherheitsteam von Hideki Yamane gemeldet<sup>[1](#fn1)</sup>.
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/de/news/_posts/2010-08-24-xss-in-webrick-cve-2010-0541.md
+++ b/de/news/_posts/2010-08-24-xss-in-webrick-cve-2010-0541.md
@@ -66,7 +66,7 @@ Ruby-Sicherheitsteam von Hideki Yamane gemeldet<sup>[1](#fn1)</sup>.
 
 
 [1]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-0541
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[2]: https://blade.ruby-lang.org/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
 [5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/de/news/_posts/2012-01-04-denial-of-service-attacke-fr-rubys-hash-algorithmus-gefunden-cve-2011-4815.md
+++ b/de/news/_posts/2012-01-04-denial-of-service-attacke-fr-rubys-hash-algorithmus-gefunden-cve-2011-4815.md
@@ -89,7 +89,7 @@ dieses Problem gemeldet haben.
 
 
 [1]: http://ruby-doc.org/core-1.8.7/String.html#method-i-hash
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/391606
+[2]: https://blade.ruby-lang.org/ruby-talk/391606
 [3]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-4815
 [4]: http://www.ocert.org/advisories/ocert-2011-003.html
 [5]: http://jruby.org/2011/12/27/jruby-1-6-5-1

--- a/de/news/_posts/2013-02-08-ruby-2-0-0-rc2-verffentlicht.md
+++ b/de/news/_posts/2013-02-08-ruby-2-0-0-rc2-verffentlicht.md
@@ -142,7 +142,7 @@ mir bei dieser Veröffentlichung geholfen haben, sehr dankbar.
 [10]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [11]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [12]: https://bugs.ruby-lang.org/issues/6679
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[13]: https://blade.ruby-lang.org/ruby-dev/46547
 [14]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [15]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [16]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/de/news/_posts/2013-02-08-ruby-2-0-0-rc2-verffentlicht.md
+++ b/de/news/_posts/2013-02-08-ruby-2-0-0-rc2-verffentlicht.md
@@ -143,8 +143,8 @@ mir bei dieser Veröffentlichung geholfen haben, sehr dankbar.
 [11]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [12]: https://bugs.ruby-lang.org/issues/6679
 [13]: https://blade.ruby-lang.org/ruby-dev/46547
-[14]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[15]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[14]: https://blade.ruby-lang.org/ruby-core/48984
+[15]: https://blade.ruby-lang.org/ruby-core/49119
 [16]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft
 [17]: https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2
 [18]: https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz

--- a/en/about/index.md
+++ b/en/about/index.md
@@ -224,7 +224,7 @@ For a more complete list, see [Awesome Rubies][awesome-rubies].
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/en/community/ruby-core/writing-patches/index.md
+++ b/en/community/ruby-core/writing-patches/index.md
@@ -49,4 +49,4 @@ But until then, following the above guidelines would help you to avoid
 frustration.
 
 
-[ruby-core-post]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[ruby-core-post]: https://blade.ruby-lang.org/ruby-core/25139

--- a/en/documentation/faq/1/index.md
+++ b/en/documentation/faq/1/index.md
@@ -181,7 +181,7 @@ The following is a summary of a posting made by Matz in
 > web pages formed.
 
 [ruby-talk:00382]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/382
-[ruby-list:15977]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/15977
+[ruby-list:15977]: https://blade.ruby-lang.org/ruby-list/15977
 
 ### Where is the Ruby Home Page?
 

--- a/en/documentation/faq/1/index.md
+++ b/en/documentation/faq/1/index.md
@@ -148,7 +148,7 @@ programming language newer (and hopefully better) than Perl.
 (Based on an explanation from Matz in [\[ruby-talk:00394\]][ruby-talk:00394]
 on June 11, 1999.)
 
-[ruby-talk:00394]: https://web.archive.org/web/20220516220807/http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/394
+[ruby-talk:00394]: https://blade.ruby-lang.org/ruby-talk/394
 
 ### What is the history of Ruby?
 
@@ -180,7 +180,7 @@ The following is a summary of a posting made by Matz in
 > Since then, highly active mailing lists have been established and
 > web pages formed.
 
-[ruby-talk:00382]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/382
+[ruby-talk:00382]: https://blade.ruby-lang.org/ruby-talk/382
 [ruby-list:15977]: https://blade.ruby-lang.org/ruby-list/15977
 
 ### Where is the Ruby Home Page?

--- a/en/documentation/faq/10/index.md
+++ b/en/documentation/faq/10/index.md
@@ -69,7 +69,7 @@ then invoke it using:
 ruby -r eval -e0
 ~~~
 
-[ruby-talk:444]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/444
+[ruby-talk:444]: https://blade.ruby-lang.org/ruby-talk/444
 
 ### Is there a debugger for Ruby?
 

--- a/en/documentation/faq/11/index.md
+++ b/en/documentation/faq/11/index.md
@@ -189,4 +189,4 @@ def primes(limit)
 end
 ~~~
 
-[ruby-talk:4482]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/4482
+[ruby-talk:4482]: https://blade.ruby-lang.org/ruby-talk/4482

--- a/en/documentation/faq/3/index.md
+++ b/en/documentation/faq/3/index.md
@@ -141,7 +141,7 @@ $ CC="cc -Ae" CFLAGS=-O ./configure --prefix=/opt/gnu
 There may also be problems with HP's native `sed`.
 He recommends installing the GNU equivalent.
 
-[ruby-talk:5041]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/5401
+[ruby-talk:5041]: https://blade.ruby-lang.org/ruby-talk/5401
 
 ### Are precompiled binaries available?
 

--- a/en/documentation/faq/5/index.md
+++ b/en/documentation/faq/5/index.md
@@ -234,4 +234,4 @@ combine(:it1, :it2) do |x|
 end
 ~~~
 
-[ruby-talk:5252]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/5252
+[ruby-talk:5252]: https://blade.ruby-lang.org/ruby-talk/5252

--- a/en/news/_posts/2002-12-07-raa-2-1-0.md
+++ b/en/news/_posts/2002-12-07-raa-2-1-0.md
@@ -47,4 +47,4 @@ NAKAMURA, Hiroshi aka NaHi and U.Nakamura aka usa.
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/58018
+[2]: https://blade.ruby-lang.org/ruby-talk/58018

--- a/en/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
+++ b/en/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
@@ -16,4 +16,4 @@ ruby-talk.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/59202
+[1]: https://blade.ruby-lang.org/ruby-talk/59202

--- a/en/news/_posts/2003-01-31-raa-2-3-0.md
+++ b/en/news/_posts/2003-01-31-raa-2-3-0.md
@@ -17,5 +17,5 @@ RAA [Ruby Application Archive][1] has been updated. (see [\[ruby-talk:63170\]][2
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/63170
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/62840
+[2]: https://blade.ruby-lang.org/ruby-talk/63170
+[3]: https://blade.ruby-lang.org/ruby-talk/62840

--- a/en/news/_posts/2003-02-21-first-europeen-ruby-conference.md
+++ b/en/news/_posts/2003-02-21-first-europeen-ruby-conference.md
@@ -18,4 +18,4 @@ mailing-lists, and so on, see [\[ruby-talk:65418\]][1])
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65418
+[1]: https://blade.ruby-lang.org/ruby-talk/65418

--- a/en/news/_posts/2003-02-24-happy-birthday-ruby.md
+++ b/en/news/_posts/2003-02-24-happy-birthday-ruby.md
@@ -17,4 +17,4 @@ Inc][1] and RubyConf 2003!. See [\[ruby-talk:65632\]][2].
 
 
 [1]: http://rubycentral.org
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632
+[2]: https://blade.ruby-lang.org/ruby-talk/65632

--- a/en/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
+++ b/en/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
@@ -17,7 +17,7 @@ process 3 years ago.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/88503
+[1]: https://blade.ruby-lang.org/ruby-talk/88503
 [2]: http://www.rubyconf.org
 [3]: http://www.rubyist.net/%7Ematz/slides/rc2003
 [4]: http://rcrchive.net

--- a/en/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
+++ b/en/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
@@ -17,4 +17,4 @@ guidelines for potential authors.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/123137
+[1]: https://blade.ruby-lang.org/ruby-talk/123137

--- a/en/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
+++ b/en/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
@@ -13,5 +13,5 @@ Congratulations to the recipients!
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/133197
+[1]: https://blade.ruby-lang.org/ruby-talk/133197
 [2]: http://www.rubycentral.org/grant/announce.html

--- a/en/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
+++ b/en/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
@@ -13,5 +13,5 @@ two weeks. Non-full may continue past that, but not forever. Go to the
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/154337
+[1]: https://blade.ruby-lang.org/ruby-talk/154337
 [2]: http://www.rubyconf.org

--- a/en/news/_posts/2006-06-20-the-future-of-ruby.md
+++ b/en/news/_posts/2006-06-20-the-future-of-ruby.md
@@ -19,5 +19,5 @@ information is only what we think we know at this point in that process.
 
 
 [1]: http://eigenclass.org/hiki.rb?Changes+in+Ruby+1.9
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/197229
+[2]: https://blade.ruby-lang.org/ruby-talk/197229
 [3]: http://www.rubyist.net/~matz/slides/rc2005/mgp00006.html

--- a/en/news/_posts/2006-09-12-site-launch-at-last.md
+++ b/en/news/_posts/2006-09-12-site-launch-at-last.md
@@ -51,7 +51,7 @@ list][4].
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/131284
+[1]: https://blade.ruby-lang.org/ruby-talk/131284
 [2]: http://redhanded.hobix.com/redesign2005/
 [3]: http://radiantcms.org
 [4]: http://rubyforge.org/mailman/listinfo/vit-discuss/

--- a/en/news/_posts/2007-03-12-ruby-1-8-6-released.md
+++ b/en/news/_posts/2007-03-12-ruby-1-8-6-released.md
@@ -34,7 +34,7 @@ check them out after upgrading Ruby to 1.8.6.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/en/news/_posts/2010-08-16-ruby-1-8-7-p302-is-released.md
+++ b/en/news/_posts/2010-08-16-ruby-1-8-7-p302-is-released.md
@@ -48,7 +48,7 @@ SHA256(ruby-1.8.7-p302.zip):
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/en/news/2010/08/16/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/en/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
+++ b/en/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
@@ -76,4 +76,4 @@ team by Hideki Yamane. <sup>[\*1](#fn1)</sup>
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/en/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
+++ b/en/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
@@ -73,7 +73,7 @@ team by Hideki Yamane. <sup>[\*1](#fn1)</sup>
 
 
 [1]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-0541
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[2]: https://blade.ruby-lang.org/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
 [5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/en/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/en/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -114,7 +114,7 @@ all the people who helped me do this release.
 [8]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[11]: https://blade.ruby-lang.org/ruby-dev/46547
 [12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/en/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/en/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -115,6 +115,6 @@ all the people who helped me do this release.
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
 [11]: https://blade.ruby-lang.org/ruby-dev/46547
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[12]: https://blade.ruby-lang.org/ruby-core/48984
+[13]: https://blade.ruby-lang.org/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/es/about/index.md
+++ b/es/about/index.md
@@ -224,7 +224,7 @@ del 2003.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/es/community/ruby-core/writing-patches/index.md
+++ b/es/community/ruby-core/writing-patches/index.md
@@ -47,4 +47,4 @@ Pero hasta entonces, seguir las pautas anteriores te ayudaría a evitar
 una frustración.
 
 
-[ruby-core-post]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[ruby-core-post]: https://blade.ruby-lang.org/ruby-core/25139

--- a/es/news/_posts/2007-03-15-liberado-ruby-1-8-6.md
+++ b/es/news/_posts/2007-03-15-liberado-ruby-1-8-6.md
@@ -44,7 +44,7 @@ actualizarse a Ruby 1.8.6.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/es/news/_posts/2010-08-18-liberado-ruby-1-8-7-p302.md
+++ b/es/news/_posts/2010-08-18-liberado-ruby-1-8-7-p302.md
@@ -49,7 +49,7 @@ SHA256(ruby-1.8.7-p302.zip):
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/en/news/2010/08/16/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/fr/about/index.md
+++ b/fr/about/index.md
@@ -217,7 +217,7 @@ le 22 décembre 2003.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/fr/news/_posts/2007-03-15-ruby-1-8-6-released.md
+++ b/fr/news/_posts/2007-03-15-ruby-1-8-6-released.md
@@ -30,7 +30,7 @@ Le fichier NEWS récapitule les grands changements utiles à l\'utilisateur ; le
 
 À partir de maintenant commence le développement de la branche 1.8.7. La branche 1.8.6, quant à elle, est maintenue et intègrera les mises-à-jour importantes éventuelles (bugs critiques, failles de sécurité). Gardez donc l\'œil ouvert.
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/fr/news/_posts/2013-02-11-sortie-de-ruby-2-0-0-rc2.md
+++ b/fr/news/_posts/2013-02-11-sortie-de-ruby-2-0-0-rc2.md
@@ -130,6 +130,6 @@ chaleureusement.
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
 [11]: https://blade.ruby-lang.org/ruby-dev/46547
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[12]: https://blade.ruby-lang.org/ruby-core/48984
+[13]: https://blade.ruby-lang.org/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/fr/news/_posts/2013-02-11-sortie-de-ruby-2-0-0-rc2.md
+++ b/fr/news/_posts/2013-02-11-sortie-de-ruby-2-0-0-rc2.md
@@ -129,7 +129,7 @@ chaleureusement.
 [8]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[11]: https://blade.ruby-lang.org/ruby-dev/46547
 [12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/fr/news/_posts/2013-02-25-sortie-de-ruby-2-0-0-p0.md
+++ b/fr/news/_posts/2013-02-25-sortie-de-ruby-2-0-0-p0.md
@@ -217,7 +217,7 @@ Merci à tous et à toutes !
 [11]: http://www.infoq.com/news/2012/11/ruby-20-preview1
 [12]: http://jp.rubyist.net/magazine/?0041-200Special
 [13]: https://bugs.ruby-lang.org/issues/6679
-[14]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[14]: https://blade.ruby-lang.org/ruby-dev/46547
 [15]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [16]: https://bugs.ruby-lang.org/issues/6670
 [17]: https://bugs.ruby-lang.org/issues/2152

--- a/fr/news/_posts/2013-02-25-sortie-de-ruby-2-0-0-p0.md
+++ b/fr/news/_posts/2013-02-25-sortie-de-ruby-2-0-0-p0.md
@@ -218,8 +218,8 @@ Merci à tous et à toutes !
 [12]: http://jp.rubyist.net/magazine/?0041-200Special
 [13]: https://bugs.ruby-lang.org/issues/6679
 [14]: https://blade.ruby-lang.org/ruby-dev/46547
-[15]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
+[15]: https://blade.ruby-lang.org/ruby-core/48984
 [16]: https://bugs.ruby-lang.org/issues/6670
 [17]: https://bugs.ruby-lang.org/issues/2152
-[18]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[18]: https://blade.ruby-lang.org/ruby-core/49119
 [19]: https://bugs.ruby-lang.org/projects/ruby/wiki/200SpecialThanks

--- a/id/about/index.md
+++ b/id/about/index.md
@@ -239,7 +239,7 @@ di Ruby, dalam Bahasa Inggris), 22 Desember 2003.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/id/news/_posts/2007-06-28-ruby-1-8-6-telah-tersedia.md
+++ b/id/news/_posts/2007-06-28-ruby-1-8-6-telah-tersedia.md
@@ -40,7 +40,7 @@ ketersediaan *patch-patch* tersebut segera setelah Anda melakukan
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/id/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/id/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -114,7 +114,7 @@ sangat berterima kasih kepada semua orang yang membantu saya untuk melakukan ril
 [8]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[11]: https://blade.ruby-lang.org/ruby-dev/46547
 [12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/id/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/id/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -115,6 +115,6 @@ sangat berterima kasih kepada semua orang yang membantu saya untuk melakukan ril
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
 [11]: https://blade.ruby-lang.org/ruby-dev/46547
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[12]: https://blade.ruby-lang.org/ruby-core/48984
+[13]: https://blade.ruby-lang.org/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/it/about/index.md
+++ b/it/about/index.md
@@ -205,7 +205,7 @@ Ruby è in grado di offrire una marea di altre funzionalità, tra cui:
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/it/community/ruby-core/index.md
+++ b/it/community/ruby-core/index.md
@@ -166,7 +166,7 @@ Guarda anche le informazioni su [Ruby’s issue tracker][10].
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/it/news/_posts/2010-11-14-ruby-1-8-7-p302-is-released.md
+++ b/it/news/_posts/2010-11-14-ruby-1-8-7-p302-is-released.md
@@ -49,7 +49,7 @@ SHA256(ruby-1.8.7-p302.zip):
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/it/news/2010/11/14/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/it/news/_posts/2010-11-14-xss-in-webrick-cve-2010-0541.md
+++ b/it/news/_posts/2010-11-14-xss-in-webrick-cve-2010-0541.md
@@ -78,4 +78,4 @@ sicurezza di Ruby da Hideki Yamane <sup>[\*1](#fn1)</sup>
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/it/news/_posts/2010-11-14-xss-in-webrick-cve-2010-0541.md
+++ b/it/news/_posts/2010-11-14-xss-in-webrick-cve-2010-0541.md
@@ -75,7 +75,7 @@ sicurezza di Ruby da Hideki Yamane <sup>[\*1](#fn1)</sup>
 
 
 [1]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-0541
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[2]: https://blade.ruby-lang.org/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
 [5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/it/news/_posts/2013-03-03-ruby-2-0-0-rc2-is-released.md
+++ b/it/news/_posts/2013-03-03-ruby-2-0-0-rc2-is-released.md
@@ -124,6 +124,6 @@ l\'autore a preparare questa versione.
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
 [11]: https://blade.ruby-lang.org/ruby-dev/46547
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[12]: https://blade.ruby-lang.org/ruby-core/48984
+[13]: https://blade.ruby-lang.org/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/it/news/_posts/2013-03-03-ruby-2-0-0-rc2-is-released.md
+++ b/it/news/_posts/2013-03-03-ruby-2-0-0-rc2-is-released.md
@@ -123,7 +123,7 @@ l\'autore a preparare questa versione.
 [8]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[11]: https://blade.ruby-lang.org/ruby-dev/46547
 [12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/ja/about/index.md
+++ b/ja/about/index.md
@@ -190,7 +190,7 @@ MRI以外のRuby処理系には以下のようなものがあります。
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/ja/news/_posts/2002-12-11-20021211.md
+++ b/ja/news/_posts/2002-12-11-20021211.md
@@ -9,5 +9,5 @@ ruby 1.6.8のpreview3がリリースされました。以下のURLからダウ�
 
 * [https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8-preview3.tar.gz][2]
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/36717
+[1]: https://blade.ruby-lang.org/ruby-list/36717
 [2]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8-preview3.tar.gz

--- a/ja/news/_posts/2002-12-13-20021213.md
+++ b/ja/news/_posts/2002-12-13-20021213.md
@@ -11,4 +11,4 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/19066
+[1]: https://blade.ruby-lang.org/ruby-dev/19066

--- a/ja/news/_posts/2002-12-17-20021217.md
+++ b/ja/news/_posts/2002-12-17-20021217.md
@@ -13,5 +13,5 @@ preview3からの変更点は[\[ruby-dev:19081\]][1]の後半部分にありま�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/19081
+[1]: https://blade.ruby-lang.org/ruby-dev/19081
 [2]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8-preview4.tar.gz

--- a/ja/news/_posts/2003-01-31-20030131.md
+++ b/ja/news/_posts/2003-01-31-20030131.md
@@ -16,4 +16,4 @@ lang: ja
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/37021
+[2]: https://blade.ruby-lang.org/ruby-list/37021

--- a/ja/news/_posts/2003-02-25-20030225.md
+++ b/ja/news/_posts/2003-02-25-20030225.md
@@ -18,5 +18,5 @@ Inc.のページやRubyConf.orgで公開されるそうです。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632
+[1]: https://blade.ruby-lang.org/ruby-talk/65632
 [2]: http://rubycentral.org/

--- a/ja/news/_posts/2003-05-06-20030506.md
+++ b/ja/news/_posts/2003-05-06-20030506.md
@@ -12,5 +12,5 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/37636
+[1]: https://blade.ruby-lang.org/ruby-list/37636
 [2]: http://ac.nikkeibp.co.jp/nsw/5th/

--- a/ja/news/_posts/2003-07-31-20030731.md
+++ b/ja/news/_posts/2003-07-31-20030731.md
@@ -13,4 +13,4 @@ Ruby 1.8.0 の 6番目のプレビュー版、Ruby 1.8.0-preview6 が公開さ�
 
 
 [1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview6.tar.gz
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/77510
+[2]: https://blade.ruby-lang.org/ruby-talk/77510

--- a/ja/news/_posts/2003-08-01-20030801.md
+++ b/ja/news/_posts/2003-08-01-20030801.md
@@ -15,4 +15,4 @@ Tk のマルチインタープリタサポート、Linux-IA64などが対応さ�
 
 
 [1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview7.tar.gz
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/77701
+[2]: https://blade.ruby-lang.org/ruby-talk/77701

--- a/ja/news/_posts/2003-09-10-20030910.md
+++ b/ja/news/_posts/2003-09-10-20030910.md
@@ -15,4 +15,4 @@ ruby-lang.orgを運用しているマシンのメンテナンスのため、日�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/38390
+[1]: https://blade.ruby-lang.org/ruby-list/38390

--- a/ja/news/_posts/2003-10-17-20031017.md
+++ b/ja/news/_posts/2003-10-17-20031017.md
@@ -16,4 +16,4 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/38546
+[1]: https://blade.ruby-lang.org/ruby-list/38546

--- a/ja/news/_posts/2003-10-30-20031030.md
+++ b/ja/news/_posts/2003-10-30-20031030.md
@@ -17,6 +17,6 @@ Rubyを使ったアプリケーションやライブラリを作成されてい�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/21747
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/21790
+[1]: https://blade.ruby-lang.org/ruby-dev/21747
+[2]: https://blade.ruby-lang.org/ruby-dev/21790
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.1-preview1.tar.gz

--- a/ja/news/_posts/2003-10-31-20031031.md
+++ b/ja/news/_posts/2003-10-31-20031031.md
@@ -12,6 +12,6 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/84606
+[1]: https://blade.ruby-lang.org/ruby-talk/84606
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.1-preview2.tar.gz
 [3]: http://rubyforge.org/project/showfiles.php?group_id=30&amp;release_id=152

--- a/ja/news/_posts/2003-12-07-20031207.md
+++ b/ja/news/_posts/2003-12-07-20031207.md
@@ -13,6 +13,6 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/22167
+[1]: https://blade.ruby-lang.org/ruby-dev/22167
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.1-preview3.tar.gz
 [3]: http://rubyforge.org/project/showfiles.php?group_id=30

--- a/ja/news/_posts/2003-12-22-20031222.md
+++ b/ja/news/_posts/2003-12-22-20031222.md
@@ -13,6 +13,6 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/38919
+[1]: https://blade.ruby-lang.org/ruby-list/38919
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.1-preview4.tar.gz
 [3]: http://rubyforge.org/project/showfiles.php?group_id=30

--- a/ja/news/_posts/2003-12-25-20031225.md
+++ b/ja/news/_posts/2003-12-25-20031225.md
@@ -25,5 +25,5 @@ MD5チェックサムは 5d52c7d0e6a6eb6e3bc68d77e794898e です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/38985
+[1]: https://blade.ruby-lang.org/ruby-list/38985
 [2]: https://blade.ruby-lang.org/ruby-dev/22385

--- a/ja/news/_posts/2003-12-25-20031225.md
+++ b/ja/news/_posts/2003-12-25-20031225.md
@@ -26,4 +26,4 @@ MD5チェックサムは 5d52c7d0e6a6eb6e3bc68d77e794898e です。
 
 
 [1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/38985
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/22385
+[2]: https://blade.ruby-lang.org/ruby-dev/22385

--- a/ja/news/_posts/2004-08-08-20040808.md
+++ b/ja/news/_posts/2004-08-08-20040808.md
@@ -20,6 +20,6 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/39820
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/39946
+[1]: https://blade.ruby-lang.org/ruby-list/39820
+[2]: https://blade.ruby-lang.org/ruby-list/39946
 [3]: http://wiki.fdiary.net/RubyNoKai/

--- a/ja/news/_posts/2004-09-10-20040910.md
+++ b/ja/news/_posts/2004-09-10-20040910.md
@@ -18,4 +18,4 @@ Magazineは、Rubyistの、Rubyistによる、Rubyistのためのウェブマガ
 
 [1]: http://jp.rubyist.net/magazine/
 [2]: http://jp.rubyist.net/magazine/?0001
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40045
+[3]: https://blade.ruby-lang.org/ruby-list/40045

--- a/ja/news/_posts/2004-10-16-20041016.md
+++ b/ja/news/_posts/2004-10-16-20041016.md
@@ -18,4 +18,4 @@ Rubyist Magazine (通称『るびま』)は、Ruby に関する技術記事は�
 
 [1]: http://jp.rubyist.net/magazine/
 [2]: http://jp.rubyist.net/magazine/?0002
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40103
+[3]: https://blade.ruby-lang.org/ruby-list/40103

--- a/ja/news/_posts/2004-11-08-20041108.md
+++ b/ja/news/_posts/2004-11-08-20041108.md
@@ -18,5 +18,5 @@ md5値は 64478c70a44a48af1a1c256a43e5dc61 です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/24740
+[1]: https://blade.ruby-lang.org/ruby-dev/24740
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2-preview3.tar.gz

--- a/ja/news/_posts/2004-11-15-20041115.md
+++ b/ja/news/_posts/2004-11-15-20041115.md
@@ -16,4 +16,4 @@ lang: ja
 
 [1]: http://jp.rubyist.net/magazine/
 [2]: http://jp.rubyist.net/magazine/?0003
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40306
+[3]: https://blade.ruby-lang.org/ruby-list/40306

--- a/ja/news/_posts/2004-12-17-20041217.md
+++ b/ja/news/_posts/2004-12-17-20041217.md
@@ -17,4 +17,4 @@ Magazine][2]の[0004号][3]がリリースされました。([\[ruby-list:40434\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0004
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40434
+[4]: https://blade.ruby-lang.org/ruby-list/40434

--- a/ja/news/_posts/2004-12-22-20041222.md
+++ b/ja/news/_posts/2004-12-22-20041222.md
@@ -18,5 +18,5 @@ md5値は 2f53d4dc4b24e37799143645772aabd0 です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/25283
+[1]: https://blade.ruby-lang.org/ruby-dev/25283
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2-preview4.tar.gz

--- a/ja/news/_posts/2004-12-25-20041225.md
+++ b/ja/news/_posts/2004-12-25-20041225.md
@@ -20,5 +20,5 @@ MD5チェックサムは 8ffc79d96f336b80f2690a17601dea9b です。
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/40458
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/124413
+[2]: https://blade.ruby-lang.org/ruby-talk/124413
 [3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz

--- a/ja/news/_posts/2004-12-25-20041225.md
+++ b/ja/news/_posts/2004-12-25-20041225.md
@@ -19,6 +19,6 @@ MD5チェックサムは 8ffc79d96f336b80f2690a17601dea9b です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40458
+[1]: https://blade.ruby-lang.org/ruby-list/40458
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/124413
 [3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz

--- a/ja/news/_posts/2005-02-15-20050215.md
+++ b/ja/news/_posts/2005-02-15-20050215.md
@@ -15,4 +15,4 @@ Magazine][2]の[0005号][3]がリリースされました。([\[ruby-list:40620\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0005
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40620
+[4]: https://blade.ruby-lang.org/ruby-list/40620

--- a/ja/news/_posts/2005-05-09-20050509.md
+++ b/ja/news/_posts/2005-05-09-20050509.md
@@ -15,4 +15,4 @@ Magazine][2]の[0006号][3]がリリースされました。([\[ruby-list:40814\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0006
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40814
+[4]: https://blade.ruby-lang.org/ruby-list/40814

--- a/ja/news/_posts/2005-05-12-20050512.md
+++ b/ja/news/_posts/2005-05-12-20050512.md
@@ -18,5 +18,5 @@ md5sumは a5ae008de3332dc831244ac63289b761 です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/26156
+[1]: https://blade.ruby-lang.org/ruby-dev/26156
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3-preview1.tar.gz

--- a/ja/news/_posts/2005-06-19-20050619.md
+++ b/ja/news/_posts/2005-06-19-20050619.md
@@ -15,4 +15,4 @@ Magazine][2]の[0007号][3]がリリースされました。([\[ruby-list:40879\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0007
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40879
+[4]: https://blade.ruby-lang.org/ruby-list/40879

--- a/ja/news/_posts/2005-07-19-20050719.md
+++ b/ja/news/_posts/2005-07-19-20050719.md
@@ -15,4 +15,4 @@ Magazine][2]の[0008号][3]がリリースされました。([\[ruby-list:40930\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0008
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/40930
+[4]: https://blade.ruby-lang.org/ruby-list/40930

--- a/ja/news/_posts/2005-09-06-20050906.md
+++ b/ja/news/_posts/2005-09-06-20050906.md
@@ -15,4 +15,4 @@ Magazine][2]の[0009号][3]がリリースされました。([\[ruby-list:41110\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0009
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/41110
+[4]: https://blade.ruby-lang.org/ruby-list/41110

--- a/ja/news/_posts/2005-09-19-20050919.md
+++ b/ja/news/_posts/2005-09-19-20050919.md
@@ -19,5 +19,5 @@ md5sumは 6691ea6aaeeb1a51df587f714f1ae3e1 です。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27148
+[1]: https://blade.ruby-lang.org/ruby-dev/27148
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3-preview3.tar.gz

--- a/ja/news/_posts/2005-09-22-20050922.md
+++ b/ja/news/_posts/2005-09-22-20050922.md
@@ -42,7 +42,7 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27251
+[1]: https://blade.ruby-lang.org/ruby-dev/27251
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/1.8.2-patch1.gz
 [3]: {{ site.url }}/ja/news/2005/07/01/20050701/
 [4]: https://cache.ruby-lang.org/pub/ruby/1.6/1.6.8-patch1.gz

--- a/ja/news/_posts/2005-10-10-20051010.md
+++ b/ja/news/_posts/2005-10-10-20051010.md
@@ -15,4 +15,4 @@ Magazine][2]の[0010号][3]がリリースされました。([\[ruby-list:41240\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0010
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/41240
+[4]: https://blade.ruby-lang.org/ruby-list/41240

--- a/ja/news/_posts/2005-10-29-20051029.md
+++ b/ja/news/_posts/2005-10-29-20051029.md
@@ -19,6 +19,6 @@ Ruby 1.8.4の正式版は12月24日にリリースされる 予定です( [\[rub
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27548
+[1]: https://blade.ruby-lang.org/ruby-dev/27548
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4-preview1.tar.gz
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27268
+[3]: https://blade.ruby-lang.org/ruby-dev/27268

--- a/ja/news/_posts/2005-11-16-20051116.md
+++ b/ja/news/_posts/2005-11-16-20051116.md
@@ -15,4 +15,4 @@ Magazine][2]の[0011号][3]がリリースされました。([\[ruby-list:41564\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0011
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/41564
+[4]: https://blade.ruby-lang.org/ruby-list/41564

--- a/ja/news/_posts/2005-11-21-20051121.md
+++ b/ja/news/_posts/2005-11-21-20051121.md
@@ -30,5 +30,5 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27787
+[1]: https://blade.ruby-lang.org/ruby-dev/27787
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2-webrick-dos-1.patch

--- a/ja/news/_posts/2005-11-22-20051122.md
+++ b/ja/news/_posts/2005-11-22-20051122.md
@@ -30,5 +30,5 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27787
+[1]: https://blade.ruby-lang.org/ruby-dev/27787
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2-xmlrpc-dos-1.patch

--- a/ja/news/_posts/2005-12-02-20051202.md
+++ b/ja/news/_posts/2005-12-02-20051202.md
@@ -19,6 +19,6 @@ Ruby 1.8.4の正式版は12月24日にリリースされる 予定です( [\[rub
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27904
+[1]: https://blade.ruby-lang.org/ruby-dev/27904
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4-preview2.tar.gz
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27268
+[3]: https://blade.ruby-lang.org/ruby-dev/27268

--- a/ja/news/_posts/2005-12-22-20051222.md
+++ b/ja/news/_posts/2005-12-22-20051222.md
@@ -19,6 +19,6 @@ md5sumは 1ba94874e1a253d3f1373533553080ae です。 また、サイズは 43129
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/28095
+[1]: https://blade.ruby-lang.org/ruby-dev/28095
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4-preview3.tar.gz
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/27268
+[3]: https://blade.ruby-lang.org/ruby-dev/27268

--- a/ja/news/_posts/2005-12-24-20051224.md
+++ b/ja/news/_posts/2005-12-24-20051224.md
@@ -21,6 +21,6 @@ Merry Christmas! そして、Happy Hacking!
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/41728
+[1]: https://blade.ruby-lang.org/ruby-list/41728
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.4+feature

--- a/ja/news/_posts/2006-05-02-20060502.md
+++ b/ja/news/_posts/2006-05-02-20060502.md
@@ -14,4 +14,4 @@ Hanssonさんの基調講演のほか、多くのスピーカーによる興味�
 
 
 [1]: http://jp.rubyist.net/RubyKaigi2006/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/42182
+[2]: https://blade.ruby-lang.org/ruby-list/42182

--- a/ja/news/_posts/2006-08-09-1-8-5-preview3.md
+++ b/ja/news/_posts/2006-08-09-1-8-5-preview3.md
@@ -23,7 +23,7 @@ Ruby 1.8.5の正式版は日本時間の8月15日～16日付近にリリース�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/29228
+[1]: https://blade.ruby-lang.org/ruby-dev/29228
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-preview3.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.5+feature
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/29232
+[4]: https://blade.ruby-lang.org/ruby-dev/29232

--- a/ja/news/_posts/2006-08-10-20060810.md
+++ b/ja/news/_posts/2006-08-10-20060810.md
@@ -17,4 +17,4 @@ bladeを管理してくださっている原先生の[\[ruby-list:42644\]][1]に
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/42644
+[1]: https://blade.ruby-lang.org/ruby-list/42644

--- a/ja/news/_posts/2006-08-19-ruby-1-8-5-preview4.md
+++ b/ja/news/_posts/2006-08-19-ruby-1-8-5-preview4.md
@@ -22,6 +22,6 @@ Ruby 1.8.5 正式版のリリースは予定より遅れております。いま
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/29291
+[1]: https://blade.ruby-lang.org/ruby-dev/29291
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-preview4.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.5+feature

--- a/ja/news/_posts/2006-08-25-ruby-1-8-5.md
+++ b/ja/news/_posts/2006-08-25-ruby-1-8-5.md
@@ -23,6 +23,6 @@ Ruby
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/42751
+[1]: https://blade.ruby-lang.org/ruby-list/42751
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.5+feature

--- a/ja/news/_posts/2006-09-21-rubyist-magazine-0016.md
+++ b/ja/news/_posts/2006-09-21-rubyist-magazine-0016.md
@@ -15,4 +15,4 @@ Magazine][2]の[0016号][3]がリリースされました。([\[ruby-list:42813\
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0016
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/42813
+[4]: https://blade.ruby-lang.org/ruby-list/42813

--- a/ja/news/_posts/2006-11-26-rubyist-magazine-0017.md
+++ b/ja/news/_posts/2006-11-26-rubyist-magazine-0017.md
@@ -15,4 +15,4 @@ Magazine][2]の[0017号][3]がリリースされました([\[ruby-list:43013\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0017
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43013
+[4]: https://blade.ruby-lang.org/ruby-list/43013

--- a/ja/news/_posts/2006-12-04-rubykaigi-2007.md
+++ b/ja/news/_posts/2006-12-04-rubykaigi-2007.md
@@ -22,4 +22,4 @@ lang: ja
 
 
 [1]: http://jp.rubyist.net/RubyKaigi2007/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43015
+[2]: https://blade.ruby-lang.org/ruby-list/43015

--- a/ja/news/_posts/2006-12-05-ruby-1-8-5-p2.md
+++ b/ja/news/_posts/2006-12-05-ruby-1-8-5-p2.md
@@ -32,5 +32,5 @@ Ruby
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43017
+[1]: https://blade.ruby-lang.org/ruby-list/43017
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p2.tar.gz

--- a/ja/news/_posts/2006-12-25-ruby-1-8-5-p12.md
+++ b/ja/news/_posts/2006-12-25-ruby-1-8-5-p12.md
@@ -18,5 +18,5 @@ md5sumは d7d12dd9124c9b7d55cdbbee313e3931です。また、サイズは 4,526,9
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43074
+[1]: https://blade.ruby-lang.org/ruby-list/43074
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz

--- a/ja/news/_posts/2007-03-04-rubyist-magazine-0018-published.md
+++ b/ja/news/_posts/2007-03-04-rubyist-magazine-0018-published.md
@@ -15,4 +15,4 @@ Magazine][2]の[0018号][3]がリリースされました([\[ruby-list:43237\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0018
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43237
+[4]: https://blade.ruby-lang.org/ruby-list/43237

--- a/ja/news/_posts/2007-03-12-ruby-1-8-6-release.md
+++ b/ja/news/_posts/2007-03-12-ruby-1-8-6-release.md
@@ -39,7 +39,7 @@ Ruby 1.8.6がリリースされました。 (リリースについてのアナ�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/ja/news/_posts/2007-03-13-ruby-1-8-5-p35-release.md
+++ b/ja/news/_posts/2007-03-13-ruby-1-8-5-p35-release.md
@@ -29,6 +29,6 @@ URLの誤記を訂正しました。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43268
+[1]: https://blade.ruby-lang.org/ruby-list/43268
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p35.tar.gz
 [3]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_5_35/ChangeLog

--- a/ja/news/_posts/2007-05-19-rubyist-magazine-0019-published.md
+++ b/ja/news/_posts/2007-05-19-rubyist-magazine-0019-published.md
@@ -15,4 +15,4 @@ Magazine][2]の[0019号][3]がリリースされました([\[ruby-list:43537\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0019
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43537
+[4]: https://blade.ruby-lang.org/ruby-list/43537

--- a/ja/news/_posts/2007-06-09-ruby-1-8-6-p36-release.md
+++ b/ja/news/_posts/2007-06-09-ruby-1-8-6-p36-release.md
@@ -59,8 +59,8 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43608
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43609
+[1]: https://blade.ruby-lang.org/ruby-list/43608
+[2]: https://blade.ruby-lang.org/ruby-list/43609
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p36.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p36.tar.gz
 [5]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p36.zip

--- a/ja/news/_posts/2007-09-25-ruby-1-8-6-p110-release.md
+++ b/ja/news/_posts/2007-09-25-ruby-1-8-6-p110-release.md
@@ -63,8 +63,8 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44054
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44055
+[1]: https://blade.ruby-lang.org/ruby-list/44054
+[2]: https://blade.ruby-lang.org/ruby-list/44055
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.gz
 [5]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.zip

--- a/ja/news/_posts/2007-09-29-rubyist-magazine-0021-published.md
+++ b/ja/news/_posts/2007-09-29-rubyist-magazine-0021-published.md
@@ -15,4 +15,4 @@ Magazine][2]の[0021号][3]がリリースされました([\[ruby-list:44063\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0021
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44063
+[4]: https://blade.ruby-lang.org/ruby-list/44063

--- a/ja/news/_posts/2007-12-25-ruby-1-9-0-release.md
+++ b/ja/news/_posts/2007-12-25-ruby-1-9-0-release.md
@@ -33,7 +33,7 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44387
+[1]: https://blade.ruby-lang.org/ruby-list/44387
 [2]: https://blade.ruby-lang.org/ruby-dev/32713
 [3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz

--- a/ja/news/_posts/2007-12-25-ruby-1-9-0-release.md
+++ b/ja/news/_posts/2007-12-25-ruby-1-9-0-release.md
@@ -34,7 +34,7 @@ lang: ja
 
 
 [1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44387
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/32713
+[2]: https://blade.ruby-lang.org/ruby-dev/32713
 [3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz
 [5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.zip

--- a/ja/news/_posts/2007-12-25-rubyist-magazine-0022-published.md
+++ b/ja/news/_posts/2007-12-25-rubyist-magazine-0022-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0022号][3]がリリースされました([\[ruby-list:44365\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0022
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44365
+[4]: https://blade.ruby-lang.org/ruby-list/44365

--- a/ja/news/_posts/2008-03-01-ruby-1-9-0-1-snapshot-released.md
+++ b/ja/news/_posts/2008-03-01-ruby-1-9-0-1-snapshot-released.md
@@ -23,6 +23,6 @@ sumを確認してからご利用ください。ご迷惑をおかけしてし�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/33947
+[1]: https://blade.ruby-lang.org/ruby-dev/33947
 [2]: https://cache.ruby-lang.org/pub/ruby/1.9/
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/33951
+[3]: https://blade.ruby-lang.org/ruby-dev/33951

--- a/ja/news/_posts/2008-04-26-ruby-1-8-7-preview2-released.md
+++ b/ja/news/_posts/2008-04-26-ruby-1-8-7-preview2-released.md
@@ -40,7 +40,7 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/34462
+[1]: https://blade.ruby-lang.org/ruby-dev/34462
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview2.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview2.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview2.tar.zip

--- a/ja/news/_posts/2008-05-27-ruby-1-8-7-preview4-released.md
+++ b/ja/news/_posts/2008-05-27-ruby-1-8-7-preview4-released.md
@@ -46,7 +46,7 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/34848
+[1]: https://blade.ruby-lang.org/ruby-dev/34848
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview4.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview4.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview4.zip

--- a/ja/news/_posts/2008-06-01-ruby-1-8-7-has-been-released.md
+++ b/ja/news/_posts/2008-06-01-ruby-1-8-7-has-been-released.md
@@ -40,7 +40,7 @@ Ruby 1.8.7がリリースされました。 (リリースについてのアナ�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44986
+[1]: https://blade.ruby-lang.org/ruby-list/44986
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.zip

--- a/ja/news/_posts/2008-06-13-ruby-1-8-7-p17-release.md
+++ b/ja/news/_posts/2008-06-13-ruby-1-8-7-p17-release.md
@@ -39,7 +39,7 @@ lang: ja
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45021
+[1]: https://blade.ruby-lang.org/ruby-list/45021
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p17.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p17.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p17.zip

--- a/ja/news/_posts/2008-08-20-seeking-platform-maintainers.md
+++ b/ja/news/_posts/2008-08-20-seeking-platform-maintainers.md
@@ -52,5 +52,5 @@ Rubyコア開発陣はいくつかのプラットフォームにおけるRuby 1.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45267
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45345
+[1]: https://blade.ruby-lang.org/ruby-list/45267
+[2]: https://blade.ruby-lang.org/ruby-list/45345

--- a/ja/news/_posts/2008-12-31-ruby-1-9-1-rc1-released.md
+++ b/ja/news/_posts/2008-12-31-ruby-1-9-1-rc1-released.md
@@ -56,11 +56,11 @@ RC1ではまだ対応が行われていない課題は、以下のURLです。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45758
+[1]: https://blade.ruby-lang.org/ruby-list/45758
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.zip
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45759
+[5]: https://blade.ruby-lang.org/ruby-list/45759
 [6]: http://arton.no-ip.info/data/asr/Ruby-1.9.1.msi
 [7]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=9
 [8]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=7

--- a/ja/news/_posts/2009-01-21-ruby-1-9-1-rc2-released.md
+++ b/ja/news/_posts/2009-01-21-ruby-1-9-1-rc2-released.md
@@ -43,7 +43,7 @@ RC2のリリースのアナウンスがありました。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45801
+[1]: https://blade.ruby-lang.org/ruby-list/45801
 [2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc2.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc2.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc2.zip

--- a/ja/news/_posts/2009-01-30-ruby-1-9-1-released.md
+++ b/ja/news/_posts/2009-01-30-ruby-1-9-1-released.md
@@ -56,7 +56,7 @@ Ruby 1.9.1は1.8から数多くの改良が加えられています。 1.8.7以�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45836
+[1]: https://blade.ruby-lang.org/ruby-list/45836
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS
 [3]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=11
 [4]: https://bugs.ruby-lang.org

--- a/ja/news/_posts/2009-04-02-ruby-1-8-6-p368-release.md
+++ b/ja/news/_posts/2009-04-02-ruby-1-8-6-p368-release.md
@@ -40,7 +40,7 @@ Ruby 1.8.6-p368は、安定版であるruby 1.8.6の保守リリースです。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45951
+[1]: https://blade.ruby-lang.org/ruby-list/45951
 [2]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-1558
 [3]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-1447
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.gz

--- a/ja/news/_posts/2009-04-16-ruby-1-8-7-p160-release.md
+++ b/ja/news/_posts/2009-04-16-ruby-1-8-7-p160-release.md
@@ -37,7 +37,7 @@ Ruby 1.8.7-p160は安定版であるruby 1.8.7の保守リリースです。
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/45969
+[1]: https://blade.ruby-lang.org/ruby-list/45969
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.gz
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.zip

--- a/ja/news/_posts/2009-09-13-rubyist-magazine-0027-published.md
+++ b/ja/news/_posts/2009-09-13-rubyist-magazine-0027-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0027号][3]がリリースされました([\[ruby-list:46390\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0027
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/46390
+[4]: https://blade.ruby-lang.org/ruby-list/46390

--- a/ja/news/_posts/2010-03-17-rubyist-magazine-0029-published.md
+++ b/ja/news/_posts/2010-03-17-rubyist-magazine-0029-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0029号][3]がリリースされました([\[ruby-list:46925\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0029
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/46925
+[4]: https://blade.ruby-lang.org/ruby-list/46925

--- a/ja/news/_posts/2010-06-15-rubyist-magazine-0030-published.md
+++ b/ja/news/_posts/2010-06-15-rubyist-magazine-0030-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0030号][3]がリリースされました([\[ruby-list:47156\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0030
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/47156
+[4]: https://blade.ruby-lang.org/ruby-list/47156

--- a/ja/news/_posts/2010-08-16-ruby-1-8-7-p302-is-released.md
+++ b/ja/news/_posts/2010-08-16-ruby-1-8-7-p302-is-released.md
@@ -47,7 +47,7 @@ SHA256(ruby-1.8.7-p302.zip):
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/ja/news/2010/08/16/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/ja/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
+++ b/ja/news/_posts/2010-08-16-xss-in-webrick-cve-2010-0541.md
@@ -62,4 +62,4 @@ Yamane氏がRubyセキュリティチームに報告したものです( [\[ruby-
 [2]: {{ site.url }}/ja/news/2010/08/16/ruby-1-8-7-p302-is-released/
 [3]: {{ site.url }}/ja/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/ja/news/_posts/2011-04-05-rubyist-magazine-0033-published.md
+++ b/ja/news/_posts/2011-04-05-rubyist-magazine-0033-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0033号][3]がリリースされました([\[ruby-list:47953\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0033
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/47953
+[4]: https://blade.ruby-lang.org/ruby-list/47953

--- a/ja/news/_posts/2011-06-12-rubyist-magazine-0034-published.md
+++ b/ja/news/_posts/2011-06-12-rubyist-magazine-0034-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0034号][3]がリリースされました([\[ruby-list:48179\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0034
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48179
+[4]: https://blade.ruby-lang.org/ruby-list/48179

--- a/ja/news/_posts/2011-09-26-rubyist-magazine-0035-published.md
+++ b/ja/news/_posts/2011-09-26-rubyist-magazine-0035-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0035号][3]がリリースされました([\[ruby-list:48417\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0035
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48417
+[4]: https://blade.ruby-lang.org/ruby-list/48417

--- a/ja/news/_posts/2011-12-03-rubyist-magazine-0036-published.md
+++ b/ja/news/_posts/2011-12-03-rubyist-magazine-0036-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0036号][3]がリリースされました([\[ruby-list:48546\]][
 [1]: http://jp.rubyist.net/
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0036
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48546
+[4]: https://blade.ruby-lang.org/ruby-list/48546

--- a/ja/news/_posts/2012-02-05-rubyist-magazine-0037-published.md
+++ b/ja/news/_posts/2012-02-05-rubyist-magazine-0037-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0037号][3]がリリースされました([\[ruby-list:48616\]][
 [1]: https://github.com/ruby-no-kai/official/wiki
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0037
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48616
+[4]: https://blade.ruby-lang.org/ruby-list/48616

--- a/ja/news/_posts/2012-05-22-rubyist-magazine-0038-published.md
+++ b/ja/news/_posts/2012-05-22-rubyist-magazine-0038-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0038号][3]がリリースされました([\[ruby-list:48778\]][
 [1]: https://github.com/ruby-no-kai/official/wiki
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0038
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48778
+[4]: https://blade.ruby-lang.org/ruby-list/48778

--- a/ja/news/_posts/2012-09-06-rubyist-magazine-0039-published.md
+++ b/ja/news/_posts/2012-09-06-rubyist-magazine-0039-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0039号][3]がリリースされました([\[ruby-list:48941\]][
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0039
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/48941
+[4]: https://blade.ruby-lang.org/ruby-list/48941

--- a/ja/news/_posts/2012-11-25-rubyist-magazine-0040-published.md
+++ b/ja/news/_posts/2012-11-25-rubyist-magazine-0040-published.md
@@ -14,4 +14,4 @@ Magazine][2]の[0040号][3]がリリースされました([\[ruby-list:49015\]][
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0040
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49015
+[4]: https://blade.ruby-lang.org/ruby-list/49015

--- a/ja/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/ja/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -107,6 +107,6 @@ preview と rc1 を試してくれた皆さんに感謝します。 相変わら
 [10]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [11]: https://bugs.ruby-lang.org/issues/6679
 [12]: https://blade.ruby-lang.org/ruby-dev/46547
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[14]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[13]: https://blade.ruby-lang.org/ruby-core/48984
+[14]: https://blade.ruby-lang.org/ruby-core/49119
 [15]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/ja/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/ja/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -106,7 +106,7 @@ preview と rc1 を試してくれた皆さんに感謝します。 相変わら
 [9]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [10]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [11]: https://bugs.ruby-lang.org/issues/6679
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[12]: https://blade.ruby-lang.org/ruby-dev/46547
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [14]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [15]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/ja/news/_posts/2013-05-30-rubyist-magazine-0042-published.md
+++ b/ja/news/_posts/2013-05-30-rubyist-magazine-0042-published.md
@@ -15,4 +15,4 @@ Magazine][2]の[0042号][3]がリリースされました([\[ruby-list:49434\]][
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0042
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49434
+[4]: https://blade.ruby-lang.org/ruby-list/49434

--- a/ja/news/_posts/2013-09-30-rubyist-magazine-0044-published.md
+++ b/ja/news/_posts/2013-09-30-rubyist-magazine-0044-published.md
@@ -15,5 +15,5 @@ Magazine][2]の[0044号][3]がリリースされました([\[ruby-list:49619\]][
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0044
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49619
+[4]: https://blade.ruby-lang.org/ruby-list/49619
 [5]: http://jp.rubyist.net/magazine/?0043

--- a/ja/news/_posts/2013-12-21-rubyist-magazine-0045-published.md
+++ b/ja/news/_posts/2013-12-21-rubyist-magazine-0045-published.md
@@ -13,4 +13,4 @@ Magazine][2]の[0045号][3]がリリースされました([\[ruby-list:49732\]][
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0045
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49732
+[4]: https://blade.ruby-lang.org/ruby-list/49732

--- a/ja/news/_posts/2014-04-04-rubyist-magazine-0046-published.md
+++ b/ja/news/_posts/2014-04-04-rubyist-magazine-0046-published.md
@@ -14,4 +14,4 @@ Magazine][2]の[0046号][3]がリリースされました([\[ruby-list:49784\]][
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0046
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49784
+[4]: https://blade.ruby-lang.org/ruby-list/49784

--- a/ja/news/_posts/2014-06-30-rubyist-magazine-0047-published.md
+++ b/ja/news/_posts/2014-06-30-rubyist-magazine-0047-published.md
@@ -14,4 +14,4 @@ Magazine][2]の[0047号][3]がリリースされました([\[ruby-list:49858\]][
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0047
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49858
+[4]: https://blade.ruby-lang.org/ruby-list/49858

--- a/ja/news/_posts/2014-12-14-rubyist-magazine-0049-published.md
+++ b/ja/news/_posts/2014-12-14-rubyist-magazine-0049-published.md
@@ -13,4 +13,4 @@ lang: ja
 [1]: http://ruby-no-kai.org/
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0049
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50027
+[4]: https://blade.ruby-lang.org/ruby-list/50027

--- a/ja/news/_posts/2015-05-10-rubyist-magazine-0050-published.md
+++ b/ja/news/_posts/2015-05-10-rubyist-magazine-0050-published.md
@@ -13,4 +13,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://jp.rubyist.net/magazine/
 [3]: http://jp.rubyist.net/magazine/?0050
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50151
+[4]: https://blade.ruby-lang.org/ruby-list/50151

--- a/ja/news/_posts/2015-09-06-rubyist-magazine-0051-published.md
+++ b/ja/news/_posts/2015-09-06-rubyist-magazine-0051-published.md
@@ -13,4 +13,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0051
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50222
+[4]: https://blade.ruby-lang.org/ruby-list/50222

--- a/ja/news/_posts/2015-12-06-rubyist-magazine-0052-published.md
+++ b/ja/news/_posts/2015-12-06-rubyist-magazine-0052-published.md
@@ -27,4 +27,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0052
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50263
+[4]: https://blade.ruby-lang.org/ruby-list/50263

--- a/ja/news/_posts/2016-04-03-rubyist-magazine-0053-published.md
+++ b/ja/news/_posts/2016-04-03-rubyist-magazine-0053-published.md
@@ -27,4 +27,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0053
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50299
+[4]: https://blade.ruby-lang.org/ruby-list/50299

--- a/ja/news/_posts/2016-08-22-rubyist-magazine-0054-published.md
+++ b/ja/news/_posts/2016-08-22-rubyist-magazine-0054-published.md
@@ -28,4 +28,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0054
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50378
+[4]: https://blade.ruby-lang.org/ruby-list/50378

--- a/ja/news/_posts/2017-03-26-rubyist-magazine-0055-published.md
+++ b/ja/news/_posts/2017-03-26-rubyist-magazine-0055-published.md
@@ -25,4 +25,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0055
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50505
+[4]: https://blade.ruby-lang.org/ruby-list/50505

--- a/ja/news/_posts/2017-08-27-rubyist-magazine-0056-published.md
+++ b/ja/news/_posts/2017-08-27-rubyist-magazine-0056-published.md
@@ -26,4 +26,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0056
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50565
+[4]: https://blade.ruby-lang.org/ruby-list/50565

--- a/ja/news/_posts/2018-02-11-rubyist-magazine-0057-published.md
+++ b/ja/news/_posts/2018-02-11-rubyist-magazine-0057-published.md
@@ -26,4 +26,4 @@ lang: ja
 [1]: http://ruby-no-kai.org
 [2]: http://magazine.rubyist.net/
 [3]: http://magazine.rubyist.net/?0057
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50654
+[4]: https://blade.ruby-lang.org/ruby-list/50654

--- a/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
+++ b/ja/news/_posts/2018-08-28-rubyist-magazine-0058-published.md
@@ -22,4 +22,4 @@ lang: ja
 [1]: https://ruby-no-kai.org/
 [2]: https://magazine.rubyist.net/
 [3]: https://magazine.rubyist.net/articles/0058/0058-index.html
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50698
+[4]: https://blade.ruby-lang.org/ruby-list/50698

--- a/ja/news/_posts/2019-01-27-rubyist-magazine-0059-published.md
+++ b/ja/news/_posts/2019-01-27-rubyist-magazine-0059-published.md
@@ -27,4 +27,4 @@ lang: ja
 [1]: https://ruby-no-kai.org/
 [2]: https://magazine.rubyist.net/
 [3]: https://magazine.rubyist.net/articles/0059/0059-index.html
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50745
+[4]: https://blade.ruby-lang.org/ruby-list/50745

--- a/ja/news/_posts/2019-08-18-rubyist-magazine-0060-published.md
+++ b/ja/news/_posts/2019-08-18-rubyist-magazine-0060-published.md
@@ -30,4 +30,4 @@ lang: ja
 [1]: https://ruby-no-kai.org/
 [2]: https://magazine.rubyist.net/
 [3]: https://magazine.rubyist.net/articles/0060/0060-index.html
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50811
+[4]: https://blade.ruby-lang.org/ruby-list/50811

--- a/ja/news/_posts/2020-02-02-rubyist-magazine-0061-published.md
+++ b/ja/news/_posts/2020-02-02-rubyist-magazine-0061-published.md
@@ -25,4 +25,4 @@ lang: ja
 [1]: https://ruby-no-kai.org/
 [2]: https://magazine.rubyist.net/
 [3]: https://magazine.rubyist.net/articles/0061/0061-index.html
-[4]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50872
+[4]: https://blade.ruby-lang.org/ruby-list/50872

--- a/ko/about/index.md
+++ b/ko/about/index.md
@@ -174,7 +174,7 @@ MRI가 지원하지 않는 특별한 기능을 가지거나 합니다.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/ko/community/ruby-core/writing-patches/index.md
+++ b/ko/community/ruby-core/writing-patches/index.md
@@ -45,4 +45,4 @@ lang: ko
 위의 지침을 따른다면 낙심할 일을 줄일 수 있을 겁니다.
 
 
-[ruby-core-post]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[ruby-core-post]: https://blade.ruby-lang.org/ruby-core/25139

--- a/ko/news/_posts/2002-12-07-raa-2-1-0.md
+++ b/ko/news/_posts/2002-12-07-raa-2-1-0.md
@@ -47,4 +47,4 @@ NAKAMURA, Hiroshi aka NaHi and U.Nakamura aka usa.
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/58018
+[2]: https://blade.ruby-lang.org/ruby-talk/58018

--- a/ko/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
+++ b/ko/news/_posts/2002-12-18-color-scheme-of-wwwruby-langorg.md
@@ -16,4 +16,4 @@ ruby-talk.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/59202
+[1]: https://blade.ruby-lang.org/ruby-talk/59202

--- a/ko/news/_posts/2003-01-31-raa-2-3-0.md
+++ b/ko/news/_posts/2003-01-31-raa-2-3-0.md
@@ -17,5 +17,5 @@ RAA [Ruby Application Archive][1] has been updated. (see [\[ruby-talk:63170\]][2
 
 
 [1]: http://raa.ruby-lang.org/
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/63170
-[3]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/62840
+[2]: https://blade.ruby-lang.org/ruby-talk/63170
+[3]: https://blade.ruby-lang.org/ruby-talk/62840

--- a/ko/news/_posts/2003-02-21-first-europeen-ruby-conference.md
+++ b/ko/news/_posts/2003-02-21-first-europeen-ruby-conference.md
@@ -18,4 +18,4 @@ mailing-lists, and so on, see [\[ruby-talk:65418\]][1])
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65418
+[1]: https://blade.ruby-lang.org/ruby-talk/65418

--- a/ko/news/_posts/2003-02-24-happy-birthday-ruby.md
+++ b/ko/news/_posts/2003-02-24-happy-birthday-ruby.md
@@ -17,4 +17,4 @@ Inc][1] and RubyConf 2003!. See [\[ruby-talk:65632\]][2].
 
 
 [1]: http://rubycentral.org
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/65632
+[2]: https://blade.ruby-lang.org/ruby-talk/65632

--- a/ko/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
+++ b/ko/news/_posts/2003-12-19-new-ruby-change-request-rcr-process.md
@@ -17,7 +17,7 @@ process 3 years ago.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/88503
+[1]: https://blade.ruby-lang.org/ruby-talk/88503
 [2]: http://www.rubyconf.org
 [3]: http://www.rubyist.net/%7Ematz/slides/rc2003
 [4]: http://rcrchive.net

--- a/ko/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
+++ b/ko/news/_posts/2004-12-19-pragmatic-bookshelf-planning-a-series-of-ruby-books.md
@@ -17,4 +17,4 @@ guidelines for potential authors.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/123137
+[1]: https://blade.ruby-lang.org/ruby-talk/123137

--- a/ko/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
+++ b/ko/news/_posts/2005-03-11-rubycentral-codefest-grants-announced.md
@@ -13,5 +13,5 @@ Congratulations to the recipients!
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/133197
+[1]: https://blade.ruby-lang.org/ruby-talk/133197
 [2]: http://www.rubycentral.org/grant/announce.html

--- a/ko/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
+++ b/ko/news/_posts/2005-08-31-rubyconf-2005-registration-time-is-running-out.md
@@ -13,5 +13,5 @@ two weeks. Non-full may continue past that, but not forever. Go to the
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/154337
+[1]: https://blade.ruby-lang.org/ruby-talk/154337
 [2]: http://www.rubyconf.org

--- a/ko/news/_posts/2006-06-20-the-future-of-ruby.md
+++ b/ko/news/_posts/2006-06-20-the-future-of-ruby.md
@@ -19,5 +19,5 @@ lang: ko
 
 
 [1]: http://eigenclass.org/hiki.rb?Changes+in+Ruby+1.9
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/197229
+[2]: https://blade.ruby-lang.org/ruby-talk/197229
 [3]: http://www.rubyist.net/~matz/slides/rc2005/mgp00006.html

--- a/ko/news/_posts/2006-09-17-site-launch-at-last.md
+++ b/ko/news/_posts/2006-09-17-site-launch-at-last.md
@@ -42,7 +42,7 @@ The Ruby Visual Identity Team의 구성원을 소개합니다.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/131284
+[1]: https://blade.ruby-lang.org/ruby-talk/131284
 [2]: http://redhanded.hobix.com/redesign2005/
 [3]: http://radiantcms.org
 [4]: http://rubyforge.org/mailman/listinfo/vit-discuss/

--- a/ko/news/_posts/2007-01-01-ruby-1-8-5-p12.md
+++ b/ko/news/_posts/2007-01-01-ruby-1-8-5-p12.md
@@ -18,5 +18,5 @@ md5sum은 d7d12dd9124c9b7d55cdbbee313e3931이고 파일 크기는 4,526,961 바�
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43074
+[1]: https://blade.ruby-lang.org/ruby-list/43074
 [2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz

--- a/ko/news/_posts/2007-03-14-ruby-1-8-6.md
+++ b/ko/news/_posts/2007-03-14-ruby-1-8-6.md
@@ -34,6 +34,6 @@ lang: ko
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_6/NEWS
 [3]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_6/ChangeLog

--- a/ko/news/_posts/2007-03-14-uby-1-8-5-p35-release.md
+++ b/ko/news/_posts/2007-03-14-uby-1-8-5-p35-release.md
@@ -20,5 +20,5 @@ lang: ko
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43268
+[1]: https://blade.ruby-lang.org/ruby-list/43268
 [2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_5_35/ChangeLog

--- a/ko/news/_posts/2007-09-27-ruby-1-8-6-p110-release.md
+++ b/ko/news/_posts/2007-09-27-ruby-1-8-6-p110-release.md
@@ -53,8 +53,8 @@ lang: ko
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44054
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/44055
+[1]: https://blade.ruby-lang.org/ruby-list/44054
+[2]: https://blade.ruby-lang.org/ruby-list/44055
 [3]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_6_110/ChangeLog
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.bz2
 [5]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.gz

--- a/ko/news/_posts/2010-08-16-webrick-xss-cve-2010-0541.md
+++ b/ko/news/_posts/2010-08-16-webrick-xss-cve-2010-0541.md
@@ -56,4 +56,4 @@ SHA256:
 [3]: {{ site.url }}/ko/news/2010/08/16/ruby-1-8-7-p302-is-released/
 [4]: {{ site.url }}/ko/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [5]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[6]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[6]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/pl/about/index.md
+++ b/pl/about/index.md
@@ -225,7 +225,7 @@ Tu jest lista:
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/pt/about/index.md
+++ b/pt/about/index.md
@@ -236,7 +236,7 @@ Nov. 2001.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/pt/community/ruby-core/index.md
+++ b/pt/community/ruby-core/index.md
@@ -169,7 +169,7 @@ Veja também as informações no [_issue tracker_ do Ruby][10].
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/ru/about/index.md
+++ b/ru/about/index.md
@@ -232,7 +232,7 @@ Ruby как язык имеет несколько разных реализац
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/ru/community/ruby-core/index.md
+++ b/ru/community/ruby-core/index.md
@@ -165,7 +165,7 @@ $ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.bran
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/ru/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/ru/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -117,7 +117,7 @@ FYI: Мы добавляем записи с обновлениями, но ча
 [8]: http://el.jibun.atmarkit.co.jp/rails/2012/11/ruby-20-8256.html
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/46547
+[11]: https://blade.ruby-lang.org/ruby-dev/46547
 [12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
 [13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/ru/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
+++ b/ru/news/_posts/2013-02-08-ruby-2-0-0-rc2-is-released.md
@@ -118,6 +118,6 @@ FYI: Мы добавляем записи с обновлениями, но ча
 [9]: https://speakerdeck.com/nagachika/rubyist-enumeratorlazy
 [10]: https://bugs.ruby-lang.org/issues/6679
 [11]: https://blade.ruby-lang.org/ruby-dev/46547
-[12]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/48984
-[13]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/49119
+[12]: https://blade.ruby-lang.org/ruby-core/48984
+[13]: https://blade.ruby-lang.org/ruby-core/49119
 [14]: https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft

--- a/tr/about/index.md
+++ b/tr/about/index.md
@@ -207,7 +207,7 @@ Daha tam bir liste için, [Müthiş Ruby'ler][awesome-rubies]e bakın.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/tr/community/ruby-core/writing-patches/index.md
+++ b/tr/community/ruby-core/writing-patches/index.md
@@ -48,4 +48,4 @@ Bu kılavuz Ruby-Core e-posta listesindeki
 kılavuza uymak düş kırıklığına uğramamanız için önemlidir.
 
 
-[ruby-core-post]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[ruby-core-post]: https://blade.ruby-lang.org/ruby-core/25139

--- a/vi/about/index.md
+++ b/vi/about/index.md
@@ -183,7 +183,7 @@ với các hệ UNIX khác, như macOS, Windows, DOS, BeOS, OS/2, vân vân.
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/vi/community/ruby-core/index.md
+++ b/vi/community/ruby-core/index.md
@@ -157,7 +157,7 @@ Xem thêm thông tin về [Ruby’s issue tracker][10].
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/zh_cn/about/index.md
+++ b/zh_cn/about/index.md
@@ -141,7 +141,7 @@ Ruby 还有其他众多特性，下面列举一些：
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/zh_cn/community/ruby-core/index.md
+++ b/zh_cn/community/ruby-core/index.md
@@ -111,7 +111,7 @@ Ruby 开发的讨论集中在 [Ruby 核心邮件列表][mailing-lists]。如果�
 [8]: https://github.com/shyouhei/ruby/wiki/committerhowto
 [9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
 [10]: https://bugs.ruby-lang.org/
-[11]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/25139
+[11]: https://blade.ruby-lang.org/ruby-core/25139
 [12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
 [13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
 [14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/zh_tw/about/index.md
+++ b/zh_tw/about/index.md
@@ -128,7 +128,7 @@ Ruby 還具有以下的特點：
 
 
 [matz]: http://www.rubyist.net/~matz/
-[blade]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/2773
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
 [ror]: http://rubyonrails.org/
 [linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
 [artima]: http://www.artima.com/intv/closures2.html

--- a/zh_tw/news/_posts/2007-03-14-ruby-1-8-6-released.md
+++ b/zh_tw/news/_posts/2007-03-14-ruby-1-8-6-released.md
@@ -34,7 +34,7 @@ check them out after upgrading Ruby to 1.8.6.
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/43267
+[1]: https://blade.ruby-lang.org/ruby-list/43267
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.gz
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.zip

--- a/zh_tw/news/_posts/2010-08-18-ruby-1-8-7-p302-is-released.md
+++ b/zh_tw/news/_posts/2010-08-18-ruby-1-8-7-p302-is-released.md
@@ -49,7 +49,7 @@ SHA256(ruby-1.8.7-p302.zip):
 
 
 
-[1]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[1]: https://blade.ruby-lang.org/ruby-talk/367769
 [2]: {{ site.url }}/en/news/2010/08/16/xss-in-webrick-cve-2010-0541/
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2
 [4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz

--- a/zh_tw/news/_posts/2010-08-18-xss-in-webrick-cve-2010-0541.md
+++ b/zh_tw/news/_posts/2010-08-18-xss-in-webrick-cve-2010-0541.md
@@ -71,4 +71,4 @@ WEBrick 有個 XSS (cross-site scripting) 弱點, 可以讓入侵者經由特製
 [2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
-[5]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/42003
+[5]: https://blade.ruby-lang.org/ruby-dev/42003

--- a/zh_tw/news/_posts/2010-08-18-xss-in-webrick-cve-2010-0541.md
+++ b/zh_tw/news/_posts/2010-08-18-xss-in-webrick-cve-2010-0541.md
@@ -68,7 +68,7 @@ WEBrick 有個 XSS (cross-site scripting) 弱點, 可以讓入侵者經由特製
 
 
 [1]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-0541
-[2]: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/367769
+[2]: https://blade.ruby-lang.org/ruby-talk/367769
 [3]: {{ site.url }}/en/news/2010/08/16/ruby-1-9-1-p430-is-released/
 [4]: https://cache.ruby-lang.org/pub/misc/webrick-cve-2010-0541.diff
 [5]: https://blade.ruby-lang.org/ruby-dev/42003


### PR DESCRIPTION
blade.nagaokaut.ac.jp is down and I restored their archives to https://blade.ruby-lang.org. We should replace the old links to blade.ruby-lang.org.

Note: ruby-talk is still missing status. I'll replace them after restoring them.