### PR TITLE
[Data] Normalize all dates in releases.yml to Date instead of String

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -169,7 +169,7 @@
 # 3.2 series
 
 - version: 3.2.3
-  date: '2024-01-18'
+  date: 2024-01-18
   post: "/en/news/2024/01/18/ruby-3-2-3-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -193,7 +193,7 @@
     zip: fd89a0a833df4b5cb1734a7ffc86a8cf7cb3a8e25944331db674d3ad7732f615867e7e214e1fdd61e44e9c9c856b461b46219b340de7c87a758f28f3a99dd172
 
 - version: 3.2.2
-  date: '2023-03-30'
+  date: 2023-03-30
   post: "/en/news/2023/03/30/ruby-3-2-2-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
@@ -217,7 +217,7 @@
     zip: 569a68d89cc9a646cd0319d7cb8d57df3a55c0ac2c64f1f61607cc9c06b3aa8415eb8d38f7893ab3dbf072da9e919fbc454a9338e924c20a6a5110a1fa301d52
 
 - version: 3.2.1
-  date: '2023-02-08'
+  date: 2023-02-08
   post: "/en/news/2023/02/08/ruby-3-2-1-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz
@@ -388,7 +388,7 @@
 # 3.1 series
 
 - version: 3.1.4
-  date: '2023-03-30'
+  date: 2023-03-30
   post: "/en/news/2023/03/30/ruby-3-1-4-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz
@@ -412,7 +412,7 @@
     zip: 3a334302df97c2c7fec3c2d05d19a40b1ec6f95fef52c85d397196ce62fac4834f96783f0ac7fcba6e2a670f004bcc275db6f1810ace6c68a594e7d2fd9b297b
 
 - version: 3.1.3
-  date: '2022-11-24'
+  date: 2022-11-24
   post: "/en/news/2022/11/24/ruby-3-1-3-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz
@@ -436,7 +436,7 @@
     zip: 3901380a27157639dee72f80231790886d269cc741a6c9e0f6472554855be86bdb93f71577ed8d93e817ef0c8d9a168fcd6f6d426fabb465dd0dd22b5a56cfc9
 
 - version: 3.1.2
-  date: '2022-04-12'
+  date: 2022-04-12
   post: "/en/news/2022/04/12/ruby-3-1-2-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz
@@ -544,7 +544,7 @@
 # 3.0 series
 
 - version: 3.0.6
-  date: '2023-03-30'
+  date: 2023-03-30
   post: "/en/news/2023/03/30/ruby-3-0-6-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz
@@ -568,7 +568,7 @@
     zip: 576d11c668acac57cf4952228b148d17f16ab1dc491145355a4f2068b15f6cab8a4007a84d9d1eda4c1b62837675c82be99ebe6379c314f46c6ebbbf89677b5e
 
 - version: 3.0.5
-  date: '2022-11-24'
+  date: 2022-11-24
   post: "/en/news/2022/11/24/ruby-3-0-5-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz
@@ -592,7 +592,7 @@
     zip: 953cef1dd97395e04059cc76ee2a74348f2c9da0b2727c5406af26e88072e8c0bde91835354cb9f1b44f3a81a49ea7b807d7f048d138fd74ba3cabbf7859f2b3
 
 - version: 3.0.4
-  date: '2022-04-12'
+  date: 2022-04-12
   post: "/en/news/2022/04/12/ruby-3-0-4-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz
@@ -616,7 +616,7 @@
     zip: 2d97099161bcd17c5fdf1c70da6e062ae410186e7c1235e3b1df5bad6085e370bed3cf1ebd89ed9b5918cd386ae47d1f986a3c96c32f0c8a0b9375e56b66a1d9
 
 - version: 3.0.3
-  date: '2021-11-24'
+  date: 2021-11-24
   post: "/en/news/2021/11/24/ruby-3-0-3-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz
@@ -640,7 +640,7 @@
     zip: 24c2a4f455f90e54f85d9565e392519833b36aefce32dc707e6693994d175c82e84ee6c37ed4a9ddf8840479e7cdfaae714c12bc6923368bb00346d4edd434d8
 
 - version: 3.0.2
-  date: '2021-07-07'
+  date: 2021-07-07
   post: "/en/news/2021/07/07/ruby-3-0-2-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz
