### PR TITLE
Translate Ruby 3.2.1 released (ko)

### DIFF
--- a/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
+++ b/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
@@ -1,19 +1,19 @@
 ---
 layout: news_post
-title: "Ruby 3.2.1 Released"
+title: "Ruby 3.2.1 릴리스"
 author: "naruse"
-translator:
+translator: "shia"
 date: 2023-02-08 12:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.2.1 has been released.
+Ruby 3.2.1이 릴리스되었습니다.
 
-This is the first TEENY version release of the stable 3.2 series.
+3.2 안정 버전대의 첫 TEENY 버전입니다.
 
-See the [commit logs](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1) for further details.
+자세한 사항은 [커밋 로그](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1)를 확인해 주세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.2.1" | first %}
 
@@ -38,7 +38,7 @@ See the [commit logs](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1) for 
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
+++ b/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
@@ -1,0 +1,44 @@
+---
+layout: news_post
+title: "Ruby 3.2.1 Released"
+author: "naruse"
+translator:
+date: 2023-02-08 12:00:00 +0000
+lang: en
+---
+
+Ruby 3.2.1 has been released.
+
+This is the first TEENY version release of the stable 3.2 series.
+
+See the [commit logs](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.1" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.


### PR DESCRIPTION
:link: #2818

Translation of Ruby 3.2.1 Released.
https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2023-02-08-ruby-3-2-1-released.md

Actual diff aaeb5840aaa440d6b873a34fa688ed38d6f8a1b9