### PR TITLE
Ruby 2.7 reaches EOL

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -33,8 +33,7 @@
   status: security maintenance
   date: 2019-12-25
   security_maintenance_date: 2022-04-01
-  eol_date:
-  expected_eol_date: 2023-03-31
+  eol_date: 2023-03-30
 
 - name: 2.6
   status: eol


### PR DESCRIPTION
> Ruby 2.7.8 Released
> Posted by usa on 30 Mar 2023

> After this release, Ruby 2.7 reaches EOL.

https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/