### PR TITLE
Remove "E-TextEditor" And "Ruby In Stee"l's broken links.

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -111,8 +111,6 @@ ruby -v
 
 * За Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * За macOS:
   * [TextMate][32]
@@ -151,8 +149,6 @@ ruby -v
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -118,8 +118,6 @@ Rubiceros:
 
 * En Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * En macOS:
   * [TextMate][32]
@@ -165,8 +163,6 @@ comenzar.
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -112,8 +112,6 @@ Berikut adalah daftar kakas populer yang digunakan oleh para pengguna Ruby:
 
 * Pada Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * Pada macOS:
   * [TextMate][32]
@@ -156,8 +154,6 @@ adalah tempat yang baik untuk memulai.
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -107,8 +107,6 @@ Questa è una lista dei tool più comunemente usati dagli sviluppatori Ruby:
 
 * Per Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * Per macOS:
   * [TextMate][32]
@@ -149,8 +147,6 @@ iniziare.
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -96,8 +96,6 @@ Rubyistに人気のあるソフトウェアには次のようなものがあり�
 
 * Windows
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * macOS
   * [TextMate][32]
@@ -153,8 +151,6 @@ Posted by Shugo Maeda on 26 May 2006
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [36]: https://netbeans.org/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -111,8 +111,6 @@ Oto lista popularnych narzędzi używanych przez rubistów:
 
 * Dla Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * Dla macOS:
   * [TextMate][32]
@@ -153,8 +151,6 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -118,8 +118,6 @@ programadores Ruby:
 
 * No Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * No macOS:
   * [TextMate][32]
@@ -160,8 +158,6 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/ru/documentation/index.md
+++ b/ru/documentation/index.md
@@ -120,8 +120,6 @@ ruby -v
 
 * На Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * На macOS:
   * [TextMate][32]
@@ -161,8 +159,6 @@ ruby -v
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -119,8 +119,6 @@ bir tümleşik geliştirme ortamı seçmeniz daha iyi olur.
 
 * Windows'ta:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * macOS'ta:
   * [TextMate][32]
@@ -163,8 +161,6 @@ olacaktır.
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -117,8 +117,6 @@ tính năng nâng cao (ví dụ: tự động hoàn thiện, tái cấu trúc, h
 
 * Trên Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * Trên macOS:
   * [TextMate][32]
@@ -159,8 +157,6 @@ là một nơi tuyệt vời.
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -93,8 +93,6 @@ ruby -v
 
 * Windows:
   * [Notepad++][29]
-  * [E-TextEditor][30]
-  * [Ruby In Steel][31]
 
 * macOS:
   * [TextMate][32]
@@ -133,8 +131,6 @@ ruby -v
 [27]: http://www.jetbrains.com/ruby/
 [28]: http://www.scintilla.org/SciTE.html
 [29]: http://notepad-plus-plus.org/
-[30]: http://www.e-texteditor.com/
-[31]: http://www.sapphiresteel.com/
 [32]: http://macromates.com/
 [33]: https://www.barebones.com/products/bbedit/
 [34]: http://ruby-doc.org


### PR DESCRIPTION
Remove "E-TextEditor" And "Ruby In Steel"'s broken links.
"E-TextEditor" And "Ruby In Steel" are no longer being maintained. 
Links are broken links. 
These links have been removed in English Page. 
But they are remained in some other language pages. 
Now I remove them.