### PR TITLE
Use www.cve.org instead of nvd.nist.gov

### DIFF
--- a/en/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md
+++ b/en/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md
@@ -9,7 +9,7 @@ lang: en
 ---
 
 We have released the uri gem version 0.12.1, 0.11.1, 0.10.2 and 0.10.0.1 that has a security fix for a ReDoS vulnerability.
-This vulnerability has been assigned the CVE identifier [CVE-2023-28755](https://nvd.nist.gov/vuln/detail/CVE-2023-28755).
+This vulnerability has been assigned the CVE identifier [CVE-2023-28755](https://www.cve.org/CVERecord?id=CVE-2023-28755).
 
 ## Details
 
@@ -43,3 +43,4 @@ Thanks to [Dominic Couture](https://hackerone.com/dee-see?type=user) for discove
 
 * Originally published at 2023-03-28 01:00:00 (UTC)
 * Update Affected versions at 2023-03-28 02:00:00 (UTC)
+* Update CVE identifier url at 2023-03-28 04:00:00 (UTC)


### PR DESCRIPTION
We should use www.cve.org today.