### PR TITLE
Fix some broken link to bugs.ruby-lang.org wiki

### DIFF
--- a/bg/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/bg/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -12,7 +12,7 @@ lang: bg
 Това е първият предварителен преглед на Ruby 2.4.0.
 Излиза по-рано от обикновено, защото включва много новости и подобрения.
 Не се колебайте да
-[изпращате обратна връзка](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport),
+[изпращате обратна връзка](https://github.com/ruby/ruby/wiki/How-To-Report),
 тъй като все още имате възможност да повлияете на промените.
 
 ## [Обединяване на Fixnum и Bignum в Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -64,7 +64,7 @@ Ruby 2.4 показва нишките заедно с техният backtrace,
 зависят от тях.
 
 Приятно ползване на Ruby 2.4.0-preview1!
-[Свържете се с нас](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[Свържете се с нас](https://github.com/ruby/ruby/wiki/How-To-Report)
 с вашите коментари и преложения.
 
 ## Важни промени от 2.3

--- a/de/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/de/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ geben zu können.
 Ruby 2.4.0-preview1 ist die erste Vorschau auf Ruby 2.4.0 und sie
 kommt früher als üblich, weil sie zahlreiche neue Features und
 Verbesserungen enthält. Wenn Sie noch Einfluss auf die Zukunft nehmen
-wollen, dann [geben Sie uns Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport).
+wollen, dann [geben Sie uns Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report).
 
 ## [Zusammenführung von Fixnum und Bignum in Integer](https://bugs.ruby-lang.org/issues/12005)
 
@@ -71,7 +71,7 @@ Die Deadlock-Erkennung von Ruby 2.4 listet Threads nun mit ihrem
 Backtrace und abhängigen Threads.
 
 Versuchen Sie Ruby 2.4.0-preview1, haben Sie Spaß daran und [geben Sie
-Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Wesentliche Änderungen seit 2.3
 

--- a/de/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/de/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -12,7 +12,7 @@ bekanntgeben zu können.
 
 Ruby 2.4.0-preview2 ist die zweite Vorschau auf Ruby 2.4.0 und wird
 in der Absicht veröffentlicht, Meinungen und Feedback durch die
-Community einzuholen. Wir möchten Sie daher ermutigen, [uns Rückmeldung zu geben](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport),
+Community einzuholen. Wir möchten Sie daher ermutigen, [uns Rückmeldung zu geben](https://github.com/ruby/ruby/wiki/How-To-Report),
 wodurch Sie noch Einfluss auf die weitere Entwicklung nehmen können.
 
 ## [Zusammenführung von Fixnum und Bignum in Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -75,7 +75,7 @@ sinnvolles Debugging.
 Die Deadlock-Erkennung von Ruby 2.4 listet Threads nun mit ihrem
 Backtrace und abhängigen Threads.
 
-Versuchen Sie Ruby 2.4.0-preview1, haben Sie Spaß daran und [geben Sie Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+Versuchen Sie Ruby 2.4.0-preview1, haben Sie Spaß daran und [geben Sie Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Sonstige wesentliche Änderungen seit 2.3
 

--- a/de/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/de/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -13,7 +13,7 @@ ankündigen zu können.
 Ruby 2.4.0-preview3 ist die dritte Vorschau auf Ruby 2.4.0 und wird in
 der Absicht veröffentlicht, Feedback von der Gemeinschaft zu
 erhalten. Bitte
-[geben Sie uns Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport),
+[geben Sie uns Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report),
 da Sie immer noch Einfluss auf die Features nehmen können.
 
 ## [Verbesserung der Hash-Tabellen (von Wladimir Makarow)](https://bugs.ruby-lang.org/issues/12142)
@@ -96,7 +96,7 @@ sinnvolles Debugging.
 Die Deadlock-Erkennung von Ruby 2.4 listet Threads nun mit ihrem
 Backtrace und abhängigen Threads.
 
-Versuchen Sie Ruby 2.4.0-preview3, haben Sie Spaß daran und [geben Sie Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+Versuchen Sie Ruby 2.4.0-preview3, haben Sie Spaß daran und [geben Sie Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Sonstige wesentliche Änderungen seit 2.3
 

--- a/de/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/de/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ zu können.
 
 Ruby 2.4.0-rc1 ist der erste Veröffentlichungskandidat von Ruby 2.4.0
 und dient dazu, Rückmeldungen aus der Community zu
-sammeln. Bitte [geben Sie uns Feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport),
+sammeln. Bitte [geben Sie uns Feedback](https://github.com/ruby/ruby/wiki/How-To-Report),
 da noch immer die Möglichkeit besteht, Einfluss auf die Features zu
 nehmen.
 
@@ -96,7 +96,7 @@ sinnvolles Debugging.
 Die Deadlock-Erkennung von Ruby 2.4 listet Threads nun mit ihrem
 Backtrace und abhängigen Threads.
 
-Versuchen Sie Ruby 2.4.0-rc1, haben Sie Spaß daran und [geben Sie Rückmeldung](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+Versuchen Sie Ruby 2.4.0-rc1, haben Sie Spaß daran und [geben Sie Rückmeldung](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Sonstige wesentliche Änderungen seit 2.3
 

--- a/en/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/en/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ Ruby 2.4.0-preview1 is the first preview of Ruby 2.4.0.
 This preview1 is released earlier than usual because it includes so
 many new features and improvements.
 Feel free to
-[send feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[send feedback](https://github.com/ruby/ruby/wiki/How-To-Report)
 since you can still change the features.
 
 ## [Unify Fixnum and Bignum into Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -66,7 +66,7 @@ Ruby 2.4's deadlock detection shows threads with their backtrace and
 dependent threads.
 
 Try and enjoy programming with Ruby 2.4.0-preview1, and
-[send us feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[send us feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Notable Changes since 2.3
 

--- a/en/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/en/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -12,7 +12,7 @@ We are pleased to announce the release of Ruby 2.4.0-preview2.
 Ruby 2.4.0-preview2 is the second preview of Ruby 2.4.0.
 This preview2 is released to get feedback from the community.
 Feel free to
-[send feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[send feedback](https://github.com/ruby/ruby/wiki/How-To-Report)
 since you can still influence the features.
 
 ## [Unify Fixnum and Bignum into Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -69,7 +69,7 @@ Ruby 2.4's deadlock detection shows threads with their backtrace and
 dependent threads.
 
 Try and enjoy programming with Ruby 2.4.0-preview2, and
-[send us feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[send us feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Other notable changes since 2.3
 

--- a/en/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/en/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -12,7 +12,7 @@ We are pleased to announce the release of Ruby 2.4.0-preview3.
 Ruby 2.4.0-preview3 is the third preview of Ruby 2.4.0.
 This preview3 is released to get feedback from the community.
 Feel free to
-[send feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[send feedback](https://github.com/ruby/ruby/wiki/How-To-Report)
 since you can still influence the features.
 
 ## [Introduce hash table improvement (by Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
@@ -83,7 +83,7 @@ Ruby 2.4's deadlock detection shows threads with their backtrace and
 dependent threads.
 
 Try and enjoy programming with Ruby 2.4.0-preview3, and
-[send us feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[send us feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Other notable changes since 2.3
 

--- a/en/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/en/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ We are pleased to announce the release of Ruby 2.4.0-rc1.
 Ruby 2.4.0-rc1 is the first release candidate of Ruby 2.4.0.
 This rc1 is released to get feedback from the community.
 Feel free to
-[send feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[send feedback](https://github.com/ruby/ruby/wiki/How-To-Report)
 since you can still fix the features.
 
 ## [Introduce hash table improvement (by Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
@@ -83,7 +83,7 @@ Ruby 2.4's deadlock detection shows threads with their backtrace and
 dependent threads.
 
 Try and enjoy programming with Ruby 2.4.0-rc1, and
-[send us feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[send us feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Other notable changes since 2.3
 

--- a/es/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/es/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -12,7 +12,7 @@ Nos complace anunciar la entrega de Ruby 2.4.0-preview1.
 Esta versión es la primera vista previa a Ruby 2.4.0 y ha sido liberada antes
 de lo usual porque incluye muchas mejoras y características nuevas.
 Por favor no olvides enviar
-[tus comentarios](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[tus comentarios](https://github.com/ruby/ruby/wiki/How-To-Report)
 ya que aún estamos a buen tiempo de hacer cambios.
 
 ## [Integrar Fixnum y Bignum en Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -66,7 +66,7 @@ La detección de puntos muertos en Ruby 2.4 ahora muestra los threads con su
 traza inversa y los threads dependientes.
 
 Esperamos que disfrutes programar con Ruby 2.4.0-preview1 y no olvides
-[enviar tus comentarios](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[enviar tus comentarios](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Cambios significantes desde 2.3
 

--- a/es/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/es/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -12,7 +12,7 @@ Nos complace anunciar el lanzamiento de Ruby 2.4.0-preview2.
 Ruby 2.4.0-preview2 es la segunda vista previa de Ruby 2.4.0.
 Este preview2 es liberado para obtener retroalimentación de la comunidad.
 Siéntete libre de
-[enviar tus comentarios](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar tus comentarios](https://github.com/ruby/ruby/wiki/How-To-Report)
 ya que aún puedes influir en las funcionalidades.
 
 ## [Unificación de Fixnum y Bignum en Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -67,7 +67,7 @@ no incluye suficiente información para depuración.
 La detección de deadlocks en Ruby 2.4 muestra los hilos con sus respectivas trazas e hilos dependientes.
 
 ¡Prueba y disfruta programar con Ruby 2.4.0-preview2, y
-[envíanos retroalimentación](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[envíanos retroalimentación](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Otros cambios notables desde 2.3
 

--- a/es/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/es/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -12,7 +12,7 @@ Nos complace anunciar el lanzamiento de Ruby 2.4.0-preview3.
 Ruby 2.4.0-preview3 es las tercer versión preelimiar de Ruby 2.4.0.
 Esta versión preview3 es liberada para obtener retroalimentación de la comunidad.
 Tómate la libertad de
-[enviar tus comentarios](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar tus comentarios](https://github.com/ruby/ruby/wiki/How-To-Report)
 ya que aún puedes influir en las funcionalidades.
 
 ## [Presentamos una mejora a las tablas de hash por Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
@@ -81,7 +81,7 @@ no incluye suficiente información para depuración.
 La detección de deadlocks en Ruby 2.4 muestra los hilos con sus respectivas trazas e hilos dependientes.
 
 ¡Prueba y disfruta programar con Ruby 2.4.0-preview3, y
-[envíanos retroalimentación](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[envíanos retroalimentación](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Otros cambios notables desde 2.3
 

--- a/es/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/es/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ Nos complace anunciar el lanzamiento de Ruby 2.4.0-rc1.
 Ruby 2.4.0-rc1 es el primer candidato a lanzamiento de Ruby 2.4.0.
 Esta versión rc1 es liberada para obtener retroalimentación de la comunidad.
 Siéntete libre de
-[enviar tu retroalimentación](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar tu retroalimentación](https://github.com/ruby/ruby/wiki/How-To-Report)
 ya que aún puedes arreglar las funcionalidades.
 
 ## [Presentamos una mejora a las tablas de hash por Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
@@ -87,7 +87,7 @@ de deadlocks en Ruby 2.4 muestra los hilos con sus respectivas trazas e hilos
 dependientes.
 
 ¡Prueba y disfruta programar con Ruby 2.4.0-rc1, y
-[envíanos retroalimentación](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[envíanos retroalimentación](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Otros cambios notables desde 2.3
 

--- a/fr/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/fr/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -11,7 +11,7 @@ Nous sommes heureux d'annoncer la sortie de Ruby 2.4.0-rc1.
 
 Ruby 2.4.0-rc1 est la première *release candidate* pour la version stable 2.4.0
 Le but de cette version est d'obtenir des retours de la communauté : n'hésitez
-pas à nous [envoyer vos remarques](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport).
+pas à nous [envoyer vos remarques](https://github.com/ruby/ruby/wiki/How-To-Report).
 
 ## [Améliorations de la table de hachage (par Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
 
@@ -91,7 +91,7 @@ Ruby 2.4 ajoute la backtrace au rapport, ainsi qu'une liste des threads
 dépendants.
 
 Nous vous invitons à essayer tous ces changements apportés par Ruby 2.4.0-rc1
-et à nous [faire vos retours](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport) !
+et à nous [faire vos retours](https://github.com/ruby/ruby/wiki/How-To-Report) !
 
 ## Autres changements notables depuis la version 2.3
 

--- a/fr/news/_posts/2016-12-25-ruby-2-4-0-released.md
+++ b/fr/news/_posts/2016-12-25-ruby-2-4-0-released.md
@@ -90,7 +90,7 @@ Ruby 2.4 ajoute la backtrace au rapport, ainsi qu'une liste des threads
 dépendants.
 
 Nous vous invitons à essayer tous ces changements apportés par Ruby 2.4.0-rc1
-et à nous [faire vos retours](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport) !
+et à nous [faire vos retours](https://github.com/ruby/ruby/wiki/How-To-Report) !
 
 ## Autres changements notables depuis la version 2.3
 

--- a/id/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/id/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ Ruby 2.4.0-preview1 adalah *preview* pertama dari Ruby 2.4.0.
 Preview1 ini dirilis lebih awal dari biasanya karena versi ini mencakup
 banyak fitur baru dan perbaikan.
 Jangan ragu untuk
-[mengirimkan umpan balik](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[mengirimkan umpan balik](https://github.com/ruby/ruby/wiki/How-To-Report)
 karena Anda masih bisa mengubah fitur-fitur ini.
 
 ## [Menyatukan Fixnum dan Bignum ke dalam Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -67,7 +67,7 @@ mencakup informasi yang cukup untuk *debugging*.
 *dependency*-nya.
 
 Coba dan nikmati memprogram dengan Ruby 2.4.0-preview1, dan
-[kirimkan umpan balik ke kami](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[kirimkan umpan balik ke kami](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Perubahan Penting sejak 2.3
 

--- a/id/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/id/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -12,7 +12,7 @@ Kami dengan senang hati mengumumkan rilis dari Ruby 2.4.0-preview2.
 Ruby 2.4.0-preview2 adalah *preview* kedua dari Ruby 2.4.0.
 Preview2 ini dirilis untuk mendapatkan umpan balik dari komunitas.
 Jangan ragu untuk
-[mengirimkan umpan balik](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[mengirimkan umpan balik](https://github.com/ruby/ruby/wiki/How-To-Report)
 karena Anda masih dapat mengubah fitur-fitur ini.
 
 ## [Menyatukan Fixnum dan Bignum ke dalam Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -69,7 +69,7 @@ Pendeteksi *deadlock* Ruby 2.4 menunjukkan *thread* dengan *backtrace* dan
 *dependency thread*.
 
 Coba dan nikmati memprogram dengan Ruby 2.4.0-preview2, dan
-[kirim umpan balik ke kami](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[kirim umpan balik ke kami](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Perubahan Penting sejak 2.3
 

--- a/id/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/id/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -12,7 +12,7 @@ Kami dengan senang hati mengumumkan rilis dari Ruby 2.4.0-preview3.
 Ruby 2.4.0-preview3 adalah *preview* ketiga dari Ruby 2.4.0.
 Preview3 ini dirilis untuk mendapatkan umpan balik dari komunitas.
 Jangan ragu untuk
-[mengirimkan umpan balik](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[mengirimkan umpan balik](https://github.com/ruby/ruby/wiki/How-To-Report)
 karena Anda masih bisa mengubah fitur-fitur ini.
 
 ## [Memperkenalkan penyempurnaan hash table oleh Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
@@ -87,7 +87,7 @@ tidak mengandung cukup informasi untuk *debugging*.
 *backtrace* dan *dependency*-nya.
 
 Coba dan nikmati memprogram dengan Ruby 2.4.0-preview3, dan
-[kirimkan umpan balik ke kami](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[kirimkan umpan balik ke kami](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Perubahan penting lainnya sejak 2.3
 

--- a/id/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/id/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ Kami dengan senang hati mengumumkan rilis dari Ruby 2.4.0-rc1.
 Ruby 2.4.0-rc1 adalah kandidat rilis pertama dari Ruby 2.4.0.
 rc1 ini dirilis untuk mendapatkan umpan balik dari komunitas.
 Jangan ragu untuk
-[mengirimkan umpan balik](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[mengirimkan umpan balik](https://github.com/ruby/ruby/wiki/How-To-Report)
 karena Anda masih bisa memperbaiki fitur-fitur.
 
 ## [Memperkenalkan penyempurnaan hash table (oleh Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
@@ -85,7 +85,7 @@ tidak mengandung cukup informasi untuk *debugging*.
 *backtrace* dan *dependency*-nya.
 
 Coba dan nikmati memprogram dengan Ruby 2.4.0-rc1, dan [kirimkan umpan balik ke
-kami](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+kami](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Perubahan penting lainnya sejak 2.3
 

--- a/it/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/it/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -11,7 +11,7 @@ Siamo lieti di annunciare la release di Ruby 2.4.0-preview2.
 
 Ruby 2.4.0-preview2 è la prima anteprima di Ruby 2.4.0.
 Questa preview2 è rilasciata per avere dei feedback dalla community.
-[Mandate pure feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[Mandate pure feedback](https://github.com/ruby/ruby/wiki/How-To-Report)
 poiché potete ancora influenzare le features.
 
 ## [Fixnum e Bignum unificati in Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -70,7 +70,7 @@ La deadlock detection di Ruby 2.4's mostra i thread con il loro backtrace e i
 thread dipendenti.
 
 Dilettatevi nella programmazione con Ruby 2.4.0-preview2 e
-[mandateci feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[mandateci feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Modifiche importanti dalla 2.3
 

--- a/ja/dev/index.md
+++ b/ja/dev/index.md
@@ -9,7 +9,7 @@ lang: ja
 
 ## Wiki
 
-Rubyの開発に関連する文書は現在主に[Redmine(問題追跡システム)のWiki][1]に集められています。
+Rubyの開発に関連する文書は現在主に[GitHubのWiki][1]に集められています。
 
 ## 質疑応答
 
@@ -20,7 +20,7 @@ Rubyの開発についての議論は、主に、メーリングリストruby-de
 
 Rubyの不具合や機能追加の要望などは[Redmine(問題追跡システム)][2]で管理されています。
 
-また、[RedmineのWiki][1]では、Rubyの開発を追いかけるにあたって役に立つ情報が集積されています。 そちらも参照してください。
+また、[GitHubのWiki][1]では、Rubyの開発を追いかけるにあたって役に立つ情報が集積されています。 そちらも参照してください。
 
 ## ソースコード
 
@@ -49,7 +49,7 @@ Posted by usa on 13 Aug 2008
 
 
 
-[1]: https://bugs.ruby-lang.org/projects/ruby/wiki
+[1]: https://github.com/ruby/ruby/wiki
 [2]: https://bugs.ruby-lang.org/
 [3]: {{ site.data.downloads.nightly_snapshot.url.gz }}
 [4]: {{ site.data.downloads.stable_snapshots[0].url.gz }}

--- a/ja/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/ja/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -11,7 +11,7 @@ Ruby 2.4.0-preview3がリリースされました.
 
 これはRuby 2.4.0に向けた3番目のプレビューリリースになります。
 プレビューリリースとはRubyコミュニティのフィードバックを得るためにリリースされています。
-何かお気づきの際は、Ruby 2.4.0をよりよくするために[Ruby バグレポートガイドライン](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReportJa)を参考にしてバグレポートや提案を送ってください。
+何かお気づきの際は、Ruby 2.4.0をよりよくするために[Ruby バグレポートガイドライン](https://github.com/ruby/ruby/wiki/How-To-Report-Ja)を参考にしてバグレポートや提案を送ってください。
 
 ## [Introduce hash table improvement by Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
 
@@ -77,7 +77,7 @@ Ruby 2.4's deadlock detection shows threads with their backtrace and
 dependent threads.
 
 Try and enjoy programming with Ruby 2.4.0-preview3, and
-[send us feedback](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[send us feedback](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Other notable changes since 2.3
 

--- a/ko/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/ko/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ lang: ko
 이 프리뷰는 많은 새 기능과 개선들을 포함하고 있어서
 이례적으로 이르게 릴리스 되었습니다.
 아직 기능이 확정되지 않았으니, 자유롭게
-[피드백](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)을 보내주세요.
+[피드백](https://github.com/ruby/ruby/wiki/How-To-Report)을 보내주세요.
 
 ## [Fixnum과 Bignum을 Integer로 통합](https://bugs.ruby-lang.org/issues/12005)
 
@@ -63,7 +63,7 @@ ASCII 대/소문자 대응 대신에 유니코드 대/소문자 대응을 지원
 루비 2.4의 교착상태 탐지는 스레드의 백트레이스와 의존하고 있는 스레드에 대한 정보를 보여주게 됩니다.
 
 루비 2.4.0-preview1로 즐겁게 프로그램을 작성해보세요.
-그리고 여러분의 [느낀 점을 알려주세요](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+그리고 여러분의 [느낀 점을 알려주세요](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 2.3 이후의 주목할 만한 변경
 

--- a/ko/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/ko/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -11,7 +11,7 @@ lang: ko
 
 루비 2.4.0-preview2은 루비 2.4.0의 두 번째 프리뷰입니다.
 이 프리뷰는 커뮤니티의 반응을 살펴보기 위해 릴리스되었습니다.
-기능에서 혼란을 느낀다면 부담없이 [피드백](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)을 보내주세요.
+기능에서 혼란을 느낀다면 부담없이 [피드백](https://github.com/ruby/ruby/wiki/How-To-Report)을 보내주세요.
 
 ## [Fixnum과 Bignum을 Integer로 통합](https://bugs.ruby-lang.org/issues/12005)
 
@@ -65,7 +65,7 @@ ASCII 대/소문자 대응 대신에 유니코드 대/소문자 대응을 지원
 루비 2.4의 교착상태 탐지는 스레드의 백트레이스와 의존하고 있는 스레드에 대한 정보를 보여주게 됩니다.
 
 루비 2.4.0-preview2로 즐겁게 프로그램을 작성해보세요.
-그리고 여러분이 [느낀 점을 알려주세요](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+그리고 여러분이 [느낀 점을 알려주세요](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 2.3 이후의 주목할 만한 변경
 

--- a/ko/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/ko/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -11,7 +11,7 @@ lang: ko
 
 루비 2.4.0-preview3은 루비 2.4.0의 세 번째 프리뷰입니다.
 이 프리뷰는 커뮤니티의 반응을 살펴보기 위해 릴리스되었습니다.
-기능에서 혼란을 느낀다면 부담없이 [피드백](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)을 보내주세요.
+기능에서 혼란을 느낀다면 부담없이 [피드백](https://github.com/ruby/ruby/wiki/How-To-Report)을 보내주세요.
 
 ## [Vladimir Makarov의 해시 테이블 개선을 도입](https://bugs.ruby-lang.org/issues/12142)
 
@@ -75,7 +75,7 @@ ASCII 대/소문자 대응 대신에 유니코드 대/소문자 대응을 지원
 루비 2.4의 교착상태 탐지는 스레드의 백트레이스와 의존하고 있는 스레드에 대한 정보를 보여주게 됩니다.
 
 루비 2.4.0-preview3으로 즐겁게 프로그램을 작성해보세요.
-그리고 여러분이 [느낀 점을 알려주세요](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+그리고 여러분이 [느낀 점을 알려주세요](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 2.3 이후의 주목할 만한 변경
 

--- a/ko/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/ko/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ lang: ko
 루비 2.4.0-rc1은 루비 2.4.0의 첫 번째 릴리스 후보입니다.
 rc1은 커뮤니티의 피드백을 받기 위해 릴리스되었습니다.
 아직 기능을 고칠 수 있으니 자유롭게
-[피드백을 보내주세요](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport).
+[피드백을 보내주세요](https://github.com/ruby/ruby/wiki/How-To-Report).
 
 ## [해시 테이블의 성능을 향상시켰습니다(Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
 
@@ -84,7 +84,7 @@ Fixnum이나 Bignum 클래스를 변경하는 모든 C 확장을 고쳐야 합�
 스레드를 보여줍니다.
 
 루비 2.4.0-rc1로 프로그래밍 해보고
-[의견을 보내주세요](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[의견을 보내주세요](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 그 외의 중요한 2.3 이후의 변경 사항
 

--- a/pl/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/pl/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -12,7 +12,7 @@ Jest nam miło ogłosić wydanie Rubiego 2.4.0-preview1.
 Ruby 2.4.0-preview1 jest pierwszym wydaniem wstępnym Rubiego 2.4.0.
 Wydanie preview1 pojawiło się wcześniej niż zwykle ponieważ zawiera
 dużo usprawnień oraz funkcjonalności.
-[Podziel się](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[Podziel się](https://github.com/ruby/ruby/wiki/How-To-Report)
 z nami swoimi uwagami poniważ Ruby 2.4.0 jest nadal w trakcie rozwoju
 
 ## [Połączenie Fixnum i Bignum do klasy Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -64,7 +64,7 @@ na debugowanie. Od Rubiego 2.4 pokazywane będą zrzuty stosu oraz
 zależności oczekujących wątków.
 
 Wypróbuj Rubiego 2.4.0-preview1 i
-[podziel się](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[podziel się](https://github.com/ruby/ruby/wiki/How-To-Report)
 z nami swoimi spostrzeżeniami!
 
 ## Znaczące zmiany w stosunku do wersji 2.3

--- a/pt/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/pt/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ Ruby 2.4.0-preview1 é o primeiro *preview* do Ruby 2.4.0.
 Este preview1 está sendo lançado antes do usual porque ele inclui várias
 funcionalidades novas e melhorias.
 Sinta-se a vontade para
-[enviar comentários](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar comentários](https://github.com/ruby/ruby/wiki/How-To-Report)
 já que você ainda pode mudar as funcionalidades.
 
 
@@ -67,7 +67,7 @@ A detecção de *deadlock* no Ruby 2.4 mostrar *threads* com seu histórico e
 *threads* dependentes.
 
 Experimente e aproveite programando com Ruby 2.4.0-preview1, e
-[nos envie comentários](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[nos envie comentários](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Mudanças notáveis desde 2.3
 

--- a/pt/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/pt/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -12,7 +12,7 @@ Estamos satisfeitos em anunciar o lançamento do Ruby 2.4.0-preview2.
 Ruby 2.4.0-preview2 é o segundo *preview* do Ruby 2.4.0.
 Este preview2 está sendo lançado para receber comentários da comunidade.
 Sinta-se a vontade para
-[enviar comentários](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar comentários](https://github.com/ruby/ruby/wiki/How-To-Report)
 sendo que você ainda pode mudar as funcionalidades.
 
 ## [Unificação de Fixnum e Bignum em Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -69,7 +69,7 @@ A detecção de *deadlock* no Ruby 2.4 mostrar *threads* com seu histórico e
 *threads* dependentes.
 
 Experimente e aproveite programando com Ruby 2.4.0-preview2, e
-[nos envie comentários](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[nos envie comentários](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Mudanças notáveis desde de 2.3
 

--- a/pt/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/pt/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -13,7 +13,7 @@ A versão 2.4.0-preview3 do Ruby é a terceira *preview* do Ruby 2.4.0,
 lançada com o fim de obter *feedback* da comunidade.
 
 Poderão
-[enviar *feedback*](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[enviar *feedback*](https://github.com/ruby/ruby/wiki/How-To-Report)
 uma vez que ainda podem influenciar das funcionalidades.
 
 ## [Introdução de melhorias nas hash tables por Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
@@ -78,7 +78,7 @@ inclui informação suficiente para depuração.
 A deteção de *deadlocks* no Ruby 2.4 mostra *threads* com o seu *backtrace* e *threads* dependentes.
 
 Experimente e desfrute a programação com o Ruby 2.4.0-preview3 e
-[envie-nos o seu *feedback*](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[envie-nos o seu *feedback*](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Outras alterações importantes desde a versão 2.3
 

--- a/ru/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/ru/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ Ruby 2.4.0-preview1 – это первое превью Ruby 2.4.0.
 Этот preview1 вышел раньше, чем обычно, так как он содержит очень много
 нововведений и улучшений.
 Пожалуйста, присылайте
-[отзывы](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport),
+[отзывы](https://github.com/ruby/ruby/wiki/How-To-Report),
 так как вы все еще можете повлиять на нововведения.
 
 ## [Объединение Fixnum и Bignum в Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -65,7 +65,7 @@ Ruby игнорирует ошибки в тредах, если другой т
 бектрейсами и зависимыми потоками.
 
 Пробуйте и наслаждайтесь программированием на Ruby 2.4.0-preview1, и присылайте,
-пожалуйста, нам [отзывы](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+пожалуйста, нам [отзывы](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Значительные изменения от версии 2.3
 

--- a/vi/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/vi/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -13,7 +13,7 @@ Chúng tôi rất hân hạnh được thông báo về việc phát hành Ruby 
 Phiên bản Ruby 2.4.0-preview1 là phiên bản preview đầu tiên của Ruby 2.4.0.
 Bản preview1 lần này được phát hành sớm hơn so với thông thường vì nó bao gồm rất
 nhiều chức năng và cải tiến. Mọi người đừng ngại
-[phản hồi](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport) lại cho
+[phản hồi](https://github.com/ruby/ruby/wiki/How-To-Report) lại cho
 chúng tôi về phiên bản này, vì các chức năng vẫn có thể được thay đổi và cập nhật.
 
 ## [Hợp nhất Fixnum và Bignum vào Integer](https://bugs.ruby-lang.org/issues/12005)
@@ -69,7 +69,7 @@ khi phát hiện ra Deadlock, Ruby sẽ hiển thị các thread cùng với bac
 và các threads liên quan.
 
 Mời mọi người dùng thử và cảm nhận việc lập trình với Ruby 2.4.0-preview1,
-đồng thời [gửi phản hồi cho chúng tôi](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+đồng thời [gửi phản hồi cho chúng tôi](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Thay đổi đáng chú ý so với phiên bản 2.3
 

--- a/vi/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/vi/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -12,7 +12,7 @@ Chúng tôi rất hân hạnh được thông báo về việc phát hành Ruby 
 Phiên bản 2.4.0-rc1 là phiên bản release candidate đầu tiên của Ruby 2.4.0.
 Phiên bản rc1 này được phát hành để nhận phản hồi từ cộng đồng.
 Hãy thoải mái
-[gửi phản hồi](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)
+[gửi phản hồi](https://github.com/ruby/ruby/wiki/How-To-Report)
 vì bạn vẫn có thể sửa những tính năng.
 
 ## [Giới thiệu cải tiến hash table (bởi Vladimir Makarov)](https://bugs.ruby-lang.org/issues/12142)
@@ -76,7 +76,7 @@ Ruby đã có cơ chế phát hiện deadlock của các threads, tuy nhiên cá
 Từ bản 2.4 trở đi, khi phát hiện ra Deadlock, Ruby sẽ hiển thị các thread cùng với backtrace và các threads liên quan.
 
 Mời mọi người dùng thử và cảm nhận việc lập trình với Ruby 2.4.0-rc1, và
-[gửi phản hồi cho chúng tôi](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+[gửi phản hồi cho chúng tôi](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## Thay đổi đáng chú ý so với phiên bản 2.3
 

--- a/zh_cn/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/zh_cn/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -11,7 +11,7 @@ lang: zh_cn
 
 Ruby 2.4.0-preview1 是 Ruby 2.4.0 的首个预览版。
 这个预览版的发布比平常早一点，因为它包括了很多新功能和改进。
-敬请给我们[反馈](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)，因为你还可以改变一些功能。
+敬请给我们[反馈](https://github.com/ruby/ruby/wiki/How-To-Report)，因为你还可以改变一些功能。
 
 ## [统一 Fixnum 和 Bignum 为 Integer](https://bugs.ruby-lang.org/issues/12005)
 
@@ -53,7 +53,7 @@ Ruby 忽视线程中的异常，除非另一个线程显式地执行直至结束
 Ruby 在线程等待地时候会进行死锁检查，但是检查的结果没有足够的信息用来调试。
 Ruby 2.4 死锁检查会显示他们的栈信息和依赖线程。
 
-尝试并且享受用与 Ruby 2.4.0-preview1 的编码时光，有任何问题，敬请[反馈](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+尝试并且享受用与 Ruby 2.4.0-preview1 的编码时光，有任何问题，敬请[反馈](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 自 2.3 起显著的改变
 

--- a/zh_cn/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/zh_cn/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -11,7 +11,7 @@ lang: zh_cn
 
 Ruby 2.4.0-rc1 是 Ruby 2.4.0 的第一个候选版本。
 发布 rc1 版本是为了从社区得带更多反馈。
-请[发送反馈](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)，
+请[发送反馈](https://github.com/ruby/ruby/wiki/How-To-Report)，
 因为你可以帮助修复这些功能。
 
 ## [哈希表的提升（由 Vladimir Makarov 提供）](https://bugs.ruby-lang.org/issues/12142)
@@ -69,7 +69,7 @@ Ruby 忽视线程中的异常，除非另一个线程显式地执行直至结束
 Ruby 在线程等待地时候会进行死锁检查，但是检查的结果没有足够的信息用来调试。
 Ruby 2.4 死锁检查会显示他们的栈信息和依赖线程。
 
-尝试并且享受用与 Ruby 2.4.0-rc1 的编码时光，有任何问题，敬请[反馈](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)!
+尝试并且享受用与 Ruby 2.4.0-rc1 的编码时光，有任何问题，敬请[反馈](https://github.com/ruby/ruby/wiki/How-To-Report)!
 
 ## 其他自 2.3 起显著的改变
 

--- a/zh_tw/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/zh_tw/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -11,7 +11,7 @@ lang: zh_tw
 
 Ruby 2.4.0-preview1 是 Ruby 2.4.0 的首個預覽版。
 這個預覽版發佈的比平常早，因為包含了許多新功能和改良。
-有任何想修改的功能，敬請給我們[建議](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)。
+有任何想修改的功能，敬請給我們[建議](https://github.com/ruby/ruby/wiki/How-To-Report)。
 
 ## [Fixnum 和 Bignum 統整為 Integer](https://bugs.ruby-lang.org/issues/12005)
 
@@ -52,7 +52,7 @@ Ruby 2.4 還包括以下效能優化及語法變更：
 Ruby 在等待線程執行時會進行死鎖檢查，但檢查結果沒有足夠的資訊來除錯。
 Ruby 2.4 的死鎖檢查會顯示錯誤資訊及相依的線程。
 
-請嘗試並享受與 Ruby 2.4.0-preview1 的編碼時光，有任何問題敬請[不吝指出](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)！
+請嘗試並享受與 Ruby 2.4.0-preview1 的編碼時光，有任何問題敬請[不吝指出](https://github.com/ruby/ruby/wiki/How-To-Report)！
 
 ## 自 2.3 起重要的變化
 

--- a/zh_tw/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/zh_tw/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -11,7 +11,7 @@ lang: zh_tw
 
 Ruby 2.4.0-preview2 是 Ruby 2.4.0 的第二個預覽版。
 為了獲得社群的寶貴意見發佈了此版本。
-請不吝[至此反饋](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)，你仍可以對將來的功能做出改變。
+請不吝[至此反饋](https://github.com/ruby/ruby/wiki/How-To-Report)，你仍可以對將來的功能做出改變。
 
 ## [Fixnum 和 Bignum 統整為 Integer](https://bugs.ruby-lang.org/issues/12005)
 
@@ -52,7 +52,7 @@ Ruby 2.4 還包括以下效能優化及語法變更：
 Ruby 在等待線程執行時會進行死鎖檢查，但檢查結果沒有足夠的資訊來除錯。
 Ruby 2.4 的死鎖檢查會顯示錯誤資訊及相依的線程。
 
-請嘗試並享受與 Ruby 2.4.0-preview2 的編碼時光，有任何問題敬請[不吝指出](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)！
+請嘗試並享受與 Ruby 2.4.0-preview2 的編碼時光，有任何問題敬請[不吝指出](https://github.com/ruby/ruby/wiki/How-To-Report)！
 
 ## 自 2.3 起重要的變化
 

--- a/zh_tw/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/zh_tw/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -11,7 +11,7 @@ lang: zh_tw
 
 Ruby 2.4.0-preview3 是 Ruby 2.4.0 的第三個預覽版。
 為了獲得社群的寶貴意見所以發佈了 preview3。
-請不吝[至此反饋](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)，您仍可以對將來的功能做出改變。
+請不吝[至此反饋](https://github.com/ruby/ruby/wiki/How-To-Report)，您仍可以對將來的功能做出改變。
 
 ## [Vladimir Makarov 改良了哈希表](https://bugs.ruby-lang.org/issues/12142)
 
@@ -60,7 +60,7 @@ Ruby 2.4 還包括以下效能優化及語法變更：
 Ruby 在等待線程執行時會進行死鎖檢查，但檢查結果沒有足夠的資訊來除錯。
 Ruby 2.4 的死鎖檢查會顯示錯誤資訊及相依的線程。
 
-請嘗試並享受與 Ruby 2.4.0-preview3 的編碼時光，有任何問題敬請[不吝指出](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)！
+請嘗試並享受與 Ruby 2.4.0-preview3 的編碼時光，有任何問題敬請[不吝指出](https://github.com/ruby/ruby/wiki/How-To-Report)！
 
 ## 自 2.3 起重要的變化
 

--- a/zh_tw/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
+++ b/zh_tw/news/_posts/2016-12-12-ruby-2-4-0-rc1-released.md
@@ -11,7 +11,7 @@ lang: zh_tw
 
 Ruby 2.4.0-rc1 是 Ruby 2.4.0 的第一個候選版本。
 為了獲得社群的寶貴意見所以發佈了 rc1。
-請不吝[至此反饋](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)，您仍可以對將來的功能做出改變。
+請不吝[至此反饋](https://github.com/ruby/ruby/wiki/How-To-Report)，您仍可以對將來的功能做出改變。
 
 ## [Vladimir Makarov 改良了哈希表](https://bugs.ruby-lang.org/issues/12142)
 
@@ -60,7 +60,7 @@ Ruby 2.4 還包括以下效能優化及語法變更：
 Ruby 在等待線程執行時會進行死鎖檢查，但檢查結果沒有足夠的資訊來除錯。
 Ruby 2.4 的死鎖檢查會顯示錯誤資訊及相依的線程。
 
-請嘗試並享受與 Ruby 2.4.0-rc1 的編碼時光，有任何問題敬請[不吝指出](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport)！
+請嘗試並享受與 Ruby 2.4.0-rc1 的編碼時光，有任何問題敬請[不吝指出](https://github.com/ruby/ruby/wiki/How-To-Report)！
 
 ## 自 2.3 起重要的變化
 


### PR DESCRIPTION
Several links are broken due to migrate the wiki from bugs.ruby-lang.org to the ruby/ruby GitHub repository.
- https://bugs.ruby-lang.org/issues/19679

This PR migrated what we can in this PR, but the following links doesn't seem to exist for the migrated page:
- https://bugs.ruby-lang.org/projects/ruby/wiki/200UpgradeNotesDraft
- https://bugs.ruby-lang.org/projects/ruby/wiki/200SpecialThanks
- https://bugs.ruby-lang.org/projects/ruby/wiki/MJIT