### PR TITLE
Translate "CVE-2023-36617: ReDoS vulnerability in URI" (ko)

### DIFF
--- a/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
+++ b/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
@@ -1,0 +1,43 @@
+---
+layout: news_post
+title: "CVE-2023-36617: ReDoS vulnerability in URI"
+author: "hsbt"
+translator:
+date: 2023-06-29 01:00:00 +0000
+tags: security
+lang: en
+---
+
+We have released the uri gem version 0.12.2, 0.10.3 that has a security fix for a ReDoS vulnerability.
+This vulnerability has been assigned the CVE identifier [CVE-2023-36617](https://www.cve.org/CVERecord?id=CVE-2023-36617).
+
+## Details
+
+A ReDoS issue was discovered in the URI component through 0.12.1 for Ruby. The URI parser mishandles invalid URLs that have specific characters. There is an increase in execution time for parsing strings to URI objects with rfc2396_parser.rb and rfc3986_parser.rb.
+
+NOTE: this issue exists because of an incomplete fix for [CVE-2023-28755](https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/).
+
+The `uri` gem version 0.12.1 and all versions prior 0.12.1 are vulnerable for this vulnerability.
+
+## Recommended action
+
+We recommend to update the `uri` gem to 0.12.2. In order to ensure compatibility with bundled version in older Ruby series, you may update as follows instead:
+
+* For Ruby 3.0: Update to `uri` 0.10.3
+* For Ruby 3.1 and 3.2: Update to `uri` 0.12.2
+
+You can use `gem update uri` to update it. If you are using bundler, please add `gem "uri", ">= 0.12.2"` (or other version mentioned above) to your `Gemfile`.
+
+## Affected versions
+
+* uri gem 0.12.1 or before
+
+## Credits
+
+Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for discovering this issue.
+
+Thanks to [nobu](https://github.com/nobu) for fixing this issue.
+
+## History
+
+* Originally published at 2023-06-29 01:00:00 (UTC)

--- a/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
+++ b/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
@@ -1,6 +1,6 @@
 ---
 layout: news_post
-title: "CVE-2023-36617: ReDoS vulnerability in URI"
+title: "CVE-2023-36617: URI의 ReDoS 취약점"
 author: "hsbt"
 translator: "shia"
 date: 2023-06-29 01:00:00 +0000
@@ -13,7 +13,7 @@ ReDoS 취약점에 대한 보안 수정이 포함된 uri gem 버전 0.12.2, 0.10
 
 ## 세부 내용
 
-0.12.1 이전의 URI 구성 요소에서 ReDoS 문제가 발견되었습니다. URI 구문 분석기가 특정 문자가 포함된 유효하지 않은 URL을 잘못 처리합니다. 이로 인해 `rfc2396_parser.rb`와 `rfc3986_parser.rb`를 사용하는 URI 객체에 대한 문자열 구문 분석 실행 시간이 증가합니다.
+0.12.1 이전의 URI 구성 요소에서 ReDoS 문제가 발견되었습니다. URI 구문 분석기가 특정 문자가 포함된 유효하지 않은 URL을 잘못 처리합니다. 이로 인해 `rfc2396_parser.rb`와 `rfc3986_parser.rb`를 사용해 문자열을 URI 객체로 구문 분석하는 데 걸리는 실행 시간이 증가합니다.
 
 NOTE: 이 문제는 [CVE-2023-28755](https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/)의 불완전한 수정으로 발생했습니다.
 

--- a/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
+++ b/ko/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
@@ -2,42 +2,42 @@
 layout: news_post
 title: "CVE-2023-36617: ReDoS vulnerability in URI"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2023-06-29 01:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-We have released the uri gem version 0.12.2, 0.10.3 that has a security fix for a ReDoS vulnerability.
-This vulnerability has been assigned the CVE identifier [CVE-2023-36617](https://www.cve.org/CVERecord?id=CVE-2023-36617).
+ReDoS 취약점에 대한 보안 수정이 포함된 uri gem 버전 0.12.2, 0.10.3을 릴리스했습니다.
+이 취약점에는 CVE 식별자 [CVE-2023-36617](https://www.cve.org/CVERecord?id=CVE-2023-36617)이 할당되었습니다.
 
-## Details
+## 세부 내용
 
-A ReDoS issue was discovered in the URI component through 0.12.1 for Ruby. The URI parser mishandles invalid URLs that have specific characters. There is an increase in execution time for parsing strings to URI objects with rfc2396_parser.rb and rfc3986_parser.rb.
+0.12.1 이전의 URI 구성 요소에서 ReDoS 문제가 발견되었습니다. URI 구문 분석기가 특정 문자가 포함된 유효하지 않은 URL을 잘못 처리합니다. 이로 인해 `rfc2396_parser.rb`와 `rfc3986_parser.rb`를 사용하는 URI 객체에 대한 문자열 구문 분석 실행 시간이 증가합니다.
 
-NOTE: this issue exists because of an incomplete fix for [CVE-2023-28755](https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/).
+NOTE: 이 문제는 [CVE-2023-28755](https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/)의 불완전한 수정으로 발생했습니다.
 
-The `uri` gem version 0.12.1 and all versions prior 0.12.1 are vulnerable for this vulnerability.
+`uri` gem의 0.12.1과 모든 0.12.1 이하 버전이 이 취약점에 취약합니다.
 
-## Recommended action
+## 권장 조치
 
-We recommend to update the `uri` gem to 0.12.2. In order to ensure compatibility with bundled version in older Ruby series, you may update as follows instead:
+`uri` gem을 0.12.2로 업데이트하는 것이 좋습니다. 이전 Ruby 버전대에 포함된 버전과의 호환성을 보장하기 위해 다음과 같이 업데이트할 수 있습니다.
 
-* For Ruby 3.0: Update to `uri` 0.10.3
-* For Ruby 3.1 and 3.2: Update to `uri` 0.12.2
+* Ruby 3.0: `uri` 0.10.3으로 업데이트
+* Ruby 3.1과 3.2: `uri` 0.12.2로 업데이트
 
-You can use `gem update uri` to update it. If you are using bundler, please add `gem "uri", ">= 0.12.2"` (or other version mentioned above) to your `Gemfile`.
+`gem update uri`를 사용하여 업데이트할 수 있습니다. bundler를 사용하는 경우 `gem "uri", ">= 0.12.2"`(또는 위에 언급된 다른 버전)을 `Gemfile`에 추가하세요.
 
-## Affected versions
+## 해당 버전
 
-* uri gem 0.12.1 or before
+* uri gem 0.12.1과 그 이하
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for discovering this issue.
+이 문제를 발견해 준 [ooooooo_q](https://hackerone.com/ooooooo_q)에게 감사를 표합니다.
 
-Thanks to [nobu](https://github.com/nobu) for fixing this issue.
+이 문제를 수정해 준 [nobu](https://github.com/nobu)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2023-06-29 01:00:00 (UTC)
+* 2023-06-29 01:00:00 (UTC) 최초 공개


### PR DESCRIPTION
:link: #2818

Translate https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
Actual diff is  f5fe7a1013abbf2d6f8a4e255875b1a2032ca0f7