### PR TITLE
Translate 3.1.6-released, 3.3.2-released, datadog-oss-program(zh_cn)

### DIFF
--- a/zh_cn/news/_posts/2024-05-29-ruby-3-1-6-released.md
+++ b/zh_cn/news/_posts/2024-05-29-ruby-3-1-6-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Ruby 3.1.6 已发布"
+author: "hsbt"
+translator: "GAO Jun"
+date: 2024-05-29 9:00:00 +0000
+lang: zh_cn
+---
+
+Ruby 3.1.6 已发布。
+
+Ruby 3.1 目前处于安全维护状态。一般来说，在此期间我们只会修正安全问题。但在 Ruby 3.1.5 发布后，我们发现了一些编译失败的问题。
+因此，我们决定发布 Ruby 3.1.6 来修正这些问题。
+
+您可以点击下面的链接来了解详情。
+
+* [Bug #20151: Can't build Ruby 3.1 on FreeBSD 14.0](https://bugs.ruby-lang.org/issues/20151)
+* [Bug #20451: Bad Ruby 3.1.5 backport causes fiddle to fail to build](https://bugs.ruby-lang.org/issues/20451)
+* [Bug #20431: Ruby 3.3.0 build fail with make: *** \[io_buffer.o\] Error 1](https://bugs.ruby-lang.org/issues/20431)
+
+您可以通过 [发布说明](https://github.com/ruby/ruby/releases/tag/v3_1_6) 获取进一步信息。
+
+## 下载
+
+{% assign release = site.data.releases | where: "version", "3.1.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      文件大小: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      文件大小: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      文件大小: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 发布说明
+
+许多提交者、开发人员以及用户提供了问题报告，帮助我们完成了此版本。
+感谢他们的贡献。

--- a/zh_cn/news/_posts/2024-05-30-datadog-oss-program.md
+++ b/zh_cn/news/_posts/2024-05-30-datadog-oss-program.md
@@ -1,0 +1,28 @@
+---
+layout: news_post
+title: "Datadog 为 ruby-lang.org 提供开源软件社区支持"
+author: "hsbt"
+translator: "GAO Jun"
+date: 2024-05-30 00:00:00 +0000
+lang: zh_cn
+---
+
+我们很激动地宣布 Ruby 官方站点，ruby-lang.org，采用了 Datadog 的 [Datadog 开源软件社区支持](https://opensource.datadoghq.com/projects/oss-program/) 来进行运维监控。
+
+这使我们能够有效地实时监控 Ruby 用户站点的性能和可用性。使用 Datadog 的好处包括以下几点：
+
+## CDN 可见性
+
+由 Fastly 提供的 cache.ruby-lang.org 是 Ruby 生态系统中的重要一环。Datadog 能监控 CDN 的性能，跟踪缓存覆盖率和错误率，提升用户体验。
+
+## 统一的数据可视化
+
+ruby-lang.org 提供了多种 Web 服务。Datadog 能够在同一仪表板中可视化地呈现日志分析数据以及应用程序性能监控 (APM) 数据。
+
+## JIT 跟踪可见性
+
+通过 Datadog 的跟踪功能，我们可以在请求通过 Web 服务器和数据库时进行捕获并跟踪。这有助于识别瓶颈和有问题的请求。
+
+我们发布了关键指标的 [公共仪表板](https://p.ap1.datadoghq.com/sb/1271b83e-af90-11ee-9072-da7ad0900009-01633a8fa8c0b0c0051f1889afdf55dc)。随着我们持续改进监控，尤其是 YJIT 性能，我们将相应地更新仪表板。
+
+我们希望采用 Datadog 能有助于提高 Ruby 社区的站点性能。请继续使用 ruby-lang.org 来享受更好的用户体验。

--- a/zh_cn/news/_posts/2024-05-30-ruby-3-3-2-released.md
+++ b/zh_cn/news/_posts/2024-05-30-ruby-3-3-2-released.md
@@ -1,0 +1,43 @@
+---
+layout: news_post
+title: "Ruby 3.3.2 已发布"
+author: "k0kubun"
+translator: "GAO Jun"
+date: 2024-05-30 03:50:00 +0000
+lang: zh_cn
+---
+
+Ruby 3.3.2 已发布.
+
+此版本包含了很多问题修正补丁。
+您可以通过 [发布说明](https://github.com/ruby/ruby/releases/tag/v3_3_2) 获取进一步信息。
+
+## 下载
+
+{% assign release = site.data.releases | where: "version", "3.3.2" | first %}
+
+* <{{ release.url.gz }}>
+
+      文件大小: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      文件大小: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      文件大小: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 发布说明
+
+许多提交者、开发人员以及用户提供了问题报告，帮助我们完成了此版本。
+感谢他们的贡献。


### PR DESCRIPTION
Translation of the following posts (zh_cn),

Ruby 3.3.2 Released
Datadog provides OSS community support for ruby-lang.org
Ruby 3.1.6 Released