### PR TITLE
Translate "Add section about official Ruby Language Documentation" (ko)

### DIFF
--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -16,6 +16,10 @@ Ruby를 배울 수 있는 매뉴얼과 튜토리얼, 코딩할 때 도움이 되
 [Ruby를 브라우저에서 시험해 볼 수도 있지만][1], Ruby를 설치하기 위해서
 [설치 설명서](installation/)를 읽어보아도 좋습니다.
 
+### Ruby Language Documentation
+
+The authoritative Ruby language documentation at [docs.ruby-lang.org][docs-rlo-en] is the place to start if you want to understand Ruby. It covers all aspects of the language and should be the first place you look when learning or referencing Ruby programming language. Other resources listed below are complementary to the official language documentation or they present Ruby documentation in a different format/style/flavor.
+
 ### 초보자용 문서
 
 [공식 FAQ](faq/)
@@ -60,7 +64,7 @@ Ruby를 배울 수 있는 매뉴얼과 튜토리얼, 코딩할 때 도움이 되
 ### 참조
 
 [공식 API 문서][docs-rlo-en]
-: 아직 릴리스되지 않은 트렁크를 포함한 여러 Ruby 버전의 공식 API 문서입니다.
+: 아직 릴리스되지 않은 트렁크를 포함한 여러 Ruby 버전의 공식 language 문서입니다.
 
 [Ruby C API 레퍼런스][extensions] (영문)
 : Ruby의 공식 C API 문서입니다.

--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -16,9 +16,9 @@ Ruby를 배울 수 있는 매뉴얼과 튜토리얼, 코딩할 때 도움이 되
 [Ruby를 브라우저에서 시험해 볼 수도 있지만][1], Ruby를 설치하기 위해서
 [설치 설명서](installation/)를 읽어보아도 좋습니다.
 
-### Ruby Language Documentation
+### Ruby 언어 문서
 
-The authoritative Ruby language documentation at [docs.ruby-lang.org][docs-rlo-en] is the place to start if you want to understand Ruby. It covers all aspects of the language and should be the first place you look when learning or referencing Ruby programming language. Other resources listed below are complementary to the official language documentation or they present Ruby documentation in a different format/style/flavor.
+Ruby를 이해하고 싶다면, [docs.ruby-lang.org][docs-rlo-en]의 권위 있는 Ruby 언어 문서가 출발점입니다. 이 문서는 언어의 모든 측면을 다루며, Ruby 프로그래밍 언어를 배우거나 참조할 때 처음으로 찾아봐야 하는 곳입니다. 아래 나열된 다른 자료들은 공식 언어 문서를 보완하거나 다른 형식/스타일/맛으로 Ruby 문서를 제공합니다.
 
 ### 초보자용 문서
 
@@ -64,7 +64,7 @@ The authoritative Ruby language documentation at [docs.ruby-lang.org][docs-rlo-e
 ### 참조
 
 [공식 API 문서][docs-rlo-en]
-: 아직 릴리스되지 않은 트렁크를 포함한 여러 Ruby 버전의 공식 language 문서입니다.
+: 아직 릴리스되지 않은 트렁크를 포함한 여러 Ruby 버전의 공식 언어 문서입니다.
 
 [Ruby C API 레퍼런스][extensions] (영문)
 : Ruby의 공식 C API 문서입니다.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Translates #3352
Actual diff: 6c8751aec6deb7e6e7316dd7a82cb099583a408e