### PR TITLE
Update Conferences Page

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -36,7 +36,7 @@ event dates, location, CFP (Call For Proposals) and Registration information.
 
 An updated list of Regional Ruby Conferences is available at [RubyConferences.org][rc].
 
-You can also find the GitHub repository link there to add or update information yourself. 
+You can also find the GitHub repository link there to add or update information yourself.
 
 [rc]: http://rubyconferences.org/
 [1]: http://rubyconf.org/

--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -18,13 +18,8 @@ event dates, location, CFP (Call For Proposals) and Registration information.
 
 [RubyConf][1]
 : Every year since 2001, [Ruby Central, Inc.][2] has produced RubyConf,
-  the International Ruby conference. Attendance grew by a factor of ten
-  between 2001 and 2006. RubyConf has provided a forum for presentations
-  about Ruby technologies by their creators, including talks by
-  Nathaniel Talbot on Test Unit, Jim Weirich on Rake, David Heinemeier
-  Hansson on Ruby on Rails, Why the Lucky Stiff on the YAML library, and
-  Sasada Koichi on YARV. Matz has attended, and spoken at, all the
-  RubyConfs but one.
+  the International Ruby conference. RubyConf has provided a forum for presentations
+  about Ruby technologies by their creators
 
 [RubyKaigi][3]
 : The first Japanese Ruby conference, RubyKaigi 2006, took place in
@@ -39,52 +34,11 @@ event dates, location, CFP (Call For Proposals) and Registration information.
 
 ### Regional Ruby Conferences
 
-[Ruby Central][2] administers a [Regional Conference Grant Program][6],
-to offset expenses for local and regional groups wanting to organize
-events.
+An updated list of Regional Ruby Conferences is available at [RubyConferences.org][rc].
 
-Ruby Central had also teamed up with SVForum (previously known as SDForum)
-to produce the Silicon Valley Ruby Conference, which took place in 2006
-and in 2007.
-
-[WindyCityRails][9] is an annual gathering for all who are passionate about
-Ruby on Rails. The Chicago-based conference has served the Ruby
-community since 2008.
-
-[Steel City Ruby][16]: Pittsburg, PA
-
-[GoRuCo][19]: New York City's annual Ruby conference. A one-day single-track conference.
-
-[DeccanRubyConf][20]: Pune's (India) annual Ruby conference,
-themed around fun activities filled around the day.
-It is a single-day single-track conference.
-
-[Southeast Ruby][21]: Nashville, TN workshop and conference.
-
-### Ruby At Other Conferences
-
-There has been a Ruby track at the [O’Reilly Open Source Conference][10]
-(OSCON) since 2004, and an increasing presence on the part of Ruby and
-Rubyists at other non-Ruby-specific gatherings. A number of conferences
-have also been devoted to [Ruby on Rails][11], including Ruby Central’s
-[RailsConf][12], RailsConf Europe (co-produced in 2006 by Ruby
-Central and [Skills Matter][14], and in 2007 by Ruby Central and
-O’Reilly), and Canada on Rails.
-
-
+You can also find the GitHub repository link there to add or update information yourself. 
 
 [rc]: http://rubyconferences.org/
 [1]: http://rubyconf.org/
-[2]: http://rubycentral.org
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org
-[6]: https://rubycentral.org/grants
-[9]: http://windycityrails.org
-[10]: http://conferences.oreillynet.com/os2006/
-[11]: http://www.rubyonrails.org
-[12]: http://www.railsconf.org
-[14]: http://www.skillsmatter.com
-[16]: http://steelcityruby.org/
-[19]: http://goruco.com/
-[20]: http://www.deccanrubyconf.org/
-[21]: https://southeastruby.com/


### PR DESCRIPTION
- Remove out-of-date information
- Remove regional conferences which are no longer up-to-date in favor of a link to rubyconferences.org