### PR TITLE
Added IBM text and link as a sponsor.

### DIFF
--- a/en/about/website/index.md
+++ b/en/about/website/index.md
@@ -54,6 +54,8 @@ Also many thanks to the organizations that support us:
 
 <img src="../../../images/sponsor/works-on-arm.png" alt="Works on Arm" width="300" height="26" />
 
+[IBM][ibm] (hosting)
+
 [Fastly][fastly] (CDN)
 
 <img src="../../../images/sponsor/fastly.png" alt="Fastly" width="200" height="200" />
@@ -76,6 +78,7 @@ Also many thanks to the organizations that support us:
 [rubyassociation]: http://www.ruby.or.jp
 [heroku]: https://www.heroku.com/
 [works-on-arm]: https://www.arm.com/markets/computing-infrastructure/works-on-arm
+[ibm]: https://www.ibm.com
 [fastly]: http://www.fastly.com
 [hatena]: http://hatenacorp.jp/
 [mackerel]: https://mackerel.io/


### PR DESCRIPTION
This PR is to add the IBM text and the link into the "organizations supporting us" section in our [website page](https://www.ruby-lang.org/en/about/website/) as our appreciation. IBM has been sponsoring the "ppc64le (Ubuntu)" and "s390x (Ubuntu)" servers used in [RubyCI](https://rubyci.org/).

I have been discussing with IBM folks about the usage of the IBM logo image. According to the discussion, a single individual either the trademark owner (maybe matz) or the website owner in the Ruby project needs to sign IBM's trademark agreement document to use the logo image on our Ruby's website. And so far I don't think we want to do it.

To be fair, IBM folks spent time discussing with IBM's branding management team to improve the situation for us.

As a note, before I asked IBM, IBM usually did such things via a foundation or other entities with [IBM's logo requests - 3rd party](https://www.ibm.com/brand/ibm-logos/logo-requests/#third-parties) (IBM site's account is required to see the page).

You can check the updated website page [here](https://github.com/junaruga/www.ruby-lang.org/blob/wip/website-sponsor-ibm/en/about/website/index.md) on my forked repository.

---

The commit message is below.

I don't think that we want to use IBM logo image for now. Because according to a discussion with IBM folks, if we use the IBM logo image on our website, a single individual in the Ruby project needs to sign IBM's trademark agreement basically to make sure that the logo guidelines are followed. The individual is either the trademark owner or the website owner.

Considering the cost and merit for us, I don't think we want to sign the trademark agreement.
