### PR TITLE
Remove obsolete editor links

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -95,8 +95,6 @@ Here is a list of popular tools used by Rubyists:
 
 * On Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * On macOS:
   * [TextMate][32]
@@ -132,8 +130,6 @@ If you have questions about Ruby the
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org


### PR DESCRIPTION
The E-TextEditor link is pointing to an insurance website, and the website for Ruby in Steel no longer exists.