### PR TITLE
Translation of 2024-04-23 published news to ko

### DIFF
--- a/ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
+++ b/ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search"
+author: "hsbt"
+translator:
+date: 2024-04-23 10:00:00 +0000
+tags: security
+lang: en
+---
+
+We have released the Ruby version 3.0.7, 3.1.5, 3.2.4 and 3.3.1 that have a security fix for an arbitrary memory address read vulnerability in Regex search.
+This vulnerability has been assigned the CVE identifier [CVE-2024-27282](https://www.cve.org/CVERecord?id=CVE-2024-27282).
+
+## Details
+
+An issue was discovered in Ruby 3.x through 3.3.0.
+
+If attacker-supplied data is provided to the Ruby regex compiler, it is possible to extract arbitrary heap data relative to the start of the text, including pointers and sensitive strings.
+
+## Recommended action
+
+We recommend to update the Ruby to version 3.3.1 or later. In order to ensure compatibility with older Ruby series, you may update as follows instead:
+
+* For Ruby 3.0 users: Update to 3.0.7
+* For Ruby 3.1 users: Update to 3.1.5
+* For Ruby 3.2 users: Update to 3.2.4
+* For Ruby 3.3 users: Update to 3.3.1
+
+## Affected versions
+
+* Ruby 3.0.6 or lower
+* Ruby 3.1.4 or lower
+* Ruby 3.2.3 or lower
+* Ruby 3.3.0
+
+## Credits
+
+Thanks to [sp2ip](https://hackerone.com/sp2ip?type=user) for discovering this issue.
+
+## History
+
+* Originally published at 2024-04-23 10:00:00 (UTC)

--- a/ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
+++ b/ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md
@@ -1,42 +1,42 @@
 ---
 layout: news_post
-title: "CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search"
+title: "CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2024-04-23 10:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-We have released the Ruby version 3.0.7, 3.1.5, 3.2.4 and 3.3.1 that have a security fix for an arbitrary memory address read vulnerability in Regex search.
-This vulnerability has been assigned the CVE identifier [CVE-2024-27282](https://www.cve.org/CVERecord?id=CVE-2024-27282).
+정규표현식 검색의 임의의 메모리 주소 읽기 취약점에 대한 보안 수정을 포함하는 Ruby 3.0.7, 3.1.5, 3.2.4, 3.3.1을 릴리스했습니다.
+이 취약점은 CVE 번호 [CVE-2024-27282](https://www.cve.org/CVERecord?id=CVE-2024-27282)로 등록되어 있습니다.
 
-## Details
+## 세부 내용
 
-An issue was discovered in Ruby 3.x through 3.3.0.
+Ruby 3.0.0부터 3.3.0까지 문제가 발견되었습니다.
 
-If attacker-supplied data is provided to the Ruby regex compiler, it is possible to extract arbitrary heap data relative to the start of the text, including pointers and sensitive strings.
+공격자가 제공한 데이터가 Ruby 정규표현식 컴파일러에 제공되면, 텍스트 시작 지점과 관련된 임의의 힙 데이터를 추출할 수 있습니다. 여기에는 포인터와 민감한 문자열을 포함됩니다.
 
-## Recommended action
+## 권장 조치
 
-We recommend to update the Ruby to version 3.3.1 or later. In order to ensure compatibility with older Ruby series, you may update as follows instead:
+Ruby를 3.3.1이나 그 이상으로 업데이트하는 것이 좋습니다. 이전 Ruby 버전대에 포함된 버전과의 호환성을 보장하기 위해 다음과 같이 업데이트할 수 있습니다.
 
-* For Ruby 3.0 users: Update to 3.0.7
-* For Ruby 3.1 users: Update to 3.1.5
-* For Ruby 3.2 users: Update to 3.2.4
-* For Ruby 3.3 users: Update to 3.3.1
+* Ruby 3.0 사용자: 3.0.7로 업데이트
+* Ruby 3.1 사용자: 3.1.5로 업데이트
+* Ruby 3.2 사용자: 3.2.4로 업데이트
+* Ruby 3.3 사용자: 3.3.1로 업데이트
 
-## Affected versions
+## 해당 버전
 
-* Ruby 3.0.6 or lower
-* Ruby 3.1.4 or lower
-* Ruby 3.2.3 or lower
+* Ruby 3.0.6과 그 이하
+* Ruby 3.1.4와 그 이하
+* Ruby 3.2.3과 그 이하
 * Ruby 3.3.0
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [sp2ip](https://hackerone.com/sp2ip?type=user) for discovering this issue.
+이 문제를 발견해 준 [sp2ip](https://hackerone.com/sp2ip?type=user)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2024-04-23 10:00:00 (UTC)
+* 2024-04-23 10:00:00 (UTC) 최초 공개

--- a/ko/news/_posts/2024-04-23-ruby-3-0-7-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-0-7-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 3.0.7 Released"
+author: "hsbt"
+translator:
+date: 2024-04-23 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.0.7 has been released.
+
+This release includes security fixes.
+Please check the topics below for details.
+
+* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_7) for further details.
+
+After this release, Ruby 3.0 reaches EOL. In other words, this is expected to be the last release of Ruby 3.0 series.
+We will not release Ruby 3.0.8 even if a security vulnerability is found (but could release if a severe regression is found).
+We recommend all Ruby 3.0 users to start migration to Ruby 3.3, 3.2, or 3.1 immediately.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.0.7" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2024-04-23-ruby-3-0-7-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-0-7-released.md
@@ -1,28 +1,28 @@
 ---
 layout: news_post
-title: "Ruby 3.0.7 Released"
+title: "Ruby 3.0.7 릴리스"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2024-04-23 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.0.7 has been released.
+Ruby 3.0.7이 릴리스되었습니다.
 
-This release includes security fixes.
-Please check the topics below for details.
+이번 릴리스에는 보안 수정 사항이 포함되어 있습니다.
+자세한 내용은 아래 항목을 참조하세요.
 
-* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
-See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_7) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_0_7)을 참조하세요.
 
-After this release, Ruby 3.0 reaches EOL. In other words, this is expected to be the last release of Ruby 3.0 series.
-We will not release Ruby 3.0.8 even if a security vulnerability is found (but could release if a severe regression is found).
-We recommend all Ruby 3.0 users to start migration to Ruby 3.3, 3.2, or 3.1 immediately.
+이 릴리스가 끝나면 Ruby 3.0은 EOL에 도달합니다. 즉, 이번 릴리스가 Ruby 3.0 버전대의 마지막 릴리스가 될 것입니다.
+보안 취약점이 발견되더라도 Ruby 3.0.8는 릴리스되지 않을 것입니다. (심각한 회귀 버그가 발생하는 경우는 예외입니다.)
+모든 Ruby 3.0 사용자는 즉시 Ruby 3.3, 3.2, 3.1로 마이그레이션할 것을 권장합니다.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.0.7" | first %}
 
@@ -47,7 +47,7 @@ We recommend all Ruby 3.0 users to start migration to Ruby 3.3, 3.2, or 3.1 imme
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2024-04-23-ruby-3-1-5-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-1-5-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 3.1.5 Released"
+author: "hsbt"
+translator:
+date: 2024-04-23 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.1.5 has been released.
+
+This release includes security fixes.
+Please check the topics below for details.
+
+* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_5) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.1.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2024-04-23-ruby-3-1-5-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-1-5-released.md
@@ -1,24 +1,24 @@
 ---
 layout: news_post
-title: "Ruby 3.1.5 Released"
+title: "Ruby 3.1.5 릴리스"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2024-04-23 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.1.5 has been released.
+Ruby 3.1.5가 릴리스되었습니다.
 
-This release includes security fixes.
-Please check the topics below for details.
+이번 릴리스에는 보안 수정 사항이 포함되어 있습니다.
+자세한 내용은 아래 항목을 참조하세요.
 
-* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
-See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_5) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_1_5)를 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.1.5" | first %}
 
