### PR TITLE
Translate 2024-10-28 ReDoS Rexml CVE news (ja)

### DIFF
--- a/ja/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
+++ b/ja/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
@@ -1,0 +1,33 @@
+---
+layout: news_post
+title: "CVE-2024-49761: REXML の ReDoS 脆弱性"
+author: "kou"
+translator: "teeta32"
+date: 2024-10-28 03:00:00 +0000
+tags: security
+lang: ja
+---
+
+REXML gem に ReDoS 脆弱性が発見されました。この脆弱性は [CVE-2024-49761](https://www.cve.org/CVERecord?id=CVE-2024-49761) として登録されています。REXML gem のアップグレードを強く推奨します。
+
+この脆弱性は Ruby 3.2 以降では発生しません。メンテナンスされている Ruby では Ruby 3.1 だけが本脆弱性の影響を受けます。Ruby 3.1 は 2025 年 3 月に EOL となることに注意してください。
+
+## 詳細
+
+以下のような XML※をパースするときに ReDoS 脆弱性が存在します。
+
+※16 進数の数値文字参照 (&#x...;) の &# と x...; の間に多くの数字を含む XML
+
+REXML gem を 3.3.9 以上にアップデートしてください。
+
+## 影響を受けるバージョン
+
+* Ruby 3.1 以前で REXML gem 3.3.8 以前を利用する場合
+
+## クレジット
+
+* この脆弱性情報は、[manun](https://hackerone.com/manun) 氏によって報告されました。
+
+## 更新履歴
+
+* 2024-10-28 12:00:00 (JST) 初版


### PR DESCRIPTION
Translated [CVE-2024-49761: ReDoS vulnerability in REXML](https://www.ruby-lang.org/en/news/2024/10/28/redos-rexml-cve-2024-49761/) into Japanese.

refs: #3400