### PR TITLE
Translate "Home" link in site navigation (ja)

### DIFF
--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -3,7 +3,7 @@ ruby: Ruby
 slogan: A Programmer's Best Friend
 
 sitelinks:
-- text: Home
+- text: ホーム
   url: /ja
   home: true
 - text: ダウンロード


### PR DESCRIPTION
Done issue for ja translation: https://github.com/ruby/www.ruby-lang.org/issues/2331
Translated PR: https://github.com/ruby/www.ruby-lang.org/pull/2312