### PR TITLE
Improve community related content

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -65,7 +65,7 @@ sidebar:
       url: /en/community/user-groups/
       description: Get in contact with Rubyists in your area.
     weblogs:
-      text: Blogs
+      text: Blogs and Newsletters
       url: /en/community/weblogs/
       description: Read about what’s happening right now in the Ruby community.
     ruby_core:

--- a/en/community/index.md
+++ b/en/community/index.md
@@ -47,6 +47,8 @@ to start:
   work-in-progress, discuss the future of Ruby, and welcome newcomers to
   the Ruby community.
 
+  Additionally, you can visit [rubyvideo.dev](https://www.rubyvideo.dev/) to find videos of Ruby conferences and talks.
+
 [Podcasts](podcasts/)
 : If you prefer to listen to discussions about Ruby rather than read,
   you can tune into one of these awesome Ruby podcasts. These Rubyists

--- a/en/community/index.md
+++ b/en/community/index.md
@@ -36,10 +36,8 @@ to start:
 : Now is a fantastic time to follow Ruby’s development.
   If you are interested in helping with Ruby, start here.
 
-[Ruby Blogs](weblogs/)
-: Very little happens in the Ruby community that is not talked about on
-  the blogs. We’ve got a nice list of suggestions for you here for
-  getting plugged in.
+[Ruby Blogs and Newsletters](weblogs/)
+: Most activities and updates in the Ruby community are discussed through blogs and newsletters. Here’s a curated list to help you stay connected and informed.
 
 [Ruby Conferences](conferences/)
 : Ruby programmers around the world are getting involved in more and

--- a/en/community/index.md
+++ b/en/community/index.md
@@ -53,14 +53,8 @@ to start:
   use their podcasts to cover new releases, community news, and
   interview their fellow Ruby developers.
 
-General Ruby Information
-: * [Ruby Central][ruby-central]
-  * [Ruby at Open Directory Project][ruby-opendir]
-  * [Rails at Open Directory Project][rails-opendir]
-
-
+[Ruby Central][ruby-central]
+: Ruby Central is a non-profit organization dedicated to supporting the worldwide Ruby community.
 
 [ruby-central]: http://rubycentral.org/
 [ruby-discord]: https://discord.gg/ad2acQFtkh
-[ruby-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
-[rails-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -30,7 +30,7 @@ updates.
 * [**DEV Ruby Tag**][dev-ruby-tag] is the collection of all posts
   tagged Ruby within the DEV Community. DEV is a network of thousands
   of software developers who blog about and discuss code.
-* [**Riding Rails**][riding-rails] is the official group blog of the
+* [**Ruby on Rails Blog**][ruby-on-rails-blog] is the official group blog of the
   Ruby on Rails team. If you are running Rails, this blog is essential
   for notification of security updates and an overall view of the wide
   Rails community.
@@ -49,7 +49,7 @@ out there, be sure to share!
 [rubyland]: http://rubyland.news/
 [ruby-weekly]: https://rubyweekly.com/
 [dev-ruby-tag]: https://dev.to/t/ruby
-[riding-rails]: https://rubyonrails.org/blog/
+[ruby-on-rails-blog]: https://rubyonrails.org/blog/
 [reddit]: http://www.reddit.com/r/ruby
 [hn]: http://news.ycombinator.com/
 [short-ruby-newsletter]: https://newsletter.shortruby.com/

--- a/en/community/weblogs/index.md
+++ b/en/community/weblogs/index.md
@@ -1,13 +1,18 @@
 ---
 layout: page
-title: "Blogs"
+title: "Blogs and Newsletters"
 lang: en
 ---
 
-Ruby blogs have exploded over the past years and given sufficient
-hunting, you can unearth hundreds of blogs sharing bits of Ruby code,
-describing new techniques, or speculating on Ruby’s future.
+Ruby blogs and newsletters have exploded over the past years and given
+sufficient hunting, you can unearth hundreds of blogs sharing bits of
+Ruby code, describing new techniques, or speculating on Ruby’s future.
 {: .summary}
+
+### Newsletters
+
+* [**Ruby Weekly**][ruby-weekly]: A newsletter that curates the most interesting Ruby articles and news each week.
+* [**Short Ruby Newsletter**][short-ruby-newsletter]: A weekly summary of the articles, discussions, and news from the Ruby community.
 
 ### Mining for Ruby Blogs
 
@@ -22,9 +27,6 @@ describing new techniques, or speculating on Ruby’s future.
 A few notable blogs stand out for the frequency and immediacy of their
 updates.
 
-* [**Ruby Weekly**][ruby-weekly]: Although more of a newsletter than a
-  blog, Ruby Weekly is a distillation of the most interesting Ruby
-  articles and news each week.
 * [**DEV Ruby Tag**][dev-ruby-tag] is the collection of all posts
   tagged Ruby within the DEV Community. DEV is a network of thousands
   of software developers who blog about and discuss code.
@@ -47,6 +49,7 @@ out there, be sure to share!
 [rubyland]: http://rubyland.news/
 [ruby-weekly]: https://rubyweekly.com/
 [dev-ruby-tag]: https://dev.to/t/ruby
-[riding-rails]: http://weblog.rubyonrails.org/
+[riding-rails]: https://rubyonrails.org/blog/
 [reddit]: http://www.reddit.com/r/ruby
 [hn]: http://news.ycombinator.com/
+[short-ruby-newsletter]: https://newsletter.shortruby.com/


### PR DESCRIPTION
Main changes:

1. I think [rubyvideo.dev](https://www.rubyvideo.dev/) is doing an amazing job indexing videos from Ruby conferences and is a great resource to be listed along with "Ruby Conferences".
2. Nowadays newsletters like [RubyWeekly](https://rubyweekly.com/) or [Short Ruby Newsletter](https://newsletter.shortruby.com/)  is a equally if not more common way for Ruby developers to get their news from the community. So I think it's good to at least put it at the same level as the "Blogs" list.
    - I decided to NOT rename the page's path so old links can still work.
4. The open directory links are both dead so I removed them and gave more space to "Ruby Central".
5. Minor tweaks on phrasing and updated the Rails blog's link