### PR TITLE
Move 3.0.6 from stable to security_maintenance

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,11 +9,11 @@ stable:
 
   - 3.2.2
   - 3.1.4
-  - 3.0.6
 
 # optional
 security_maintenance:
 
+  - 3.0.6
 
 # optional
 eol:


### PR DESCRIPTION
Ruby 3.0 is currently in the security maintenance phase.

https://github.com/ruby/www.ruby-lang.org/blob/cc3efe91365c8729df523cb99d7d3ea9d5c7eeb8/_data/branches.yml#L25-L28