### PR TITLE
Removed a CVE link that was added by mistake in ruby-3.2.4 release announces.

### DIFF
--- a/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) for further details.
 

--- a/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/en/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -14,7 +14,6 @@ Please check the topics below for details.
 
 * [CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search]({%link en/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc]({%link en/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: Buffer overread vulnerability in StringIO]({%link en/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) for further details.
 

--- a/es/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/es/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ revise detalles en los temas siguientes.
 
 * [CVE-2024-27282: Lectura de direcciones de memoria arbitrarias al buscar Regex]({%link es/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: Vulnerabilidad RCE con .rdoc_options en RDoc](https://www.ruby-lang.org/es/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: Vulnerabilidad de sobre-lectura de buffer en StringIO](https://www.ruby-lang.org/es/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
 Ver más detalles en la [publicación en Github](https://github.com/ruby/ruby/releases/tag/v3_2_4).
 

--- a/ja/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/ja/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ Ruby 3.2.4 がリリースされました。
 
 * [CVE-2024-27282: 正規表現検索における任意のメモリアドレス読み取りの脆弱性]({%link ja/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 内の .rdoc_options におけるRCE 脆弱性]({%link ja/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: StringIOにおけるバッファーオーバーリード脆弱性]({%link ja/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 詳しくは [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_4) を参照してください。
 

--- a/ja/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/ja/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -14,7 +14,6 @@ Ruby 3.3.1 がリリースされました。
 
 * [CVE-2024-27282: 正規表現検索における任意のメモリアドレス読み取りの脆弱性]({%link ja/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 内の .rdoc_options におけるRCE 脆弱性]({%link ja/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: StringIOにおけるバッファーオーバーリード脆弱性]({%link ja/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 詳しくは [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_3_1) を参照してください。
 

--- a/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ Ruby 3.2.4가 릴리스되었습니다.
 
 * [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_4)를 참조하세요.
 

--- a/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/ko/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -14,7 +14,6 @@ Ruby 3.3.1이 릴리스되었습니다.
 
 * [CVE-2024-27282: 정규표현식 검색의 임의의 메모리 주소 읽기 취약점]({%link ko/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc에서 .rdoc_options 사용 시의 RCE 취약점]({%link ko/news/_posts/2024-03-21-rce-rdoc-cve-2024-27281.md %})
-* [CVE-2024-27280: StringIO에서 버퍼 초과 읽기 취약점]({%link ko/news/_posts/2024-03-21-buffer-overread-cve-2024-27280.md %})
 
 자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_3_1)를 참조하세요.
 

--- a/zh_cn/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/zh_cn/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ Ruby 3.2.4 已发布。
 
 * [CVE-2024-27282: Regex 搜索中的任意地址读取漏洞]({%link zh_cn/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 中 .rdoc_options 的 RCE 漏洞](https://www.ruby-lang.org/zh_cn/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: StringIO 中的缓存过读漏洞](https://www.ruby-lang.org/zh_cn/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
 您可以通过 [发布说明](https://github.com/ruby/ruby/releases/tag/v3_2_4) 获取进一步信息。
 

--- a/zh_cn/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/zh_cn/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -14,7 +14,6 @@ Ruby 3.3.1 已发布。
 
 * [CVE-2024-27282: Regex 搜索中的任意地址读取漏洞]({%link zh_cn/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 中 .rdoc_options 的 RCE 漏洞](https://www.ruby-lang.org/zh_cn/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: StringIO 中的缓存过读漏洞](https://www.ruby-lang.org/zh_cn/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
 您可以通过 [发布说明](https://github.com/ruby/ruby/releases/tag/v3_3_1) 获取进一步信息。
 

--- a/zh_tw/news/_posts/2024-04-23-ruby-3-2-4-released.md
+++ b/zh_tw/news/_posts/2024-04-23-ruby-3-2-4-released.md
@@ -14,7 +14,6 @@ Ruby 3.2.4 已經發布了。
 
 * [CVE-2024-27282: Regex 搜尋的任意記憶體位址讀取漏洞]({%link zh_tw/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 中 .rdoc_options 的 RCE 漏洞](https://www.ruby-lang.org/zh_tw/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: StringIO 中的緩衝區 overread 漏洞](https://www.ruby-lang.org/zh_tw/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
 詳細的變動請參閱 [GitHub 發布](https://github.com/ruby/ruby/releases/tag/v3_2_4)。
 

--- a/zh_tw/news/_posts/2024-04-23-ruby-3-3-1-released.md
+++ b/zh_tw/news/_posts/2024-04-23-ruby-3-3-1-released.md
@@ -14,7 +14,6 @@ Ruby 3.3.1 已經發布了。
 
 * [CVE-2024-27282: Regex 搜尋的任意記憶體位址讀取漏洞]({%link zh_tw/news/_posts/2024-04-23-arbitrary-memory-address-read-regexp-cve-2024-27282.md %})
 * [CVE-2024-27281: RDoc 中 .rdoc_options 的 RCE 漏洞](https://www.ruby-lang.org/zh_tw/news/2024/03/21/rce-rdoc-cve-2024-27281/)
-* [CVE-2024-27280: StringIO 中的緩衝區 overread 漏洞](https://www.ruby-lang.org/zh_tw/news/2024/03/21/buffer-overread-cve-2024-27280/)
 
 詳細的變動請參閱 [GitHub 發布](https://github.com/ruby/ruby/releases/tag/v3_3_1)。
 


### PR DESCRIPTION
As reported at https://bugs.ruby-lang.org/issues/20685, the vulnerability CVE-2024-27280 didn't related to the ruby_3_2 branch.
Remove unrelated CVE link in the 3.2.4 release announces.