### PR TITLE
Add compatibility note about `Regexp::new`

### DIFF
--- a/en/news/_posts/2023-12-25-ruby-3-3-0-released.md
+++ b/en/news/_posts/2023-12-25-ruby-3-3-0-released.md
@@ -140,6 +140,9 @@ Note: Excluding feature bug fixes.
   deprecated. `it` will be a reference to the first block parameter in Ruby 3.4.
   [[Feature #18980]](https://bugs.ruby-lang.org/issues/18980)
 
+* `Regexp::new` now only accepts up to 2 arguments instead of 3. This was
+   deprecated in Ruby 3.2. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
+
 ### Removed environment variables
 
 The following deprecated methods are removed.


### PR DESCRIPTION
I couldn't find any mentions of this either in the Ruby 3.3 release note or the 3.2 deprecation that @jeremyevans [mentioned](https://bugs.ruby-lang.org/issues/18797).

I'm not sure this should be considered a bugfix, so I added a small mention to this new behavior. LMK if anything else needs to change.