### PR TITLE
Remove snapshot-ruby_2_7

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -44,13 +44,6 @@ stable_snapshots:
       zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_3_0.zip
     version: '3.0'
 
-  - branch: ruby_2_7
-    url:
-      gz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.gz
-      xz: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.tar.xz
-      zip: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-ruby_2_7.zip
-    version: '2.7'
-
 nightly_snapshot:
 
   url:


### PR DESCRIPTION
Because generating snapshot-ruby_2_7 stopped.

https://github.com/ruby/actions/commit/b105aad95d851d30746dc3f31616d73c738ac91f