### PR TITLE
Translate "CVE-2024-49761: ReDoS vulnerability in REXML" (ko)

### DIFF
--- a/ko/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
+++ b/ko/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
@@ -1,0 +1,31 @@
+---
+layout: news_post
+title: "CVE-2024-49761: ReDoS vulnerability in REXML"
+author: "kou"
+translator:
+date: 2024-10-28 03:00:00 +0000
+tags: security
+lang: en
+---
+
+There is a ReDoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-49761](https://www.cve.org/CVERecord?id=CVE-2024-49761). We strongly recommend upgrading the REXML gem.
+
+This does not happen with Ruby 3.2 or later. Ruby 3.1 is the only affected maintained Ruby. Note that Ruby 3.1 will reach EOL on 2025-03.
+
+## Details
+
+When parsing an XML that has many digits between `&#` and `x...;` in a hex numeric character reference (`&#x...;`).
+
+Please update REXML gem to version 3.3.9 or later.
+
+## Affected versions
+
+* REXML gem 3.3.8 or prior with Ruby 3.1 or prior
+
+## Credits
+
+Thanks to [manun](https://hackerone.com/manun) for discovering this issue.
+
+## History
+
+* Originally published at 2024-10-28 03:00:00 (UTC)

--- a/ko/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
+++ b/ko/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
@@ -1,31 +1,31 @@
 ---
 layout: news_post
-title: "CVE-2024-49761: ReDoS vulnerability in REXML"
+title: "CVE-2024-49761: REXML의 ReDoS 취약점"
 author: "kou"
-translator:
+translator: "shia"
 date: 2024-10-28 03:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-There is a ReDoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-49761](https://www.cve.org/CVERecord?id=CVE-2024-49761). We strongly recommend upgrading the REXML gem.
+REXML gem에서 ReDoS 취약점이 발견되었습니다. 이 취약점은 CVE 번호 [CVE-2024-49761](https://www.cve.org/CVERecord?id=CVE-2024-49761)로 등록되었습니다. REXML gem 업그레이드를 강하게 추천합니다.
 
-This does not happen with Ruby 3.2 or later. Ruby 3.1 is the only affected maintained Ruby. Note that Ruby 3.1 will reach EOL on 2025-03.
+Ruby 3.2나 그 이상에서는 이 문제가 발생하지 않습니다. 유지 관리 중인 Ruby 중 유일하게 영향을 받는 버전은 Ruby 3.1입니다. Ruby 3.1은 2025년 3월에 EOL이 예정되어 있습니다.
 
-## Details
+## 세부 내용
 
-When parsing an XML that has many digits between `&#` and `x...;` in a hex numeric character reference (`&#x...;`).
+16진수 숫자 문자 참조(`&#x...;`)에서 `&#`과 `x...;` 사이에 많은 숫자가 있는 XML을 파싱할 때 발생합니다.
 
-Please update REXML gem to version 3.3.9 or later.
+REXML gem을 3.3.9나 그 이상으로 업데이트하세요.
 
-## Affected versions
+## 해당 버전
 
-* REXML gem 3.3.8 or prior with Ruby 3.1 or prior
+* Ruby 3.1과 그 이하 버전에서 REXML gem 3.3.8과 그 이하
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [manun](https://hackerone.com/manun) for discovering this issue.
+이 문제를 발견해 준 [manun](https://hackerone.com/manun)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2024-10-28 03:00:00 (UTC)
+* 2024-10-28 03:00:00 (UTC) 최초 공개


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Translation of https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md

Actual diff is 3a5e8cb47a32d4537bc7a20a7eda4c50b1e77ab0