### PR TITLE
Fix correct name for 1Password (zh_tw)

### DIFF
--- a/zh_tw/about/website/index.md
+++ b/zh_tw/about/website/index.md
@@ -65,7 +65,7 @@ lang: zh_tw
 
 <img src="../../../images/sponsor/dd.png" alt="Datadog" width="200" height="200" />
 
-[1password](https://1password.com/) (密碼管理器)
+[1Password][1password] (密碼管理器)
 
 <img src="../../../images/sponsor/1password.png" alt="1password" width="300" height="57" />
 


### PR DESCRIPTION
Apply changes of #3292 and https://github.com/ruby/www.ruby-lang.org/commit/88ad266088656c9bd8f4f5a7711ec2f4830f151b.

Thank you.