### PR TITLE
Fix links to ReDoS vulnerability posts in Ruby 3.2.2 released news (en)

### DIFF
--- a/en/news/_posts/2023-03-30-ruby-3-2-2-released.md
+++ b/en/news/_posts/2023-03-30-ruby-3-2-2-released.md
@@ -12,8 +12,8 @@ Ruby 3.2.2 has been released.
 This release includes security fixes.
 Please check the topics below for details.
 
-* [CVE-2023-28755: ReDoS vulnerability in URI]({%link es/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md %})
-* [CVE-2023-28756: ReDoS vulnerability in Time]({%link es/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md %})
+* [CVE-2023-28755: ReDoS vulnerability in URI]({%link en/news/_posts/2023-03-28-redos-in-uri-cve-2023-28755.md %})
+* [CVE-2023-28756: ReDoS vulnerability in Time]({%link en/news/_posts/2023-03-30-redos-in-time-cve-2023-28756.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_2) for further details.
 


### PR DESCRIPTION
Ruby 3.2.2 released news post links to the Spanish version of ReDoS vulnerability posts, CVE-2023-28755 and CVE-2023-28756. The post should link to the original version, which is in English. This PR is created to fix these links.