### PR TITLE
Fix typo in Ruby 3.3.0-rc1 news

### DIFF
--- a/en/news/_posts/2023-12-11-ruby-3-3-0-rc1-released.md
+++ b/en/news/_posts/2023-12-11-ruby-3-3-0-rc1-released.md
@@ -152,7 +152,7 @@ The following deprecated methods are removed.
 
 ### Removed environment variables
 
-The following deprecated methods are removed.
+The following deprecated environment variables are removed.
 
 * Environment variable `RUBY_GC_HEAP_INIT_SLOTS` has been deprecated and is a no-op. Please use environment variables `RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS` instead. [Feature #19785](https://bugs.ruby-lang.org/issues/19785)
 


### PR DESCRIPTION
Spotted by `diff -u en/news/_posts/{2023-11-12-ruby-3-3-0-preview3-released.md,2023-12-11-ruby-3-3-0-rc1-released.md}`:

``` diff
@@ -128,7 +152,7 @@
 
 ### Removed environment variables
 
-The following deprecated environment variables are removed.
+The following deprecated methods are removed.
 
 * Environment variable `RUBY_GC_HEAP_INIT_SLOTS` has been deprecated and is a no-op. Please use environment variables `RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS` instead. [Feature #19785](https://bugs.ruby-lang.org/issues/19785)
 
```