### PR TITLE
Fix orthography in hello_world.md

### DIFF
--- a/es/examples/hello_world.md
+++ b/es/examples/hello_world.md
@@ -9,10 +9,10 @@ layout: null
 # Son superfluos:
 #
 # * Un método "main"
-# * Nueva linea
+# * Nueva línea
 # * Punto y coma
 #
-# Aqui esta el código:
+# Aquí está el código:
 
 puts "¡Hola Mundo!"
 {% endhighlight %}


### PR DESCRIPTION
This change fixes the spelling of various words in the _hello_world_ Spanish example

References:
1. `línea` https://dle.rae.es/l%C3%ADnea?m=form
2. `aquí` https://dle.rae.es/aqu%C3%AD?m=form
3. `está` (means _to be_, 3rd person conjugation of `estar` https://dle.rae.es/estar?m=form
![image](https://github.com/user-attachments/assets/17a32b2d-0c2e-48ba-9062-fe529b2bc386)
