### PR TITLE
Translate "CVE-2024-43398: DoS vulnerability in REXML" (ko)

### DIFF
--- a/ko/news/_posts/2024-08-22-dos-rexml-cve-2024-43398.md
+++ b/ko/news/_posts/2024-08-22-dos-rexml-cve-2024-43398.md
@@ -1,0 +1,31 @@
+---
+layout: news_post
+title: "CVE-2024-43398: DoS vulnerability in REXML"
+author: "kou"
+translator:
+date: 2024-08-22 03:00:00 +0000
+tags: security
+lang: en
+---
+
+There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-43398](https://www.cve.org/CVERecord?id=CVE-2024-43398). We strongly recommend upgrading the REXML gem.
+
+## Details
+
+When parsing an XML that has many deep elements that have same local name attributes.
+
+It's only affected with the tree parser API. If you're using `REXML::Document.new` to parse an XML, you may be affected.
+
+Please update REXML gem to version 3.3.6 or later.
+
+## Affected versions
+
+* REXML gem 3.3.5 or prior
+
+## Credits
+
+Thanks to [l33thaxor](https://hackerone.com/l33thaxor) for discovering this issue.
+
+## History
+
+* Originally published at 2024-08-22 03:00:00 (UTC)

--- a/ko/news/_posts/2024-08-22-dos-rexml-cve-2024-43398.md
+++ b/ko/news/_posts/2024-08-22-dos-rexml-cve-2024-43398.md
@@ -1,31 +1,31 @@
 ---
 layout: news_post
-title: "CVE-2024-43398: DoS vulnerability in REXML"
+title: "CVE-2024-43398: REXML의 DoS 취약점"
 author: "kou"
-translator:
+translator: "shia"
 date: 2024-08-22 03:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-43398](https://www.cve.org/CVERecord?id=CVE-2024-43398). We strongly recommend upgrading the REXML gem.
+REXML gem에서 DoS 취약점이 발견되었습니다. 이 취약점은 CVE 번호 [CVE-2024-43398](https://www.cve.org/CVERecord?id=CVE-2024-43398)로 등록되었습니다. REXML gem 업그레이드를 강하게 추천합니다.
 
-## Details
+## 세부 내용
 
-When parsing an XML that has many deep elements that have same local name attributes.
+동일한 지역 이름 속성을 가진 여러 깊은 요소를 포함하는 XML을 파싱할 때, REXML gem은 처리에 긴 시간이 걸립니다.
 
-It's only affected with the tree parser API. If you're using `REXML::Document.new` to parse an XML, you may be affected.
+해당 취약점은 트리 파서 API에만 영향을 줍니다. XML을 파싱하기 위해 `REXML::Document.new`를 사용한다면 영향을 받을 수 있습니다.
 
-Please update REXML gem to version 3.3.6 or later.
+REXML gem을 3.3.6이나 그 이상으로 업데이트하세요.
 
-## Affected versions
+## 해당 버전
 
-* REXML gem 3.3.5 or prior
+* REXML gem 3.3.5와 그 이하
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [l33thaxor](https://hackerone.com/l33thaxor) for discovering this issue.
+이 문제를 발견해 준 [l33thaxor](https://hackerone.com/l33thaxor)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2024-08-22 03:00:00 (UTC)
+* 2024-08-22 03:00:00 (UTC) 최초 공개


### PR DESCRIPTION
:link: #2818

Translate #3348, #3354

Actual diff is 53d16662835f2b127571a93356690d701255f208