@@ -43,7 +43,7 @@ See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_5) for 
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -1,24 +1,24 @@
 ---
 layout: news_post
-title: "Ruby 3.2.4 Released"
+title: "Ruby 3.2.4 릴리스"
 author: "nagachika"
-translator:
+translator: "shia"
 date: 2024-04-23 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.2.4 has been released.
+Ruby 3.2.4가 릴리스되었습니다.
 
-This release includes security fixes.
-Please check the topics below for details.
+이번 릴리스에는 보안 수정 사항이 포함되어 있습니다.
+자세한 내용은 아래 항목을 참조하세요.
 
-* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
-See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_4)를 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.2.4" | first %}
 
@@ -43,7 +43,7 @@ See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for 
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 3.2.4 Released"
+author: "nagachika"
+translator:
+date: 2024-04-23 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.2.4 has been released.
+
+This release includes security fixes.
+Please check the topics below for details.
+
+* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.4" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 3.3.1 Released"
+author: "naruse"
+translator:
+date: 2024-04-23 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.3.1 has been released.
+
+This release includes security fixes.
+Please check the topics below for details.
+
+* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.3.1" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -1,24 +1,24 @@
 ---
 layout: news_post
-title: "Ruby 3.3.1 Released"
+title: "Ruby 3.3.1 릴리스"
 author: "naruse"
-translator:
+translator: "shia"
 date: 2024-04-23 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.3.1 has been released.
+Ruby 3.3.1이 릴리스되었습니다.
 
-This release includes security fixes.
-Please check the topics below for details.
+이번 릴리스에는 보안 수정 사항이 포함되어 있습니다.
+자세한 내용은 아래 항목을 참조하세요.
 
-* [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
+* [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/rce-rdoc-cve-2024-27281/)
+* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점](https://www.ruby-lang.org/ko/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
-See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_3_1)를 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.3.1" | first %}
 
@@ -43,7 +43,7 @@ See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for 
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Translation of 2024-04-23 published news to ko.

- [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md)
- [Ruby 3.0.7 Released](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-04-23-ruby-3-0-7-released.md)
- [Ruby 3.1.5 Released](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-04-23-ruby-3-1-5-released.md)
- [Ruby 3.2.4 Released](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-04-23-ruby-3-2-4-released.md)
- [Ruby 3.3.1 Released](https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-04-23-ruby-3-3-1-released.md)
- #3226

Translation diff is [f0f97d1](https://github.com/ruby/www.ruby-lang.org/pull/3228/commits/f0f97d13b641981f3e9da16abf29f4216c487817)