### PR TITLE
Fix quoting of backtraces

### DIFF
--- a/en/news/_posts/2024-10-07-ruby-3-4-0-preview2-released.md
+++ b/en/news/_posts/2024-10-07-ruby-3-4-0-preview2-released.md
@@ -55,6 +55,7 @@ Note: Excluding feature bug fixes.
   * Use a single quote instead of a backtick as a opening quote. [[Feature #16495]]
   * Display a class name before a method name (only when the class has a permanent name). [[Feature #19117]]
   * `Kernel#caller`, `Thread::Backtrace::Location`'s methods, etc. are also changed accordingly.
+
   ```
   Old:
   test.rb:1:in `foo': undefined method `time' for an instance of Integer


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/10/07/ruby-3-4-0-preview2-released/ renders it wrong, so I hope this fixes it.
Otherwise we might need to dedent the triple backticks completely.

![Screenshot from 2024-10-07 20-09-35](https://github.com/user-attachments/assets/ae02794a-7bc2-4afd-a685-2eb6ad854b10)
