### PR TITLE
Update MailmanLists dashboard urls.

### DIFF
--- a/bg/community/mailing-lists/index.md
+++ b/bg/community/mailing-lists/index.md
@@ -32,7 +32,7 @@ comp.lang.ruby дискусионна група.
 
 ## Абониране
 
-[Абониране](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Абониране](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/de/community/mailing-lists/index.md
+++ b/de/community/mailing-lists/index.md
@@ -38,13 +38,13 @@ comp.lang.ruby (Newsgroup)
   [comp.lang.ruby](news:comp.lang.ruby)-Newsgroup eine gute Anlaufstelle.
   ([FAQ][clrFAQ])
 
-Siehe [https://ml.ruby-lang.org/mailman3/postorius/lists/](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+Siehe [https://ml.ruby-lang.org/mailman3/lists/](https://ml.ruby-lang.org/mailman3/lists/)
 für weitere Informationen über alle Mailinglisten bei ruby-lang.org,
 einschließlich der Listen in japanischer Sprache.
 
 ## An- oder Abmelden
 
-[An- oder Abmelden](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[An- oder Abmelden](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/en/community/mailing-lists/index.md
+++ b/en/community/mailing-lists/index.md
@@ -31,7 +31,7 @@ The comp.lang.ruby Newsgroup
 
 ## Subscribe or Unsubscribe
 
-See [https://ml.ruby-lang.org/mailman3/postorius/lists/](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+See [https://ml.ruby-lang.org/mailman3/lists/](https://ml.ruby-lang.org/mailman3/lists/)
 for more information about all mailing lists on ruby-lang.org,
 including the lists in Japanese language.
 

--- a/es/community/mailing-lists/index.md
+++ b/es/community/mailing-lists/index.md
@@ -28,7 +28,7 @@ Ruby-CVS
 
 ## Suscribirse o desuscribirse
 
-[Suscribirse o desuscribirse](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Suscribirse o desuscribirse](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/fr/community/mailing-lists/index.md
+++ b/fr/community/mailing-lists/index.md
@@ -29,7 +29,7 @@ Ruby-CVS
 
 ## S’inscrire ou résilier son inscription
 
-[S’inscrire ou résilier son inscription](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[S’inscrire ou résilier son inscription](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/id/community/mailing-lists/index.md
+++ b/id/community/mailing-lists/index.md
@@ -42,7 +42,7 @@ termasuk daftar milis dalam bahasa Jepang.
 
 ## Mulai atau Berhenti Berlangganan
 
-[Mulai atau Berhenti Berlangganan](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Mulai atau Berhenti Berlangganan](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/it/community/mailing-lists/index.md
+++ b/it/community/mailing-lists/index.md
@@ -28,7 +28,7 @@ Ruby-CVS
 
 ## Iscriviti o annulla la tua iscrizione
 
-(Iscriviti o annulla la tua iscrizione)[https://ml.ruby-lang.org/mailman3/postorius/lists/]
+(Iscriviti o annulla la tua iscrizione)[https://ml.ruby-lang.org/mailman3/lists/]
 
 
 

--- a/ja/community/mailing-lists/index.md
+++ b/ja/community/mailing-lists/index.md
@@ -8,12 +8,12 @@ lang: ja
 
 参加希望の方は、それぞれのリンク先のページより登録を行ってください。
 
-## [ruby-list](https://ml.ruby-lang.org/mailman3/postorius/lists/ruby-list.ml.ruby-lang.org/)(日本語)
+## [ruby-list](https://ml.ruby-lang.org/mailman3/lists/ruby-list.ml.ruby-lang.org/)(日本語)
 
 Rubyを使ってプログラムを書く人たちが情報交換を行うためのメーリングリストです。
 Rubyを使う上での疑問点についての相談や、Rubyを利用したアプリケーションやライブラリなどのリリース情報の紹介、Rubyに関連するイベントの紹介などが行われています。
 
-## [ruby-dev](https://ml.ruby-lang.org/mailman3/postorius/lists/ruby-dev.ml.ruby-lang.org/)(日本語)
+## [ruby-dev](https://ml.ruby-lang.org/mailman3/lists/ruby-dev.ml.ruby-lang.org/)(日本語)
 
 Rubyの開発者向け公式メーリングリストです。
 こちらではRuby自体のバグの報告とそれに対する対応や、将来の仕様拡張や実装上の問題などについての議論が行われています。
@@ -22,11 +22,11 @@ Rubyの開発者向け公式メーリングリストです。
 
 また、セキュリティ関連のバグや脆弱性については後述する非公開メーリングリストへ報告してください。
 
-## [ruby-talk](https://ml.ruby-lang.org/mailman3/postorius/lists/ruby-talk.ml.ruby-lang.org/)(英語)
+## [ruby-talk](https://ml.ruby-lang.org/mailman3/lists/ruby-talk.ml.ruby-lang.org/)(英語)
 
 英語で一般的な話題を取り扱っています。 上記ruby-listの英語版という位置づけになります。
 
-## [ruby-core](https://ml.ruby-lang.org/mailman3/postorius/lists/ruby-core.ml.ruby-lang.org/)(英語)
+## [ruby-core](https://ml.ruby-lang.org/mailman3/lists/ruby-core.ml.ruby-lang.org/)(英語)
 
 英語でRubyの実装について話し合っています。 上記ruby-devの英語版という位置づけになります。
 

--- a/ko/community/mailing-lists/index.md
+++ b/ko/community/mailing-lists/index.md
@@ -28,11 +28,11 @@ comp.lang.ruby 뉴스그룹
   [comp.lang.ruby](news:comp.lang.ruby) 뉴스그룹에서 체크아웃하세요. ([FAQ][clrFAQ])
 
 ruby-lang.org의 일본어 리스트를 포함한 모든 메일링 리스트에 대해 자세히 알고
-싶다면 [https://ml.ruby-lang.org/mailman3/postorius/lists/](https://ml.ruby-lang.org/mailman3/postorius/lists/)를 참조하세요.
+싶다면 [https://ml.ruby-lang.org/mailman3/lists/](https://ml.ruby-lang.org/mailman3/lists/)를 참조하세요.
 
 ## 구독과 해지
 
-[구독과 해지](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[구독과 해지](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/pl/community/mailing-lists/index.md
+++ b/pl/community/mailing-lists/index.md
@@ -33,7 +33,7 @@ listy:
 
 ## Subscribe or Unsubscribe
 
-[Subscribe or Unsubscribe](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Subscribe or Unsubscribe](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/pt/community/mailing-lists/index.md
+++ b/pt/community/mailing-lists/index.md
@@ -35,7 +35,7 @@ Ruby &lt;&lt; portuguese
 
 ## Inscrever ou Desinscrever
 
-[Inscrever ou Desinscrever](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Inscrever ou Desinscrever](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/ru/community/mailing-lists/index.md
+++ b/ru/community/mailing-lists/index.md
@@ -32,7 +32,7 @@ Ruby-CVS
 
 ## Подписаться или не подписаться
 
-[Подписаться или не подписаться](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Подписаться или не подписаться](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/tr/community/mailing-lists/index.md
+++ b/tr/community/mailing-lists/index.md
@@ -31,11 +31,11 @@ comp.lang.ruby Haber Grubu
 
 Japonca dilindeki listeler de dahil olmak üzere ruby-lang.org'daki tüm e-posta
 listeleri hakkında daha fazla bilgi için
-[https://ml.ruby-lang.org/mailman3/postorius/lists/](https://ml.ruby-lang.org/mailman3/postorius/lists/)'a göz atın.
+[https://ml.ruby-lang.org/mailman3/lists/](https://ml.ruby-lang.org/mailman3/lists/)'a göz atın.
 
 ## Abone Olun ya da Abonelikten Ayrılın
 
-[Abone Olun ya da Abonelikten Ayrılın](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Abone Olun ya da Abonelikten Ayrılın](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/vi/community/mailing-lists/index.md
+++ b/vi/community/mailing-lists/index.md
@@ -32,7 +32,7 @@ The comp.lang.ruby Newsgroup
 
 ## Đăng ký theo dõi hoặc Hủy đăng ký
 
-[Đăng ký theo dõi hoặc Hủy đăng ký](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[Đăng ký theo dõi hoặc Hủy đăng ký](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/zh_cn/community/mailing-lists/index.md
+++ b/zh_cn/community/mailing-lists/index.md
@@ -26,7 +26,7 @@ comp.lang.ruby新闻组
 
 ## 订阅或退订
 
-[订阅或退订](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[订阅或退订](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 

--- a/zh_tw/community/mailing-lists/index.md
+++ b/zh_tw/community/mailing-lists/index.md
@@ -27,7 +27,7 @@ The comp.lang.ruby 新聞組
 
 ## 立即訂閱或是取消訂閱
 
-[立即訂閱或是取消訂閱](https://ml.ruby-lang.org/mailman3/postorius/lists/)
+[立即訂閱或是取消訂閱](https://ml.ruby-lang.org/mailman3/lists/)
 
 
 


### PR DESCRIPTION
https://ml.ruby-lang.org/mailman3/postorius/lists/ruby-list.ml.ruby-lang.org/

is 404 status. It's updated with

https://ml.ruby-lang.org/mailman3/lists/ruby-core.ml.ruby-lang.org/