### PR TITLE
Improve ja/downloads/releases/ layout

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -483,7 +483,7 @@ hr.hidden-modern { display: none; }
 
 .release-list th,
 .release-list td {
-  padding: 2px 2em 2px 0px;
+  padding: 2px 1em 2px 0px;
 }
 
 .buttons .button {


### PR DESCRIPTION
With windows chrome ja/downloads/releases/ has too many line breaks. 
This change improves that. See <a href= "https://gist.github.com/gotoken/f51d105dba6f48b5b65180aacb2f9634">screenshots</a>.