### PR TITLE
Add neovim to Editors and IDEs section

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -87,6 +87,7 @@ Here is a list of popular tools used by Rubyists:
   * [Kate][kate]
   * [KDevelop][kdevelop]
   * [NetBeans][36]
+  * [Neovim][neovim] with [Ruby LSP][ruby-lsp-nvim]
   * [RubyMine][27]
   * [SciTe][28]
   * [Sublime Text][37]
@@ -147,3 +148,5 @@ If you have questions about Ruby the
 [eric]: https://eric-ide.python-projects.org/
 [kdevelop]: https://www.kdevelop.org/
 [kate]: https://kate-editor.org/
+[neovim]: https://neovim.io/
+[ruby-lsp-nvim]: https://shopify.github.io/ruby-lsp/editors.html#neovim


### PR DESCRIPTION
Neovim is a popular choice for Rubyists, so I've added a link to it and to instructions to set it up with Ruby LSP.