### PR TITLE
Translate "Ruby 3.2.6 Released" (ko)

### DIFF
--- a/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
+++ b/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
@@ -1,17 +1,17 @@
 ---
 layout: news_post
-title: "Ruby 3.2.6 Released"
+title: "Ruby 3.2.6 릴리스"
 author: nagachika
-translator:
+translator: shia
 date: 2024-10-30 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.2.6 has been released.
+Ruby 3.2.6이 릴리스되었습니다.
 
-Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_6) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_6)을 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.2.6" | first %}
 
@@ -36,7 +36,7 @@ Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
+++ b/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 3.2.6 Released"
+author: nagachika
+translator:
+date: 2024-10-30 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.2.6 has been released.
+
+Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_6) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.

--- a/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
+++ b/ko/news/_posts/2024-10-30-ruby-3-2-6-released.md
@@ -9,7 +9,7 @@ lang: ko
 
 Ruby 3.2.6이 릴리스되었습니다.
 
-자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_6)을 참조하세요.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_2_6)를 참조하세요.
 
 ## 다운로드
 


### PR DESCRIPTION
:link: #2818

Translates https://github.com/ruby/www.ruby-lang.org/blob/master/en/news/_posts/2024-10-30-ruby-3-2-6-released.md

Actual diff is 2a05205a5607e5b43ec73418914c35ba4ec6b06d