### PR TITLE
Follow up "Remote Ruby podcast link is broken" on others

### DIFF
--- a/id/community/podcasts/index.md
+++ b/id/community/podcasts/index.md
@@ -31,6 +31,6 @@ Anda juga dapat memulai *podcast* Ruby sendiri and menambahkan pada daftar
 berikut!
 
 [rooftop_ruby]: https://www.rooftopruby.com
-[remote_ruby]: https://remoteruby.transistor.fm/
+[remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com

--- a/ko/community/podcasts/index.md
+++ b/ko/community/podcasts/index.md
@@ -30,6 +30,6 @@ Ruby와 Ruby 커뮤니티에 대한 뉴스, 인터뷰, 토론을 들어보세요
 당신의 Ruby 팟캐스트를 시작하고 이 목록에 추가할 수도 있습니다!
 
 [rooftop_ruby]: https://www.rooftopruby.com
-[remote_ruby]: https://remoteruby.transistor.fm/
+[remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com


### PR DESCRIPTION
Follow up https://github.com/ruby/www.ruby-lang.org/pull/3345

Update Remote Ruby podcast url on id, ko too.