### PR TITLE
Fix typo in 2023-06-29-redos-in-uri-CVE-2023-36617.md

### DIFF
--- a/en/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
+++ b/en/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
@@ -8,7 +8,7 @@ tags: security
 lang: en
 ---
 
-We have released the uri gem version 0.12.1, 0.10.2 that has a security fix for a ReDoS vulnerability.
+We have released the uri gem version 0.12.2, 0.10.3 that has a security fix for a ReDoS vulnerability.
 This vulnerability has been assigned the CVE identifier [CVE-2023-36617](https://www.cve.org/CVERecord?id=CVE-2023-36617).
 
 ## Details


### PR DESCRIPTION
The versions released today are 0.12.2 and 0.10.3.
https://rubygems.org/gems/uri/versions/0.12.2
https://rubygems.org/gems/uri/versions/0.10.3