### PR TITLE
Replace commit logs to GitHub releases at en and ja

### DIFF
--- a/en/news/_posts/2022-11-24-ruby-2-7-7-released.md
+++ b/en/news/_posts/2022-11-24-ruby-2-7-7-released.md
@@ -15,7 +15,7 @@ Please check the topics below for details.
 * [CVE-2021-33621: HTTP response splitting in CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 This release also includes some build problem fixes. They are not considered to affect compatibility with previous versions.
-See the [commit logs](https://github.com/ruby/ruby/compare/v2_7_6...v2_7_7) for further details.
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v2_7_7) for further details.
 
 ## Download
 

--- a/en/news/_posts/2022-11-24-ruby-3-0-5-released.md
+++ b/en/news/_posts/2022-11-24-ruby-3-0-5-released.md
@@ -15,7 +15,7 @@ Please check the topics below for details.
 * [CVE-2021-33621: HTTP response splitting in CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 This release also includes some bug fixes.
-See the [commit logs](https://github.com/ruby/ruby/compare/v3_0_4...v3_0_5) for further details.
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_5) for further details.
 
 ## Download
 

--- a/en/news/_posts/2022-11-24-ruby-3-1-3-released.md
+++ b/en/news/_posts/2022-11-24-ruby-3-1-3-released.md
@@ -17,7 +17,7 @@ Please check the topics below for details.
 This release also includes a fix for build failure with Xcode 14 and macOS 13 (Ventura).
 See [the related ticket](https://bugs.ruby-lang.org/issues/18912) for more details.
 
-See the [commit logs](https://github.com/ruby/ruby/compare/v3_1_2...v3_1_3) for further details.
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_3) for further details.
 
 ## Download
 

--- a/en/news/_posts/2023-02-08-ruby-3-2-1-released.md
+++ b/en/news/_posts/2023-02-08-ruby-3-2-1-released.md
@@ -11,7 +11,7 @@ Ruby 3.2.1 has been released.
 
 This is the first TEENY version release of the stable 3.2 series.
 
-See the [commit logs](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1) for further details.
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_1) for further details.
 
 ## Download
 

--- a/ja/news/_posts/2022-11-24-ruby-2-7-7-released.md
+++ b/ja/news/_posts/2022-11-24-ruby-2-7-7-released.md
@@ -15,7 +15,7 @@ Ruby 2.7.7 がリリースされました。
 * [CVE-2021-33621: HTTP response splitting in CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 このリリースには、いくつかのビルド上の問題への対応も含まれています。これらの変更は以前のバージョンとの互換性には影響しないと判断されています。
-詳しくは [commit logs](https://github.com/ruby/ruby/compare/v2_7_6...v2_7_7) を参照してください。
+詳しくは [GitHub releases](https://github.com/ruby/ruby/releases/tag/v2_7_7) を参照してください。
 
 ## ダウンロード
 

--- a/ja/news/_posts/2022-11-24-ruby-3-0-5-released.md
+++ b/ja/news/_posts/2022-11-24-ruby-3-0-5-released.md
@@ -15,7 +15,7 @@ Ruby 3.0.5 がリリースされました。
 * [CVE-2021-33621: HTTP response splitting in CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 このリリースには、いくつかのバグ修正も含まれています。
-詳しくは [commit logs](https://github.com/ruby/ruby/compare/v3_0_4...v3_0_5) を参照してください。
+詳しくは [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_5) を参照してください。
 
 ## ダウンロード
 

--- a/ja/news/_posts/2022-11-24-ruby-3-1-3-released.md
+++ b/ja/news/_posts/2022-11-24-ruby-3-1-3-released.md
@@ -17,7 +17,7 @@ Ruby 3.1.3 がリリースされました。
 またこのリリースでは Xcode 14 や macOS 13 (Ventura) でのビルドがうまくいかない問題に対する対策も含まれています。
 詳しくは [関連チケット](https://bugs.ruby-lang.org/issues/18912) を参照してください。
 
-その他の変更点について詳しくは [commit logs](https://github.com/ruby/ruby/compare/v3_1_2...v3_1_3) を参照してください。
+その他の変更点について詳しくは [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_3) を参照してください。
 
 ## ダウンロード
 

--- a/ja/news/_posts/2023-02-08-ruby-3-2-1-released.md
+++ b/ja/news/_posts/2023-02-08-ruby-3-2-1-released.md
@@ -11,7 +11,7 @@ Ruby 3.2.1 がリリースされました。
 
 これは 3.2 シリーズにおける最初の TEENY リリースになります。
 
-詳しい変更については [commit log](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1) を参照してください。
+詳しい変更については [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_1) を参照してください。
 
 ## ダウンロード
 


### PR DESCRIPTION
I created [GitHub releases for Ruby 3.2.1](https://github.com/ruby/ruby/releases/tag/v3_2_1) and other versions. It's useful note contained notable changes.