### PR TITLE
Fix draft-release workflow yaml syntax

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: www
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,4 +59,3 @@ jobs:
           body: "This is an automated pull request to create a release"
           draft: true
 
-      working-directory: www


### PR DESCRIPTION
Move `working-directory` directive to defaults. Failed runs: https://github.com/ruby/www.ruby-lang.org/actions/workflows/draft-release.yml