### PR TITLE
Add section about official Ruby Language Documentation

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -12,6 +12,10 @@ Guides, tutorials, and reference material to help you learn more about Ruby
 Although you can easily [try Ruby in your browser][1], you can also read
 the [installation guide](installation/) for help on installing Ruby.
 
+### Ruby Language Documentation
+
+The authoritative Ruby language documentation at [docs.ruby-lang.org][docs-rlo-en] is the place to start if you want to understand Ruby. It covers all aspects of the language and should be the first place you look when learning or referencing Ruby programming language. Other resources listed below are complementary to the official language documentation or they present Ruby documentation in a different format/style/flavor.
+
 ### Getting Started
 
 [Official FAQ](/en/documentation/faq/)
@@ -52,7 +56,7 @@ the [installation guide](installation/) for help on installing Ruby.
 ### Reference Documentation
 
 [Official API Documentation][docs-rlo-en]
-: The official Ruby API documentation for different versions including
+: The official Ruby language documentation for different versions including
   the currently unreleased (trunk) version.
 
 [Ruby Core Reference][13]


### PR DESCRIPTION
### Context

1. In my experience, not many developers use the docs.ruby-lang.org documentation as their main point of reference about the language, and people occasionally ask what the official documentation is. 

For this I think it is good to move the link to the official documentation at the top of the page. 

2. I also discovered that there are people who, when reading API documentation, automatically think about web API and do not consider that API is an Application Programming Interface. When we usethe term here API documentation, we refer to the documentation about how to use the language.

For this, I think it is good to use a wording that says "the Ruby language documentation" instead of "the Ruby API documentation"

### Changes

- Introduce new section highlighting docs.ruby-lang.org as the authoritative source for Ruby language documentation

- Clarify that this should be the first reference for learning Ruby or when having the need to understand how Ruby works

- Explain that other resources are complementary or present documentation in different styles

- Try to help quickly identify the official Ruby language documentation for the reader by removing an acronym and replacing it with an explicit wording


PS: I am not an English speaker, so if anyone can help with better phrasing, please do so. 


