### PR TITLE
Change in docs rubykoans.com to github.com/edgecase/ruby_koans.

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -126,7 +126,7 @@ ruby -v
 е чудесно място да ги зададете.
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -128,7 +128,7 @@ If you have questions about Ruby the
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -139,7 +139,7 @@ comenzar.
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -124,7 +124,7 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 
 [2]: http://jeveuxapprendreruby.fr/
 [3]: https://try.ruby-lang.org/
-[4]: https://rubykoans.com/
+[4]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [6]: http://pine.fm/LearnToProgram/
 [7]: http://www.ruby-doc.org/docs/ApprendreProgrammer/Apprendre_%E0_Programmer.pdf

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -130,7 +130,7 @@ adalah tempat yang baik untuk memulai.
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -124,7 +124,7 @@ iniziare.
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -131,7 +131,7 @@ Ruby를 코딩할 때 운영체제의 기본 편집기를 사용할 수 있습�
 있습니다.
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -128,7 +128,7 @@ angielskim).
 Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -136,7 +136,7 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: http://why.carlosbrando.com/
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://aprendaaprogramar.rubyonrails.com.br/

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -135,7 +135,7 @@ ruby -v
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -137,7 +137,7 @@ olacaktır.
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -134,7 +134,7 @@ là một nơi tuyệt vời.
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -108,7 +108,7 @@ ruby -v
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -103,7 +103,7 @@ lang: zh_tw
 
 
 [1]: https://try.ruby-lang.org/
-[2]: https://rubykoans.com/
+[2]: https://github.com/edgecase/ruby_koans
 [5]: https://poignant.guide
 [7]: http://www.techotopia.com/index.php/Ruby_Essentials
 [8]: http://pine.fm/LearnToProgram/


### PR DESCRIPTION
[Ruby Koans](https://www.rubykoans.com/) is permanently unacceptable: two days ago there was a strange DASH board, then 502, now https://www.rubykoans.com/ requests for authorization.  

Because Ruby Koans is one of the main tools to get into the Ruby development rapidly need to use more robust source. Substitute   https://www.rubykoans.com by https://github.com/edgecase/ruby_koans url.


![ruby_koans_dash_502](https://user-images.githubusercontent.com/23147487/234973749-23a81309-a986-43cc-9884-680bc56106d0.png)
![auth_required](https://user-images.githubusercontent.com/23147487/234974527-8344bceb-5d8b-4343-95be-f9cbb5138897.png)
![auth_required1](https://user-images.githubusercontent.com/23147487/234974540-ab555119-da24-4e4d-b3ff-194216898196.png)
