### PR TITLE
Use link function of jekyll on 2024-04-23 news

### DIFF
--- a/en/news/_posts/2024-04-23-ruby-3-0-7-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-0-7-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_7) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-0-7-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-0-7-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_0_7) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-1-5-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-1-5-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_5) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-1-5-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-1-5-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_1_5) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -13,8 +13,8 @@ This release includes security fixes.
 Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
-* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc](https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO](https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/)
+* [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
+* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for further details.
 


### PR DESCRIPTION
It seems better to use link function instead of writing news link with w.r-l.o domain. 👀 