### PR TITLE
Explicitly recommend that Ruby 3.3 users upgrade to 3.3.1 for CVE-2024-27282

### DIFF
--- a/en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
+++ b/en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
@@ -24,6 +24,7 @@ We recommend to update the Ruby to version 3.3.1 or later. In order to ensure co
 * For Ruby 3.0 users: Update to 3.0.7
 * For Ruby 3.1 users: Update to 3.1.5
 * For Ruby 3.2 users: Update to 3.2.4
+* For Ruby 3.3 users: Update to 3.3.1
 
 ## Affected versions
 


### PR DESCRIPTION
The blog post should explicitly tell Ruby 3.3 users to upgrade to 3.3.1. Otherwise, Ruby 3.3 users might mistakenly not upgrade.