### PR TITLE
Add compatibility note about `Regexp::new` (ko)

### DIFF
--- a/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
+++ b/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
@@ -139,8 +139,7 @@ IRB에 여러 개선 사항이 추가됩니다. 다음과 같은 내용이 포�
   Ruby 3.4부터 `it`은 첫 번째 블록 인수를 가리킵니다.
   [[Feature #18980]](https://bugs.ruby-lang.org/issues/18980)
 
-* `Regexp::new` now only accepts up to 2 arguments instead of 3. This was
-   deprecated in Ruby 3.2. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
+* `Regexp::new`는 최대 3개의 인수를 받았지만 이제 2개까지 허용합니다. 이는 Ruby 3.2 에서 폐기예정이었습니다. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
 
 ### 삭제된 환경 변수
 

--- a/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
+++ b/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
@@ -139,7 +139,7 @@ IRB에 여러 개선 사항이 추가됩니다. 다음과 같은 내용이 포�
   Ruby 3.4부터 `it`은 첫 번째 블록 인수를 가리킵니다.
   [[Feature #18980]](https://bugs.ruby-lang.org/issues/18980)
 
-* `Regexp::new`는 최대 3개의 인수를 받았지만 이제 2개까지 허용합니다. 이는 Ruby 3.2 에서 폐기예정이었습니다. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
+* `Regexp::new`는 최대 3개의 인수를 받았지만 이제 2개까지 허용합니다. 이는 Ruby 3.2에서 폐기예정이었습니다. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
 
 ### 삭제된 환경 변수
 

--- a/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
+++ b/ko/news/_posts/2023-12-25-ruby-3-3-0-released.md
@@ -139,6 +139,9 @@ IRB에 여러 개선 사항이 추가됩니다. 다음과 같은 내용이 포�
   Ruby 3.4부터 `it`은 첫 번째 블록 인수를 가리킵니다.
   [[Feature #18980]](https://bugs.ruby-lang.org/issues/18980)
 
+* `Regexp::new` now only accepts up to 2 arguments instead of 3. This was
+   deprecated in Ruby 3.2. [[Bug #18797]](https://bugs.ruby-lang.org/issues/18797)
+
 ### 삭제된 환경 변수
 
 폐기 예정이었던 환경 변수가 삭제됩니다.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Follow up #3175


Translation diff is a6904d6db074e19fb05b9d7d310b746eff923727