### PR TITLE
docs(readme): avoid use deprecated flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Then clone the repository and install the dependencies:
 ``` sh
 git clone https://github.com/ruby/www.ruby-lang.org.git
 cd www.ruby-lang.org/
-bundle install --without production
+bundle config set --local without production
+bundle install
 ```
 
 ## Make Changes


### PR DESCRIPTION
```
$ bundle install --without production
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local without 'production'`, and stop using this flag
```