### PR TITLE
Skip preview branch in the timeline charts on downloads/branches/

### DIFF
--- a/javascripts/branch-timeline.js
+++ b/javascripts/branch-timeline.js
@@ -6,7 +6,7 @@
 
   function drawChart() {
     const source =
-      JSON.parse(document.getElementById("branches.json").innerHTML).slice(0, 5).reverse()
+      JSON.parse(document.getElementById("branches.json").innerHTML).filter(e=>e.status != "preview").slice(0, 5).reverse()
       .map(e => {
         return {
           ...e,


### PR DESCRIPTION
The timeline chart at https://www.ruby-lang.org/en/downloads/branches/ is broken because the "preview" status is not assumed, and that is because the colors for the preview status have not yet been determined. To simplify the rendering, we will omit it for now.