### PR TITLE
Translate CVE-2023-28755 news post (id)

### DIFF
--- a/id/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md
+++ b/id/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md
@@ -1,0 +1,56 @@
+---
+layout: news_post
+title: "CVE-2023-28755: Kerentanan ReDoS pada URI"
+author: "hsbt"
+translator: "meisyal"
+date: 2023-03-28 01:00:00 +0000
+tags: security
+lang: id
+---
+
+Kami telah merilis versi *gem* uri 0.12.1, 0.11.1, 0.10.2, dan 0.10.0.1 yang
+mengandung perbaikan keamanan untuk kerentanan ReDoS.
+Kerentanan ini telah ditetapkan dengan penanda CVE
+[CVE-2023-28755](https://www.cve.org/CVERecord?id=CVE-2023-28755).
+
+## Detail
+
+Isu ReDoS ditemukan pada komponen URI. *Parser* dari URI menangani URL yang
+tidak valid yang memiliki karakter tertentu dengan tidak benar. Ini menyebabkan
+peningkatan waktu eksekusi untuk mem-*parsing* *string* dari objek URI.
+
+Versi *gem* `uri` 0.12.0, 0.11.0, 0.10.0, dan semua versi sebelum 0.10.0 rentan
+terhadap isu ini.
+
+## Rekomendasi tindakan
+
+Kami merekomendasikan untuk memperbarui *gem* `uri` ke 0.12.1. Untuk memastikan
+kompatibilitas dengan versi yang dibundel pada rangkaian Ruby lama, Anda bisa
+memperbarui dengan langkah berikut:
+
+* Untuk Ruby 2.7: Perbarui `uri` ke 0.10.0.1
+* Untuk Ruby 3.0: Perbarui `uri` ke 0.10.2
+* Untuk Ruby 3.1: Perbarui `uri` ke 0.11.1
+* Untuk Ruby 3.2: Perbarui `uri` ke 0.12.1
+
+Anda dapat menggunakan perintah `gem update uri`. Jika Anda menggunakan *bundler*,
+mohon tambahkan `gem "uri", ">= 0.12.1"` (atau versi yang telah disebut sebelumnya)
+pada `Gemfile` Anda.
+
+## Versi terimbas
+
+* *gem* uri 0.12.0
+* *gem* uri 0.11.0
+* *gem* uri 0.10.1
+* *gem* uri 0.10.0 atau sebelumnya
+
+## Rujukan
+
+Terima kasih kepada [Dominic Couture](https://hackerone.com/dee-see?type=user)
+yang telah menemukan isu ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2023-03-28 01:00:00 (UTC)
+* Memperbarui versi terimbas pada 2023-03-28 02:00:00 (UTC)
+* Memperbarui URL penanda CVE pada 2023-03-28 04:00:00 (UTC)


### PR DESCRIPTION
This PR contains the translation of "CVE-2023-28755: ReDoS vulnerability in URI" news post in Bahasa Indonesia.