### PR TITLE
add rvm-windows to installation doc

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -361,6 +361,15 @@ Ruby on your system. It can also manage different gemsets. It is
 available for macOS, Linux, or other UNIX-like operating systems.
 
 
+### RVM 4 Windows
+{: #rvm-windows}
+
+[RVM 4 Windows][rvm-windows] allows you to install and manage multiple
+installations of Ruby on Windows. It is a clone of the original RVM and
+supports the classic command line as well as Powershell by providing
+the same command line interface as the original RVM.
+
+
 ### uru
 {: #uru}
 
@@ -391,6 +400,7 @@ though, because the installed Ruby won't be managed by any tools.
 
 
 [rvm]: http://rvm.io/
+[rvm-windows]: https://github.com/magynhard/rvm-windows#readme
 [rbenv]: https://github.com/rbenv/rbenv#readme
 [rbenv-for-windows]: https://github.com/RubyMetric/rbenv-for-windows#readme
 [ruby-build]: https://github.com/rbenv/ruby-build#readme


### PR DESCRIPTION
Add the new RVM 4 Windows to the list of Ruby version managers at the installation documentation.

Included language is `en` only.


Note: As the [orignal Pull Request](https://github.com/ruby/www.ruby-lang.org/pull/3250) for all languages failed due inactive language reviewers, i decided to create one for English only.