### PR TITLE
Translate CVE-2023-28756 news post (id)

### DIFF
--- a/id/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md
+++ b/id/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "CVE-2023-28756: Kerentanan ReDoS pada Time"
+author: "hsbt"
+translator: "meisyal"
+date: 2023-03-30 11:00:00 +0000
+tags: security
+lang: id
+---
+
+Kami telah merilis versi *gem* time 0.1.1 dan 0.2.2 yang mengandung perbaikan
+keamanan untuk kerentanan ReDoS. Kerentanan ini telah ditetapkan dengan penanda
+CVE [CVE-2023-28756](https://www.cve.org/CVERecord?id=CVE-2023-28756).
+
+## Detail
+
+*Parser* dari Time menangani *string* yang tidak valid yang memiliki karakter
+tertentu dengan tidak benar. Ini menyebabkan peningkatan waktu eksekusi untuk
+mem-*parsing* *string* menjadi objek Time.
+
+Isu ini ditemukan pada versi *gem* Time 0.1.0 dan 0.2.1 serta pustaka Time dari
+Ruby 2.7.7.
+
+## Rekomendasi tindakan
+
+Kami merekomendasikan untuk memperbarui *gem* time ke 0.2.2 atau setelahnya.
+Untuk memastikan kompatibilitas dengan versi yang dibundel pada rangkaian
+Ruby lama, Anda bisa memperbarui dengan langkah berikut:
+
+* Untuk pengguna Ruby 3.0: Perbarui `time` ke 0.1.1
+* Untuk pengguna Ruby 3.1/3.2: Perbarui `time` ke 0.2.2
+
+Anda dapat menggunakan perintah `gem update time`. Jika Anda menggunakan *bundler*,
+mohon tambahkan `gem "time", ">= 0.2.2"` pada `Gemfile` Anda.
+
+Sayangnya, *gem* time hanya berjalan pada Ruby 3.0 atau setelahnya. Jika Anda
+sedang menggunakan Ruby 2.7, mohon gunakan versi Ruby terbaru.
+
+## Versi terimbas
+
+* Ruby 2.7.7 atau sebelumnya
+* *gem* time 0.1.0
+* *gem* time 0.2.1
+
+## Rujukan
+
+Terima kasih kepada [ooooooo_q](https://hackerone.com/ooooooo_q?type=user)
+yang telah menemukan isu ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2023-03-30 11:00:00 (UTC)


### PR DESCRIPTION
This PR contains the translation of "CVE-2023-28756: ReDoS vulnerability in Time" news post in Bahasa Indonesia.