### PR TITLE
Remote Ruby podcast link is broken

### DIFF
--- a/en/community/podcasts/index.md
+++ b/en/community/podcasts/index.md
@@ -30,6 +30,6 @@ wisdom to share, get in touch with the creators of these shows.
 You can also start your own Ruby podcast and get added to this list!
 
 [rooftop_ruby]: https://www.rooftopruby.com
-[remote_ruby]: https://remoteruby.transistor.fm/
+[remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com


### PR DESCRIPTION
I was looking through the Ruby podcasts today and found that the Remote Ruby podcast link is broken.

Supplied a fix here. Hopefully this gets Remote Ruby a bit more traffic!

Thank you!