### PR TITLE
Fix quotes of <main>

### DIFF
--- a/en/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/en/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -59,7 +59,7 @@ Note: Excluding feature bug fixes.
 
   New:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 

--- a/en/news/_posts/2024-10-07-ruby-3-4-0-preview2-released.md
+++ b/en/news/_posts/2024-10-07-ruby-3-4-0-preview2-released.md
@@ -63,7 +63,7 @@ Note: Excluding feature bug fixes.
 
   New:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 * `Hash#inspect` rendering has changed. [[Bug #20433]]

--- a/es/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/es/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -70,7 +70,7 @@ Nota: Excluyendo correcciones a problemas en características.
 
   Ahora:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 

--- a/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -56,7 +56,7 @@ Ruby {{ release.version }}がリリースされました。
 
   New:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 

--- a/ko/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/ko/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -60,7 +60,7 @@ Ruby {{ release.version }} 릴리스를 알리게 되어 기쁩니다.
 
   New:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 

--- a/zh_cn/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/zh_cn/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -55,7 +55,7 @@ lang: zh_cn
 
   现在：
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 ## C API 更新

--- a/zh_tw/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/zh_tw/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -54,7 +54,7 @@ lang: zh_tw
 
   新:
   test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
-          from test.rb:2:in `<main>'
+          from test.rb:2:in '<main>'
   ```
 
 


### PR DESCRIPTION
This changed since 3.4.0-preview1.

```
% docker run --platform linux/amd64 --rm -it ghcr.io/ruby/all-ruby env LANG=C.UTF-8 ALL_RUBY_SINCE=ruby-3.3 ./all-ruby -e 'def foo; time; end; foo'
ruby-3.3.0          -e:1:in `foo': undefined local variable or method `time' for main (NameError)

                    def foo; time; end; foo
                             ^^^^
                        from -e:1:in `<main>'
                exit 1
...
ruby-3.3.4          -e:1:in `foo': undefined local variable or method `time' for main (NameError)

                    def foo; time; end; foo
                             ^^^^
                        from -e:1:in `<main>'
                exit 1
ruby-3.4.0-preview1 -e:1:in 'Object#foo': undefined local variable or method 'time' for main (NameError)

                    def foo; time; end; foo
                             ^^^^
                        from -e:1:in '<main>'
                exit 1
```