### PR TITLE
Replace commit logs to GitHub releases (ko)

### DIFF
--- a/ko/news/_posts/2022-11-24-ruby-2-7-7-released.md
+++ b/ko/news/_posts/2022-11-24-ruby-2-7-7-released.md
@@ -15,7 +15,7 @@ Ruby 2.7.7이 릴리스되었습니다.
 * [CVE-2021-33621: CGI에서의 HTTP 응답 분할]({%link ko/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 이 릴리스는 몇몇 빌드 문제 수정을 포함합니다. 이는 이전 버전과 호환성 문제를 일으키지 않습니다.
-자세한 사항은 [커밋 로그](https://github.com/ruby/ruby/compare/v2_7_6...v2_7_7)를 확인해 주세요.
+자세한 사항은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v2_7_7)를 확인해 주세요.
 
 ## 다운로드
 

--- a/ko/news/_posts/2022-11-24-ruby-3-0-5-released.md
+++ b/ko/news/_posts/2022-11-24-ruby-3-0-5-released.md
@@ -15,7 +15,7 @@ Ruby 3.0.5가 릴리스되었습니다.
 * [CVE-2021-33621: CGI에서의 HTTP 응답 분할]({%link ko/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
 
 이 릴리스는 몇몇 버그 수정을 포함합니다.
-자세한 사항은 [커밋 로그](https://github.com/ruby/ruby/compare/v3_0_4...v3_0_5)를 확인해 주세요.
+자세한 사항은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_0_5)를 확인해 주세요.
 
 ## 다운로드
 

--- a/ko/news/_posts/2022-11-24-ruby-3-1-3-released.md
+++ b/ko/news/_posts/2022-11-24-ruby-3-1-3-released.md
@@ -17,7 +17,7 @@ Ruby 3.1.3이 릴리스되었습니다.
 이 릴리스는 Xcode 14와 macOS 13(Ventura)에서의 빌드 실패에 대한 수정을 포함합니다.
 자세한 사항은 [관련 티켓](https://bugs.ruby-lang.org/issues/18912)을 확인해 주세요.
 
-자세한 사항은 [커밋 로그](https://github.com/ruby/ruby/compare/v3_1_2...v3_1_3)를 확인해 주세요.
+자세한 사항은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_1_3)를 확인해 주세요.
 
 ## 다운로드
 

--- a/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
+++ b/ko/news/_posts/2023-02-08-ruby-3-2-1-released.md
@@ -11,7 +11,7 @@ Ruby 3.2.1이 릴리스되었습니다.
 
 3.2 안정 버전대의 첫 TEENY 버전입니다.
 
-자세한 사항은 [커밋 로그](https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1)를 확인해 주세요.
+자세한 사항은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_1)를 확인해 주세요.
 
 ## 다운로드
 


### PR DESCRIPTION
:link: #2818

Apply #2980 to ko.

Use `GitHub` as it is, I think it's better. 🤔
Should we translate to `깃헙`?