### PR TITLE
Translate "Ruby 3.3.5 Released" (ko)

### DIFF
--- a/ko/news/_posts/2024-09-03-3-3-5-released.md
+++ b/ko/news/_posts/2024-09-03-3-3-5-released.md
@@ -9,9 +9,9 @@ lang: ko
 
 Ruby 3.3.5가 릴리스되었습니다.
 
-이번 릴리스에는 일반적인 업데이트로, 사소한 버그 수정이 포함되어 있습니다.
+이번 릴리스는 일반적인 업데이트로, 사소한 버그 수정이 포함되어 있습니다.
 가능한 빨리 Ruby 버전을 업그레이드하는 것을 권장합니다.
-자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_3_5)를 참조하세요.
+자세한 내용은 [GitHub 릴리스 노트](https://github.com/ruby/ruby/releases/tag/v3_3_5)를 참조하세요.
 
 ## 릴리스 일정
 

--- a/ko/news/_posts/2024-09-03-3-3-5-released.md
+++ b/ko/news/_posts/2024-09-03-3-3-5-released.md
@@ -1,25 +1,25 @@
 ---
 layout: news_post
-title: "Ruby 3.3.5 Released"
+title: "Ruby 3.3.5 릴리스"
 author: k0kubun
-translator:
+translator: shia
 date: 2024-09-03 06:40:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.3.5 has been released.
+Ruby 3.3.5가 릴리스되었습니다.
 
-This is a routine update that includes minor bug fixes.
-We recommend upgrading your Ruby version at your earliest convenience.
-For more details, please refer to the [GitHub release notes](https://github.com/ruby/ruby/releases/tag/v3_3_5).
+이번 릴리스에는 일반적인 업데이트로, 사소한 버그 수정이 포함되어 있습니다.
+가능한 빨리 Ruby 버전을 업그레이드하는 것을 권장합니다.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_3_5)를 참조하세요.
 
-## Release Schedule
+## 릴리스 일정
 
-As previously [announced](https://www.ruby-lang.org/en/news/2024/07/09/ruby-3-3-4-released/), we intend to release the latest stable Ruby version (currently Ruby 3.3) every 2 months following a `.1` release.
+이전에 [발표했던 것](https://www.ruby-lang.org/ko/news/2024/07/09/ruby-3-3-4-released/)처럼, 앞으로 최신 안정 버전의 Ruby(현재 Ruby 3.3)를 `.1` 릴리스 이후 2개월마다 릴리스할 계획입니다.
 
-We expect to release Ruby 3.3.6 on November 5th and Ruby 3.3.7 on January 7th. If any significant changes arise that impact a large number of users, we may release a new version earlier than scheduled.
+3.3.6은 11월 5일에, 3.3.7은 1월 7일에 릴리스될 예정입니다. 많은 사람들에게 영향을 미치는 변경 사항이 있을 경우, 예상보다 빨리 새 버전을 릴리스할 수 있습니다.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.3.5" | first %}
 
@@ -44,7 +44,7 @@ We expect to release Ruby 3.3.6 on November 5th and Ruby 3.3.7 on January 7th. I
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2024-09-03-3-3-5-released.md
+++ b/ko/news/_posts/2024-09-03-3-3-5-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 3.3.5 Released"
+author: k0kubun
+translator:
+date: 2024-09-03 06:40:00 +0000
+lang: en
+---
+
+Ruby 3.3.5 has been released.
+
+This is a routine update that includes minor bug fixes.
+We recommend upgrading your Ruby version at your earliest convenience.
+For more details, please refer to the [GitHub release notes](https://github.com/ruby/ruby/releases/tag/v3_3_5).
+
+## Release Schedule
+
+As previously [announced](https://www.ruby-lang.org/en/news/2024/07/09/ruby-3-3-4-released/), we intend to release the latest stable Ruby version (currently Ruby 3.3) every 2 months following a `.1` release.
+
+We expect to release Ruby 3.3.6 on November 5th and Ruby 3.3.7 on January 7th. If any significant changes arise that impact a large number of users, we may release a new version earlier than scheduled.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.3.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Translates #3359, #3360

Actual diff is 697873500c98348e17ac5f06d32512a0620a317c