### PR TITLE
Update translation of documentation/installation (ja)

### DIFF
--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -190,7 +190,7 @@ $ sudo pacman -S ruby
 ### Homebrew (macOS)
 {: #homebrew}
 
-Ruby2.0以降はEI Capian(10.11)のリリース以降よりMacOSに始めから含まれています。
+El Capitan (10.11) のリリース以降、macOS には Ruby 2.0 以上が同梱されています。
 [Homebrew](https://brew.sh/)はmacOSで利用されているパッケージ管理システムです。
 Homebrewを使うことでRubyを簡単にインストールできます。
 

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -154,7 +154,7 @@ SnapはCanonialによって開発されたパッケージ管理システムで�
 $ sudo snap install ruby --classic
 {% endhighlight %}
 
-Rubyにはいくつかのマイナーシリーズがあります。例えば以下のように実行するとRuby2.3に切り替えることが可能です。
+マイナーシリーズごとの channel が用意されています。例えば以下を実行するとRuby 2.3に切り替えることが可能です。
 
 {% highlight sh %}
 $ sudo snap switch ruby --channnell=2.3/stable

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -109,17 +109,17 @@ Ruby コミュニティの中の一部のメンバーは Ruby をインストー
 このページには以下のパッケージマネージャが記述されています。
 
   * [Debian, Ubuntu](#apt)
-	* [CentOS, Fedora,RHEL](#yum)
-	* [Snap](#snap)
-	* [Gentoo](#portage)
-	* [Arch Linux](#pacman)
-	* [macOS](#homebrew)
-	* [FreeBSD](#pkg)
-	* [OpenBSD](#doas)
-	* [OpenIndiana](#openindiana)
-	* [Windows Package manager](#winget)
-	* [Chocolatey package manager for Windows](#choco)
-	* [Other Distribution](#other)
+  * [CentOS, Fedora,RHEL](#yum)
+  * [Snap](#snap)
+  * [Gentoo](#portage)
+  * [Arch Linux](#pacman)
+  * [macOS](#homebrew)
+  * [FreeBSD](#pkg)
+  * [OpenBSD](#doas)
+  * [OpenIndiana](#openindiana)
+  * [Windows Package manager](#winget)
+  * [Chocolatey package manager for Windows](#choco)
+  * [Other Distribution](#other)
 
 
 ### apt (Debian or Ubuntu)

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -205,7 +205,7 @@ WindowsでRubyをインストールするには[Windows Package Manager CLI](htt
 ### Chocolatey package manager for Windows
 {: #choco}
 同じくWindowsでは[Chocolatey Package Manager](https://chocolatey.org/install) を利用してRubyのインストールが可能です。
- 
+
 {% highlight sh %}
 > choco install ruby
 {% endhighlight %}

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -7,91 +7,51 @@ lang: ja
 いくつかのツールを使ってRubyをインストールできます。
 このページでは、Rubyの管理とインストールのための、メジャーなパッケージ管理ツールとサードパーティツールについて解説します。
 
+あなたのコンピューターにはすでにRubyがインストールされているかもしれません。[ターミナルソフト][terminal]で以下のように打つと確認することができます。
 
-## システムごとのインストール方法
+{% highlight sh %}
+ruby -v
+{% endhighlight %}
 
-利用可能なインストール方法を解説します。
-お好みの使いやすい方法を選んでください。
+インストールされているRubyのバージョンに関する情報が出力されるはずです。
+## インストール方法を選択
+Rubyをインストールするには、いくつかの方法があります。
 
-* macOS
+* UNIX系のOSでは、システムの ***パッケージマネージャ*** を利用するのが最も簡単です。ただし、パッケージ化されたRubyのバージョンが最新であるとは限りません。
+* ***インストーラ*** を使えば、特定の、あるいは複数のRubyバージョンをインストールすることができます。また、Windows用のインストーラもあります。
+* ***マネージャ*** は、システム上で複数のRubyのバージョンを切り替えるのに役立ちます。
+* 最後に、***Rubyをソースからビルドする***こともできます。
 
-  * [rbenv](#rbenv)
-  * [RVM](#rvm)
+Windows 10 では、[Windows Subsystem for Linux][wsl] を使用して、サポートされている Linux ディストリビューションの 1 つをインストールし、そのシステムで利用可能なインストール方法のいずれかを使用することもできます。
+
+以下は、利用可能なインストール方法です。
+
+* [Package Management Systems](#package-management-systems)
+  * [Debian, Ubuntu](#apt)
+  * [CentOS, Fedora, RHEL](#yum)
+  * [Snap](#snap)
+  * [Gentoo](#portage)
+  * [Arch Linux](#pacman)
+  * [macOS](#homebrew)
+  * [FreeBSD](#freebsd)
+  * [OpenBSD](#openbsd)
+  * [OpenIndiana](#openindiana)
+  * [Windows Package Manager](#winget)
+  * [Chocolatey package manager for Windows](#chocolatey)
+  * [Other Distributions](#other-systems)
+* [Installers](#installers)
+  * [ruby-build](#ruby-build)
+  * [ruby-install](#ruby-install)
+  * [RubyInstaller](#rubyinstaller) (Windows)
+  * [Ruby Stack](#rubystack)
+* [Managers](#managers)
+  * [asdf-vm](#asdf-vm)
   * [chruby](#chruby)
-  * [Homebrew](#homebrew)
-  * [ソースからのビルド](#building-from-source)
-
-* Linux/UNIX
-
   * [rbenv](#rbenv)
+  * [rbenv for Windows](#rbenv-for-windows)
   * [RVM](#rvm)
-  * [chruby](#chruby)
-  * [パッケージ管理システム](#package-management-systems)
-  * [ソースからのビルド](#building-from-source)
-
-* Windows
-
-  * [WSL](#apt-wsl)
-  * [RubyInstaller](#rubyinstaller)
-  * [RailsInstaller](#railsinstaller)
-
-## サードパーティツール
-
-多くのRubyistたちは様々な特徴を持つサードパーティツールを使ってRubyをインストールしています。
-
-各ツールには様々な利点がありますが、オフィシャルにサポートしている方法ではありません。
-しかし、それぞれのコミュニティが心強い助けになるでしょう。
-
-
-### rbenv
-{: #rbenv}
-
-rbenv では複数の Ruby を管理することができます。
-
-rbenv は Ruby のインストール自体はサポートしていませんが、
-[ruby-build](https://github.com/rbenv/ruby-build) というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
-
-それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
-
-rbenv をインストールする方法は [rbenvのページ][rbenv] に記述されています。
-
-rbenv と似たツールとして、次に説明する RVM や chruby があります。
-そちらも確認して、良い方を選んでください。
-
-
-### RVM ("Ruby Version Manager")
-{: #rvm}
-
-RVM は複数の Ruby のインストールと管理を行うことができます。
-このツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
-
-RVM をインストールする方法は [rvm.io][rvm] に記述されています。
-
-### chruby
-{: #chruby}
-
-chruby では複数の Ruby を管理することができます。
-
-chruby は Ruby のインストール自体はサポートしていませんが、
-[ruby-install](https://github.com/postmodern/ruby-install) や [ruby-build](https://github.com/rbenv/ruby-build) というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
-
-それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
-
-chruby をインストールする方法は [chrubyのページ][chruby] に記述されています。
-
-### RubyInstaller
-{: #rubyinstaller}
-
-もしあなたが Windows を使っているなら [RubyInstaller][rubyinstaller] を使って Ruby をインストールすることができます。
-これは、完全な Ruby 開発環境を Windows 上にセットアップしてくれます。
-
-RubyInstaller を使うには、[RubyInstaller のページ][rubyinstaller] からダウンロードしてください。
-そしてこのインストーラを実行するだけです！
-
-### RailsInstaller
-{: #railsinstaller}
-
-[RailsInstaller][railsinstaller] を利用すると、インストーラを実行するだけで Windows 上に Rails 開発環境を構築できます。
+  * [uru](#uru)
+* [Building from source](#building-from-source)
 
 ## パッケージ管理システム
 {: #package-management-systems}
@@ -255,8 +215,91 @@ WindowsでRubyをインストールするには[Windows Package Manager CLI](htt
 ### その他のディストリビューション
 {: #other}
 その他のシステムでは，お使いのLinuxディストリビューションのマネージャのパッケージリポジトリを検索して，Rubyを探すことができます。
-もしくはサードパーティのインストーラを使うこともできます．
- 
+もしくはサードパーティのインストーラを使うこともできます。
+
+## インストーラ
+{: #installers}
+
+システムやパッケージマネージャが提供するRubyのバージョンが古い場合、サードパーティ製のインストーラを使って新しいものをインストールすることができます。
+
+インストーラの中には、同じシステム上に複数のバージョンをインストールできるものもあり、関連するマネージャは、異なるRubyを切り替えるのに役立ちます。
+
+[RVM](#rvm)をバージョン管理として使用する場合は、別途インストーラを用意する必要はなく、インストーラが付属しています。
+
+### ruby-build
+{: #ruby-build}
+
+[ruby-build][ruby-build]は[rbenv](#rbenv)のプラグインで、異なるバージョンのRubyのコンパイルとインストールを可能にします。ruby-buildはrbenvなしでスタンドアロンプログラムとして使用することも可能です。macOS、Linux、その他のUNIX系OSで利用可能です。
+
+### ruby-install
+{: #ruby-install}
+
+[ruby-install][ruby-install]は、異なるバージョンのRubyをコンパイルし、任意のディレクトリにインストールすることができます。 [chruby](#chruby) は、Rubyのバージョンを切り替えるために使用される補完的なツールです。macOS、Linux、その他のUNIX系OSで利用可能です。
+### RubyInstaller
+{: #rubyinstaller}
+
+もしあなたが Windows を使っているならRubyInstallerを使って Ruby をインストールすることができます。
+これは、完全な Ruby 開発環境を Windows 上にセットアップしてくれます。
+
+RubyInstaller を使うには、[RubyInstaller のページ][rubyinstaller] からダウンロードしてください。
+そしてインストーラを実行するだけです！
+### Ruby Stack
+{: #rubystack}
+
+Ruby on Railsを利用するためにRubyをインストールする場合は、以下のインストーラを利用することができます。
+
+* [Bitnami Ruby Stack][rubystack]は、Railsのための完全な開発環境を提供します。macOS、Linux、Windows、仮想マシン、クラウドイメージをサポートしています。
+
+## マネージャ
+{: #managers}
+
+多くのRubyistは、複数のRubyを管理するためにRubyマネージャを使用しています。プロジェクトに応じてRubyのバージョンを簡単に、あるいは自動的に切り替えることができるなどの利点がありますが、公式にはサポートされていません。しかし、それぞれのコミュニティでサポートを見つけることができます。
+
+### asdf-vm
+{: #asdf-vm}
+
+[asdf-vm][asdf-vm]は拡張可能なバージョンマネージャで、複数の言語のランタイムバージョンをプロジェクト単位で管理することができる。Rubyをインストールするには、[asdf-ruby][asdf-ruby]プラグイン（これは[ruby-build][ruby-build]を使用します）が必要です。
+### chruby
+{: #chruby}
+
+chruby では複数の Ruby を管理することができます。
+
+chruby は Ruby のインストール自体はサポートしていませんが、
+[ruby-install](https://github.com/postmodern/ruby-install) や [ruby-build][ruby-build] というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
+
+それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
+
+chruby をインストールする方法は [chrubyのページ][chruby] に記述されています。
+
+### rbenv
+{: #rbenv}
+
+rbenv では複数の Ruby を管理することができます。
+
+rbenv は Ruby のインストール自体はサポートしていませんが、
+[ruby-build][ruby-build] というポピュラーなプラグインを使うことで Ruby をインストールすることができます。
+
+それぞれのツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
+
+rbenv をインストールする方法は [rbenvのページ][rbenv] に記述されています。
+
+### rbenv for Windows
+{: #rbenv-for-windows}
+
+[rbenv for Windows][rbenv-for-windows]は、WindowsにRubyを複数インストールし、管理することができます。PowerShellで書かれているため、WindowsユーザーにとってRubyを使うためのネイティブな方法を提供します。また、コマンドラインインターフェースはUNIX系システムの[rbenv][rbenv]と互換性があります。
+
+### RVM ("Ruby Version Manager")
+{: #rvm}
+
+RVM は複数の Ruby のインストールと管理を行うことができます。
+このツールは macOS、Linux およびその他 UNIX-like なオペレーティングシステムに対応しています。
+
+RVM をインストールする方法は [rvm.io][rvm] に記述されています。
+
+### uru
+{: #uru}
+
+[Uru][uru]は、macOS、Linux、Windowsシステム上で複数のRubieを使用するのに役立つ、軽量でマルチプラットフォーム対応のコマンドラインツールです。
 
 ## ソースからのビルド
 {: #building-from-source}
@@ -291,3 +334,13 @@ $ sudo make install
 [gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/
 [homebrew]: http://brew.sh/
 [building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
+[wsl]: https://learn.microsoft.com/ja-jp/windows/wsl/about
+[ruby-build]: https://github.com/rbenv/ruby-build#readme
+[ruby-install]: https://github.com/postmodern/ruby-install#readme
+[rubyinstaller]: https://rubyinstaller.org/
+[rubystack]: https://bitnami.com/stack/ruby/virtual-machine
+[asdf-vm]: https://asdf-vm.com/
+[asdf-ruby]: https://github.com/asdf-vm/asdf-ruby
+[rbenv-for-windows]: https://github.com/ccmywish/rbenv-for-windows#readme
+[uru]: https://bitbucket.org/jonforums/uru/src/master/

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -226,7 +226,7 @@ $ doas pkg_add ruby
 
 ### Ruby on OpenIndiana
 {: #openindiana}
-[OpenIndiana](https://www.openindiana.org/)にRubyをインストールするには、ImagePackagingSystem(IPS)クライアントを利用してください。これは、RubyバイナリとRubyGemsをOpenIndianaのリポジトリから直接インストールするものです。簡単です。
+[OpenIndiana](https://www.openindiana.org/) に Ruby をインストールするには、Image Packaging System (IPS) クライアントを利用してください。これは、 Ruby バイナリと RubyGems  をOpenIndiana のリポジトリから直接インストールするものです。簡単です:
 
 {% highlight sh %}
 $ pkg install runtime/ruby

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -220,7 +220,7 @@ OpenBSDやそのディストリビューションであるadJには、Rubyの3�
 $ doas pkg_add ruby
 {% endhighlight %}
 
-複数のメジャーバージョンを並列でインストールすることができます。なぜかというと、それらのバイナリは異なる名前を持っているからです (例: ruby27, ruby26)。
+複数のメジャーバージョンを共存させインストールすることができます。それらのバイナリは異なる名前を持っているからです (例: ruby27, ruby26)。
 
 `OpenBSD` のportsコレクションの `HEAD` ブランチには、このプラットフォーム用のRubyの最新版がリリースされてから一定期間経ったものが含まれている可能性があり、[directory lang/ruby in the most recent ports collection](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD)を確認してください。
 

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -157,7 +157,7 @@ $ sudo snap install ruby --classic
 マイナーシリーズごとの channel が用意されています。例えば以下を実行するとRuby 2.3に切り替えることが可能です。
 
 {% highlight sh %}
-$ sudo snap switch ruby --channnell=2.3/stable
+$ sudo snap switch ruby --channnel=2.3/stable
 $ sudo snap refresh
 {% endhighlight %}
 

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -144,7 +144,7 @@ $ sudo yum install ruby
 
 インストールされるバージョンは、一般に、特定のディストリビューションのバージョンがリリースされた時点での、Ruby の最新バージョンです。
 
-### snap(Ubuntu または他のLinux distribution)
+### snap (Ubuntu やその他の Linux distribution)
 {: #snap}
 
 SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinuc distributionでも動かすことができます。

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -148,7 +148,7 @@ $ sudo yum install ruby
 {: #snap}
 
 SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinux distributionでも動かすことができます。
-以下のように実行します。
+以下のように利用できます:
 
 {% highlight sh %}
 $ sudo snap install ruby --classic

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -222,7 +222,7 @@ $ doas pkg_add ruby
 
 複数のメジャーバージョンを共存させインストールすることができます。それらのバイナリは異なる名前を持っているからです (例: ruby27, ruby26)。
 
-`OpenBSD` のportsコレクションの `HEAD` ブランチには、このプラットフォーム用のRubyの最新版がリリースされてから一定期間経ったものが含まれている可能性があり、[directory lang/ruby in the most recent ports collection](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD)を確認してください。
+リリース間も無い最新版の Ruby は OpenBSD の ports collection の `HEAD` ブランチで提供されている場合があります。 [最新 ports collections の lang/ruby](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD) もあわせて確認してください。
 
 ### Ruby on OpenIndiana
 {: #openindiana}

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -210,7 +210,7 @@ $ pkg install ruby
 
 ports を利用してソースコードからインストールする場合、[Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using) を利用してください。この方法はビルド設定をカスタマイズする場合に便利です。
 
-FreeBSDにおけるRubyと関連するエコシステムのもっと詳しい情報は[FreeBSD Ruby Projects website](https://wiki.freebsd.org/Ruby) で確認が可能です。 
+FreeBSDにおけるRubyとそのエコシステムの詳しい情報は [FreeBSD Ruby Projects website](https://wiki.freebsd.org/Ruby) で確認できます。
 
 ### OpenBSD
 {: #doas}

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -147,7 +147,7 @@ $ sudo yum install ruby
 ### snap (Ubuntu やその他の Linux distribution)
 {: #snap}
 
-SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinuc distributionでも動かすことができます。
+SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinux distributionでも動かすことができます。
 以下のように実行します。
 
 {% highlight sh %}

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -109,17 +109,17 @@ Ruby コミュニティの中の一部のメンバーは Ruby をインストー
 このページには以下のパッケージマネージャが記述されています。
 
   * [Debian, Ubuntu](#apt)
-  * [CentOS, Fedora,RHEL](#yum)
-  * [Snap](#snap)
-  * [Gentoo](#portage)
-  * [Arch Linux](#pacman)
-  * [macOS](#homebrew)
-  * [FreeBSD](#pkg)
-  * [OpenBSD](#doas)
-  * [OpenIndiana](#openindiana)
-  * [Windows Package manager](#winget)
-  * [Chocolatey package manager for Windows](#choco)
-  * [Other Distribution](#other)
+	* [CentOS, Fedora,RHEL](#yum)
+	* [Snap](#snap)
+	* [Gentoo](#portage)
+	* [Arch Linux](#pacman)
+	* [macOS](#homebrew)
+	* [FreeBSD](#pkg)
+	* [OpenBSD](#doas)
+	* [OpenIndiana](#openindiana)
+	* [Windows Package manager](#winget)
+	* [Chocolatey package manager for Windows](#choco)
+	* [Other Distribution](#other)
 
 
 ### apt (Debian or Ubuntu)
@@ -144,20 +144,20 @@ $ sudo yum install ruby
 
 インストールされるバージョンは、一般に、特定のディストリビューションのバージョンがリリースされた時点での、Ruby の最新バージョンです。
 
-### snap (Ubuntu やその他の Linux distribution)
+### snap(Ubuntu または他のLinux distribution)
 {: #snap}
 
-SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinux distributionでも動かすことができます。
-以下のように利用できます:
+SnapはCanonialによって開発されたパッケージ管理システムです。こちらはUbuntu上で利用が可能な点に加えて他の多数のLinuc distributionでも動かすことができます。
+以下のように実行します。
 
 {% highlight sh %}
 $ sudo snap install ruby --classic
 {% endhighlight %}
 
-マイナーシリーズごとの channel が用意されています。例えば以下を実行するとRuby 2.3に切り替えることが可能です。
+Rubyにはいくつかのマイナーシリーズがあります。例えば以下のように実行するとRuby2.3に切り替えることが可能です。
 
 {% highlight sh %}
-$ sudo snap switch ruby --channnel=2.3/stable
+$ sudo snap switch ruby --channnell=2.3/stable
 $ sudo snap refresh
 {% endhighlight %}
 
@@ -190,8 +190,9 @@ $ sudo pacman -S ruby
 ### Homebrew (macOS)
 {: #homebrew}
 
-El Capitan (10.11) のリリース以降、macOS には Ruby 2.0 以上が同梱されています。
-[Homebrew](https://brew.sh/) は macOS で広く利用されているパッケージ管理システムです。Homebrew で Ruby をインストールするのは下記のように簡単です:
+Ruby2.0以降はEI Capian(10.11)のリリース以降よりMacOSに始めから含まれています。
+[Homebrew](https://brew.sh/)はmacOSで利用されているパッケージ管理システムです。
+Homebrewを使うことでRubyを簡単にインストールできます。
 
 
 {% highlight sh %}
@@ -208,9 +209,10 @@ FreeBSDでは、Rubyをインストールする方法として、パッケージ
 $ pkg install ruby
 {% endhighlight %}
 
-ports を利用してソースコードからインストールする場合、[Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using) を利用してください。この方法はビルド設定をカスタマイズする場合に便利です。
+[Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using)を使用してRubyをインストールする場合、ソースベースの方法を使用することが可能です。
+こちらはビルドの設定ツールをカスタマイズしたい場合に便利です。
 
-FreeBSDにおけるRubyとそのエコシステムの詳しい情報は [FreeBSD Ruby Projects website](https://wiki.freebsd.org/Ruby) で確認できます。
+FreeBSDにおけるRubyと関連するエコシステムのもっと詳しい情報は[FreeBSD Ruby Projects website](https://wiki.freebsd.org/Ruby) で確認が可能です。 
 
 ### OpenBSD
 {: #doas}
@@ -220,13 +222,13 @@ OpenBSDやそのディストリビューションであるadJには、Rubyの3�
 $ doas pkg_add ruby
 {% endhighlight %}
 
-複数のメジャーバージョンを共存させインストールすることができます。それらのバイナリは異なる名前を持っているからです (例: ruby27, ruby26)。
+複数のメジャーバージョンを並列でインストールすることができます。なぜかというと、それらのバイナリは異なる名前を持っているからです (例: ruby27, ruby26)。
 
-リリース間も無い最新版の Ruby は OpenBSD の ports collection の `HEAD` ブランチで提供されている場合があります。 [最新 ports collections の lang/ruby](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD) もあわせて確認してください。
+`OpenBSD` のportsコレクションの `HEAD` ブランチには、このプラットフォーム用のRubyの最新版がリリースされてから一定期間経ったものが含まれている可能性があり、[directory lang/ruby in the most recent ports collection](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD)を確認してください。
 
 ### Ruby on OpenIndiana
 {: #openindiana}
-[OpenIndiana](https://www.openindiana.org/) に Ruby をインストールするには、Image Packaging System (IPS) クライアントを利用してください。これは、 Ruby バイナリと RubyGems  をOpenIndiana のリポジトリから直接インストールするものです。簡単です:
+[OpenIndiana](https://www.openindiana.org/)にRubyをインストールするには、ImagePackagingSystem(IPS)クライアントを利用してください。これは、RubyバイナリとRubyGemsをOpenIndianaのリポジトリから直接インストールするものです。簡単です。
 
 {% highlight sh %}
 $ pkg install runtime/ruby
@@ -245,7 +247,7 @@ WindowsでRubyをインストールするには[Windows Package Manager CLI](htt
 ### Chocolatey package manager for Windows
 {: #choco}
 同じくWindowsでは[Chocolatey Package Manager](https://chocolatey.org/install) を利用してRubyのインストールが可能です。
-
+ 
 {% highlight sh %}
 > choco install ruby
 {% endhighlight %}
@@ -256,7 +258,7 @@ WindowsでRubyをインストールするには[Windows Package Manager CLI](htt
 {: #other}
 その他のシステムでは，お使いのLinuxディストリビューションのマネージャのパッケージリポジトリを検索して，Rubyを探すことができます。
 もしくはサードパーティのインストーラを使うこともできます．
-
+ 
 
 ## ソースからのビルド
 {: #building-from-source}

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -208,8 +208,7 @@ FreeBSDでは、Rubyをインストールする方法として、パッケージ
 $ pkg install ruby
 {% endhighlight %}
 
-[Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using)を使用してRubyをインストールする場合、ソースベースの方法を使用することが可能です。
-こちらはビルドの設定ツールをカスタマイズしたい場合に便利です。
+ports を利用してソースコードからインストールする場合、[Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using) を利用してください。この方法はビルド設定をカスタマイズする場合に便利です。
 
 FreeBSDにおけるRubyと関連するエコシステムのもっと詳しい情報は[FreeBSD Ruby Projects website](https://wiki.freebsd.org/Ruby) で確認が可能です。 
 

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -191,8 +191,7 @@ $ sudo pacman -S ruby
 {: #homebrew}
 
 El Capitan (10.11) のリリース以降、macOS には Ruby 2.0 以上が同梱されています。
-[Homebrew](https://brew.sh/)はmacOSで利用されているパッケージ管理システムです。
-Homebrewを使うことでRubyを簡単にインストールできます。
+[Homebrew](https://brew.sh/) は macOS で広く利用されているパッケージ管理システムです。Homebrew で Ruby をインストールするのは下記のように簡単です:
 
 
 {% highlight sh %}


### PR DESCRIPTION
https://www.ruby-lang.org/en/documentation/installation/

Modified the description of the Japanese version of the document to match the installer and manager sections of the English version of the Ruby installation page above.