@@ -808,7 +808,7 @@
 # 2.7 series
 
 - version: 2.7.8
-  date: '2023-03-30'
+  date: 2023-03-30
   post: "/en/news/2023/03/30/ruby-2-7-8-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.bz2
@@ -837,7 +837,7 @@
     zip: e7ad3380cc81ecfebccb39acad7364a20bc5ebf9ce74ca5d82225fe0dea76e2ee46aa97e49b975dd9a00c7ff60d94907d9a27acdbb5c5a48b88a3c58e0a998be
 
 - version: 2.7.7
-  date: '2022-11-24'
+  date: 2022-11-24
   post: "/en/news/2022/11/24/ruby-2-7-7-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2
@@ -866,7 +866,7 @@
     zip: 90dabc0fcedc25e3e46d5e9f2dff01c56e142c2e71b95c4c5f4da056f1e47cb320ef8b949282fd9594869e91cd76eab27ad70061be6c26b0d0d8837ae0fb8309
 
 - version: 2.7.6
-  date: '2022-04-12'
+  date: 2022-04-12
   post: "/en/news/2022/04/12/ruby-2-7-6-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2
@@ -895,7 +895,7 @@
     zip: d7210aa211333cc1afa080b999bf1a50db1708bb8e2c608892bb42fe450f4567aa4d974532071e0eba3d96bee63ed1f2d51f123d443edc46668c4eca3fe1f791
 
 - version: 2.7.5
-  date: '2021-11-24'
+  date: 2021-11-24
   post: "/en/news/2021/11/24/ruby-2-7-5-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2
@@ -924,7 +924,7 @@
     zip: fe9a706f8139e59a40ab205dc88cdc613c9c69186cb2daeb5adc80bdf45290a523fa7e3fd0866fa12325039ba413ff1e1f4233073d352da08079dc903063b31a
 
 - version: 2.7.4
-  date: '2021-07-07'
+  date: 2021-07-07
   post: "/en/news/2021/07/07/ruby-2-7-4-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2
@@ -1199,7 +1199,7 @@
 # 2.6 series
 
 - version: 2.6.10
-  date: '2022-04-12'
+  date: 2022-04-12
   post: "/en/news/2022/04/12/ruby-2-6-10-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2
@@ -1228,7 +1228,7 @@
     zip: 352efede781c3c3b1aaaaeaa28050d530b8a350ec549218464dfe57a4d39770f5a345978fc9f6c23d5f539db70bd9f53c4fbf807dc4ec4bdf9cae1acbe6c2c99
 
 - version: 2.6.9
-  date: '2021-11-24'
+  date: 2021-11-24
   post: "/en/news/2021/11/24/ruby-2-6-9-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2
@@ -1257,7 +1257,7 @@
     zip: 9073e0fc5040434f15158f24c6a551286bc5f1c4c1cb54d6e3debb4ac039187a4f274a217bdb5c8489c72360c65d708f89eb0f2472a1f9232fcfee8e296dec57
 
 - version: 2.6.8
-  date: '2021-07-07'
+  date: 2021-07-07
   post: "/en/news/2021/07/07/ruby-2-6-8-released/"
   url:
     bz2: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2


### PR DESCRIPTION
In `_data/releases.yml`, 18 of the total 197 dates under the `date:` key are represented with quotes instead of without.

This has the side effect that when the file is YAML-parsed, these dates are parsed as `String`s instead of `Date`s, creating an unwanted inconsistency of classes.

```ruby
yaml = YAML.unsafe_load_file('_data/releases.yml')

yaml.find { |y| y['version'] == '3.2.0' }['date']
# => #<Date: 2022-12-25 ((2459939j,0s,0n),+0s,-Infj)>

yaml.find { |y| y['version'] == '3.2.2' }['date']
# => "2023-03-30"
```

This PR normalizes the 18 dates removing the quotes so that they're all parsed as `Date` class.


```ruby
yaml = YAML.unsafe_load_file('_data/releases.yml')

# master
yaml.reject { |item| item['date'].is_a?(Date) }.count
# => 18

# this branch
yaml.reject { |item| item['date'].is_a?(Date) }.count
# => 0
```