### PR TITLE
Translate CVE-2021-33621: HTTP response splitting in CGI (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md
+++ b/zh_tw/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md
@@ -1,0 +1,36 @@
+---
+layout: news_post
+title: "CVE-2021-33621: CGI 存在 HTTP 響應切分風險"
+author: "mame"
+translator: "Bear Su"
+date: 2022-11-22 02:00:00 +0000
+tags: security
+lang: zh_tw
+---
+
+我們釋出了 gci gem 版本 0.3.5、0.2.2、和 0.1.0.2，這些版本修復了 HTTP 響應切分（response splitting）安全性風險。
+此風險的 CVE 識別號為 [CVE-2021-33621](https://www.cve.org/CVERecord?id=CVE-2021-33621)。
+
+## 細節
+
+如果一個應用程式透過 cgi gem 使用不受信任的使用者輸入產生 HTTP 響應，攻擊者可以利用此風險注入惡意的 HTTP 響應標頭和/或響應內文。
+
+此外，`CGI::Cookie` 物件的內容未被正確檢查 。如果一個應用程式基於使用者輸入建立一個 `CGI::Cookie` 物件，攻擊者可以利用此風險在 `Set-Cookie` 標頭注入非法的屬性。
+我們認為此類應用程式不太會有這種使用情境，但我們還是進行了變更以預防性地檢查 `CGI::Cookie#initialize` 的參數。
+
+請更新 cgi gem 至版本 0.3.5、0.2.2、和 0.1.0.2 或之後的版本。您可以使用 `gem update cgi` 進行更新。
+如果您使用 bundler，請將 `gem "cgi", ">= 0.3.5"` 加入到您的 `Gemfile` 中。
+
+## 受影響版本
+
+* cgi gem 0.3.3 以及之前的版本
+* cgi gem 0.2.1 以及之前的版本
+* cgi gem 0.1.1 或 0.1.0.1 或 0.1.0
+
+## 致謝
+
+感謝 [Hiroshi Tokumaru](https://hackerone.com/htokumaru?type=user) 發現此問題。
+
+## 歷史
+
+* 初次發佈於 2022-11-22 02:00:00 (UTC)


### PR DESCRIPTION
Translate CVE-2021-33621: HTTP response splitting in CGI News (zh_tw)

Thank you.