### PR TITLE
Translate "CVE-2023-28756: ReDoS vulnerability in Time" (ja)

### DIFF
--- a/ja/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md
+++ b/ja/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md
@@ -1,0 +1,44 @@
+---
+layout: news_post
+title: "CVE-2023-28756: Time における ReDoS 脆弱性について"
+author: "hsbt"
+translator: "ytjmt"
+date: 2023-03-30 11:00:00 +0000
+tags: security
+lang: ja
+---
+
+
+ReDoS 脆弱性のセキュリティ修正を含む、time gem 0.1.1、0.2.2 をリリースしました。
+この脆弱性は、[CVE-2023-28756](https://www.cve.org/CVERecord?id=CVE-2023-28756) として登録されています。
+
+## 詳細
+
+特定の文字を含む無効な文字列を Time のパーサーが誤って取り扱っていました。これにより、文字列を Time オブジェクトにパースする際の実行時間の増加を引き起こしていました。
+
+ReDoS の問題は Time gem の 0.1.0、0.2.1 と Ruby 2.7.7 の Time ライブラリに見つかりました。
+
+## 推奨する対応
+
+time gem を 0.2.2 以降にアップデートすることを推奨します。古い系列の Ruby で同梱されているバージョンとの互換性を確保するためには、以下のようにアップデートできます：
+
+* Ruby 3.0: `time` を 0.1.1 にアップデート
+* Ruby 3.1/3.2: `time` を 0.2.2 にアップデート
+
+`gem update time` でアップデートできます。もし bundler を使っている場合は、`Gemfile` に `gem "time", ">= 0.2.2"` を追加してください。
+
+残念ながら、time gem は Ruby 3.0 以降でしか動作しません。もし Ruby 2.7 を使っている場合は、最新のバージョンの Ruby を利用してください。
+
+## 影響を受けるバージョン
+
+* Ruby 2.7.7 以前
+* time gem 0.1.0
+* time gem 0.2.1
+
+## クレジット
+
+この脆弱性情報は、[ooooooo_q](https://hackerone.com/ooooooo_q?type=user) 氏によって報告されました。
+
+## 更新履歴
+
+* 2023-03-30 20:00:00 (JST) 初版


### PR DESCRIPTION
Translate ["CVE-2023-28756: ReDoS vulnerability in Time"](https://www.ruby-lang.org/en/news/2023/03/30/redos-in-time-cve-2023-28756/) into Japanese.