### PR TITLE
Translate CVE-2023-36617: ReDoS vulnerability in URI (id)

### DIFF
--- a/id/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
+++ b/id/news/_posts/2023-06-29-redos-in-uri-CVE-2023-36617.md
@@ -1,0 +1,55 @@
+---
+layout: news_post
+title: "CVE-2023-36617: Kerentanan ReDoS pada URI"
+author: "hsbt"
+translator: "meisyal"
+date: 2023-06-29 01:00:00 +0000
+tags: security
+lang: id
+---
+
+Kami telah merilis versi *gem* uri 0.12.2, 0.10.3 yang memiliki perbaikan
+keamanan untuk kerentanan ReDoS.
+Kerentanan ini telah ditetapkan dengan penanda CVE
+[CVE-2023-36617](https://www.cve.org/CVERecord?id=CVE-2023-36617).
+
+## Detail
+
+Sebuah isu ReDoS ditemukan pada komponen URI hingga versi 0.12.1. URI *parser*
+menangani URL yang tidak valid yang memiliki karakter tertentu secara tidak tepat.
+Ini menyebabkan kenaikan waktu eksekusi untuk mem-*parse string* ke objek URI
+dengan rfc2396_parser.rb dan rfc3986_parser.rb.
+
+Catatan: isu ini ada karena perbaikan kurang sempurna pada
+[CVE-2023-28755](https://www.ruby-lang.org/id/news/2023/03/28/redos-in-uri-cve-2023-28755/).
+
+*Gem* `uri` versi 0.12.1 dan semua versi sebelum 0.12.1 rentan terhadap isu ini.
+
+## Tindakan yang direkomendasikan
+
+Kami merekomendasikan untuk memperbarui *gem* `uri` ke 0.12.2. Untuk memastikan
+kompatibilitas dengan versi yang dibundel pada rangkaian Ruby lama, Anda bisa
+memperbarui dengan langkah berikut.
+
+* Untuk Ruby 3.0: Perbarui `uri` ke 0.10.3
+* Untuk Ruby 3.1 dan 3.2: Perbarui `uri` ke 0.12.2
+
+Anda dapat menggunakan `gem update uri` untuk memperbarui. Jika Anda menggunakan
+*bundler*, mohon tambahkan `gem "uri", ">= 0.12.2"` (atau versi lain yang disebut
+sebelumnya) pada `Gemfile` Anda.
+
+## Versi terimbas
+
+* *Gem* uri 0.12.1 atau sebelumnya
+
+## Rujukan
+
+Terima kasih kepada [ooooooo_q](https://hackerone.com/ooooooo_q) yang telah
+menemukan isu ini.
+
+Terima kasih kepada [nobu](https://github.com/nobu) yang telah memperbaiki isu
+ini.
+
+## Riwayat
+
+* Semula dipublikasikan pada 2023-06-29 01:00:00 (UTC)


### PR DESCRIPTION
This PR contains the translation of "CVE-2023-36617: ReDoS vulnerability in URI" post in Bahasa Indonesia.