### PR TITLE
Use pub/ruby/X.Y directory instead of pub/ruby directly

### DIFF
--- a/de/news/_posts/2002-03-01-167-is-released.md
+++ b/de/news/_posts/2002-03-01-167-is-released.md
@@ -9,4 +9,4 @@ Die neue stabile Version [1.6.7][1] wurde veröffentlicht.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.7.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz

--- a/de/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
+++ b/de/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
@@ -8,7 +8,7 @@ lang: de
 I just put the 1.6.8 release package on the ftp. 1.6.8 should be the
 last release in the 1.6.x series. Check out
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz][1]
 
 I also put the first preview of 1.8.0 at
 
@@ -19,6 +19,6 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1.tar.gz
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1-errata.diff

--- a/de/news/_posts/2004-12-26-ruby-182-released.md
+++ b/de/news/_posts/2004-12-26-ruby-182-released.md
@@ -11,7 +11,7 @@ Matz announced that ruby 1.8.2 was released
 
 This is mainly a bug fix release. You can download it at:
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz][1]
 
 md5sum is 8ffc79d96f336b80f2690a17601dea9b
 
@@ -19,4 +19,4 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz

--- a/de/news/_posts/2005-09-21-ruby-183-released.md
+++ b/de/news/_posts/2005-09-21-ruby-183-released.md
@@ -10,4 +10,4 @@ Ruby 1.8.3 has been released. The source is [here][1], and the md5sum is
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.3.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3.tar.gz

--- a/de/news/_posts/2005-12-24-ruby-184-released.md
+++ b/de/news/_posts/2005-12-24-ruby-184-released.md
@@ -6,9 +6,9 @@ lang: de
 ---
 
 Ruby 1.8.4 has been released. The source is
-[https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz][1], the md5sum is
+[https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz][1], the md5sum is
 bd8c2e593e1fa4b01fd98eaf016329bb, and filesize is 4,312,965 bytes.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz

--- a/de/news/_posts/2006-08-29-ruby-1-8-5-released.md
+++ b/de/news/_posts/2006-08-29-ruby-1-8-5-released.md
@@ -7,7 +7,7 @@ lang: de
 
 Ruby 1.8.5 has been released.
 
-The source is [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz][1],
+The source is [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz][1],
 the md5sum is 3fbb02294a8ca33d4684055adba5ed6f, and filesize is
 4,438,603 bytes.
 
@@ -15,5 +15,5 @@ Mauricio Fernandez wrote [a summary of changes][2].
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz
 [2]: http://eigenclass.org/hiki.rb?ruby+1.8.5+changelog

--- a/de/news/_posts/2009-05-21-ruby-1-9-1-p129-verffentlicht.md
+++ b/de/news/_posts/2009-05-21-ruby-1-9-1-p129-verffentlicht.md
@@ -13,19 +13,19 @@ allen 1.9.1 Benutzern auf diese Version umzusteigen.
 
 #### Download
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2&gt;][1]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
 
       Größe:   7183891 bytes
       MD5:    6fa62b20f72da471195830dec4eb2013
       SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
 
       Größe:   9034947 bytes
       MD5:    c71f413514ee6341c627be2957023a5c
       SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
 
       Größe:   10299369 bytes
       MD5:    156305e9633758eb60b419fabc33b6e4
@@ -40,6 +40,6 @@ allen 1.9.1 Benutzern auf diese Version umzusteigen.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/de/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/de/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -32,19 +32,19 @@ Sie können den ursprünglichen Fehlerbericht im Ticketsystem nachlesen:
 
 ## Download
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/en/news/_posts/2002-03-01-167-is-released.md
+++ b/en/news/_posts/2002-03-01-167-is-released.md
@@ -9,4 +9,4 @@ The new stable version [1.6.7][1] is released.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.7.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz

--- a/en/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
+++ b/en/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
@@ -8,7 +8,7 @@ lang: en
 I just put the 1.6.8 release package on the ftp. 1.6.8 should be the
 last release in the 1.6.x series. Check out
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz][1]
 
 I also put the first preview of 1.8.0 at
 
@@ -19,6 +19,6 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1.tar.gz
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1-errata.diff

--- a/en/news/_posts/2004-12-26-ruby-182-released.md
+++ b/en/news/_posts/2004-12-26-ruby-182-released.md
@@ -11,7 +11,7 @@ Matz announced that ruby 1.8.2 was released
 
 This is mainly a bug fix release. You can download it at:
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz][1]
 
 md5sum is 8ffc79d96f336b80f2690a17601dea9b
 
@@ -19,4 +19,4 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz

--- a/en/news/_posts/2005-09-21-ruby-183-released.md
+++ b/en/news/_posts/2005-09-21-ruby-183-released.md
@@ -10,4 +10,4 @@ Ruby 1.8.3 has been released. The source is [here][1], and the md5sum is
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.3.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3.tar.gz

--- a/en/news/_posts/2005-12-24-ruby-184-released.md
+++ b/en/news/_posts/2005-12-24-ruby-184-released.md
@@ -6,9 +6,9 @@ lang: en
 ---
 
 Ruby 1.8.4 has been released. The source is
-[https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz][1], the md5sum is
+[https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz][1], the md5sum is
 bd8c2e593e1fa4b01fd98eaf016329bb, and filesize is 4,312,965 bytes.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz

--- a/en/news/_posts/2006-08-29-ruby-1-8-5-released.md
+++ b/en/news/_posts/2006-08-29-ruby-1-8-5-released.md
@@ -7,7 +7,7 @@ lang: en
 
 Ruby 1.8.5 has been released.
 
-The source is [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz][1],
+The source is [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz][1],
 the md5sum is 3fbb02294a8ca33d4684055adba5ed6f, and filesize is
 4,438,603 bytes.
 
@@ -15,5 +15,5 @@ Mauricio Fernandez wrote [a summary of changes][2].
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz
 [2]: http://eigenclass.org/hiki.rb?ruby+1.8.5+changelog

--- a/en/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/en/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -31,19 +31,19 @@ You can read the original report on the bug tracker:
 
 ## Download
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/es/news/_posts/2009-05-21-ruby-1-9-1-p129.md
+++ b/es/news/_posts/2009-05-21-ruby-1-9-1-p129.md
@@ -11,19 +11,19 @@ Ruby 1.9.1 que lo instalen.
 
 #### Ubicación
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2&gt;][1]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
 
       SIZE:   7183891 bytes
       MD5:    6fa62b20f72da471195830dec4eb2013
       SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
 
       SIZE:   9034947 bytes
       MD5:    c71f413514ee6341c627be2957023a5c
       SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
 
       SIZE:   10299369 bytes
       MD5:    156305e9633758eb60b419fabc33b6e4
@@ -41,6 +41,6 @@ $SAFE &gt; 0
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/es/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/es/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -32,19 +32,19 @@ Puedes leer el reporte original de el problema en el tracker:
 
 ## Descarga
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/fr/news/_posts/2009-05-14-sortie-de-ruby-1-9-1-p129.md
+++ b/fr/news/_posts/2009-05-14-sortie-de-ruby-1-9-1-p129.md
@@ -13,19 +13,19 @@ d\'installer cette mise-à-jour.
 
 #### Téléchargement
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2&gt;][1]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
 
       SIZE:   7183891 bytes
       MD5:    6fa62b20f72da471195830dec4eb2013
       SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
 
       SIZE:   9034947 bytes
       MD5:    c71f413514ee6341c627be2957023a5c
       SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
 
       SIZE:   10299369 bytes
       MD5:    156305e9633758eb60b419fabc33b6e4
@@ -43,6 +43,6 @@ $SAFE &gt; 0
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/it/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/it/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -31,19 +31,19 @@ Potete leggere la segnalazione originale sul bug tracker:
 
 ## Download
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/ja/news/_posts/2002-12-24-20021224.md
+++ b/ja/news/_posts/2002-12-24-20021224.md
@@ -7,7 +7,7 @@ lang: ja
 
 1\.6.8リリースパッケージがftp上に公開されました。1.6.8は1.6系最後のリリースになる予定です。以下からダウンロードできます。
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz][1]
 
 また、1.8.0の最初のプレビューも公開されました。
 
@@ -18,6 +18,6 @@ lang: ja
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1.tar.gz
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1-errata.diff

--- a/ja/news/_posts/2004-12-25-20041225.md
+++ b/ja/news/_posts/2004-12-25-20041225.md
@@ -9,7 +9,7 @@ Ruby安定版の最新版、Ruby 1.8.2がリリースされました(
 [\[ruby-list:40458\]][1]、[\[ruby-talk:124413\]][2]
 )。ソースコードは下記URLよりダウンロードできます。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz&gt;][3]
 
 MD5チェックサムは 8ffc79d96f336b80f2690a17601dea9b です。
 
@@ -21,4 +21,4 @@ MD5チェックサムは 8ffc79d96f336b80f2690a17601dea9b です。
 
 [1]: https://blade.ruby-lang.org/ruby-list/40458
 [2]: https://blade.ruby-lang.org/ruby-talk/124413
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz

--- a/ja/news/_posts/2005-09-21-20050921.md
+++ b/ja/news/_posts/2005-09-21-20050921.md
@@ -6,7 +6,7 @@ lang: ja
 ---
 
 Ruby 1.8.3がリリースされました。ソースコードは
-[https://cache.ruby-lang.org/pub/ruby/ruby-1.8.3.tar.gz][1]から入手できます。md5sumは63d6c2bddd6af86664e338b31f3189a6です。
+[https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3.tar.gz][1]から入手できます。md5sumは63d6c2bddd6af86664e338b31f3189a6です。
 
 近日中にミラーからも入手可能になると思います。
 
@@ -15,10 +15,10 @@ Ruby 1.8.3がリリースされました。ソースコードは
 ミラーサイト
 
 * [http://rubyforge.org/frs/?group\_id=426][2]
-* [http://www.garbagecollect.jp/ruby/ruby-1.8.3.tar.gz][3]
+* [http://www.garbagecollect.jp/ruby/1.8/ruby-1.8.3.tar.gz][3]
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.3.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3.tar.gz
 [2]: http://rubyforge.org/frs/?group_id=426
-[3]: http://www.garbagecollect.jp/ruby/ruby-1.8.3.tar.gz
+[3]: http://www.garbagecollect.jp/ruby/1.8/ruby-1.8.3.tar.gz

--- a/ja/news/_posts/2005-12-24-20051224.md
+++ b/ja/news/_posts/2005-12-24-20051224.md
@@ -9,7 +9,7 @@ lang: ja
 
 1\.8.4 のソースコードは以下のURLから入手可能です。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz&gt;][2]
 
 md5sumは bd8c2e593e1fa4b01fd98eaf016329bb です。 また、サイズは 4312965 バイトです。
 
@@ -22,5 +22,5 @@ Merry Christmas! そして、Happy Hacking!
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/41728
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz
+[2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.4+feature

--- a/ja/news/_posts/2006-08-25-ruby-1-8-5.md
+++ b/ja/news/_posts/2006-08-25-ruby-1-8-5.md
@@ -9,7 +9,7 @@ lang: ja
 
 ソースコードは以下のURLから入手できます。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz&gt;][2]
 
 md5sumは 3fbb02294a8ca33d4684055adba5ed6f です。また、サイズは 4,438,603 バイトです。
 
@@ -24,5 +24,5 @@ Ruby
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/42751
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz
+[2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz
 [3]: {{ site.url }}/ja/man/?cmd=view;name=ruby+1.8.5+feature

--- a/ja/news/_posts/2006-12-05-ruby-1-8-5-p2.md
+++ b/ja/news/_posts/2006-12-05-ruby-1-8-5-p2.md
@@ -9,7 +9,7 @@ Ruby 1.8.5-p2がリリースされました。(リリースについてのアナ
 
 ソースコードは以下のURLから入手できます。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p2.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p2.tar.gz&gt;][2]
 
 md5sumは a3517a224716f79b14196adda3e88057 です。また、サイズは 4,519,151 バイトです。
 
@@ -33,4 +33,4 @@ Ruby
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/43017
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p2.tar.gz
+[2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p2.tar.gz

--- a/ja/news/_posts/2006-12-25-ruby-1-8-5-p12.md
+++ b/ja/news/_posts/2006-12-25-ruby-1-8-5-p12.md
@@ -9,7 +9,7 @@ ruby 1.8.5-p12がリリースされました。(リリースについてのア�
 
 ソースコードは以下のURLから入手できます。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p12.tar.gz&gt;][2]
 
 md5sumは d7d12dd9124c9b7d55cdbbee313e3931です。また、サイズは 4,526,961 バイトです。
 
@@ -19,4 +19,4 @@ md5sumは d7d12dd9124c9b7d55cdbbee313e3931です。また、サイズは 4,526,9
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/43074
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz
+[2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p12.tar.gz

--- a/ja/news/_posts/2008-12-31-ruby-1-9-1-rc1-released.md
+++ b/ja/news/_posts/2008-12-31-ruby-1-9-1-rc1-released.md
@@ -15,19 +15,19 @@ RC1のリリースのアナウンスがありました。
 
 ソースコードは以下のURLよりダウンロードできます。
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.bz2&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.bz2&gt;][2]
 
       SIZE:   6181532 bytes
       MD5:    d440c030131903e72a6152149a097af3
       SHA256: 35acfb6b8d9dd9159ef308ac763c629092cda2e8c9f41254e72a7b9fa454c27f
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.gz&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.gz&gt;][3]
 
       SIZE:   7425278 bytes
       MD5:    b145bc39667f27c018b188c812f07ca6
       SHA256: a5d41b58bb9a379b3a98713c07a17757c853413104694036d9885559163f5518
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.zip&gt;][4]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.zip&gt;][4]
 
       SIZE:   8695438 bytes
       MD5:    91ca7ebd3fe4ad577d08963e81e79c82
@@ -57,9 +57,9 @@ RC1ではまだ対応が行われていない課題は、以下のURLです。
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/45758
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.bz2
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.tar.gz
-[4]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-rc1.zip
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.bz2
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.gz
+[4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.zip
 [5]: https://blade.ruby-lang.org/ruby-list/45759
 [6]: http://arton.no-ip.info/data/asr/Ruby-1.9.1.msi
 [7]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=9

--- a/ja/news/_posts/2009-05-12-ruby-1-9-1-p129-released.md
+++ b/ja/news/_posts/2009-05-12-ruby-1-9-1-p129-released.md
@@ -12,19 +12,19 @@ Ruby 1.9.1-p129がリリースされました。
 
 #### 所在
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2&gt;][1]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
 
       SIZE:   7183891 bytes
       MD5:    6fa62b20f72da471195830dec4eb2013
       SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
 
       SIZE:   9034947 bytes
       MD5:    c71f413514ee6341c627be2957023a5c
       SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
 
       SIZE:   10299369 bytes
       MD5:    156305e9633758eb60b419fabc33b6e4
@@ -37,6 +37,6 @@ Ruby 1.9.1-p129がリリースされました。
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/ja/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/ja/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -26,19 +26,19 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 ## ダウンロード
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/ko/news/_posts/2002-03-01-167-is-released.md
+++ b/ko/news/_posts/2002-03-01-167-is-released.md
@@ -9,4 +9,4 @@ The new stable version [1.6.7][1] is released.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.7.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz

--- a/ko/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
+++ b/ko/news/_posts/2002-12-24-ruby-1-6-8-and-1-8-0-preview-1.md
@@ -8,7 +8,7 @@ lang: ko
 I just put the 1.6.8 release package on the ftp. 1.6.8 should be the
 last release in the 1.6.x series. Check out
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz][1]
 
 I also put the first preview of 1.8.0 at
 
@@ -19,6 +19,6 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.6.8.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.8.tar.gz
 [2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1.tar.gz
 [3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.0-preview1-errata.diff

--- a/ko/news/_posts/2004-12-26-ruby-182-released.md
+++ b/ko/news/_posts/2004-12-26-ruby-182-released.md
@@ -11,7 +11,7 @@ Matz announced that ruby 1.8.2 was released
 
 This is mainly a bug fix release. You can download it at:
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz][1]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz][1]
 
 md5sum is 8ffc79d96f336b80f2690a17601dea9b
 
@@ -19,4 +19,4 @@ Merry Christmas!
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.2.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.2.tar.gz

--- a/ko/news/_posts/2005-09-21-ruby-183-released.md
+++ b/ko/news/_posts/2005-09-21-ruby-183-released.md
@@ -10,4 +10,4 @@ Ruby 1.8.3 has been released. The source is [here][1], and the md5sum is
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.3.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.3.tar.gz

--- a/ko/news/_posts/2005-12-24-ruby-184-released.md
+++ b/ko/news/_posts/2005-12-24-ruby-184-released.md
@@ -6,9 +6,9 @@ lang: ko
 ---
 
 Ruby 1.8.4 has been released. The source is
-[https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz][1], the md5sum is
+[https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz][1], the md5sum is
 bd8c2e593e1fa4b01fd98eaf016329bb, and filesize is 4,312,965 bytes.
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.4.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.4.tar.gz

--- a/ko/news/_posts/2006-09-17-ruby-1-8-5-released.md
+++ b/ko/news/_posts/2006-09-17-ruby-1-8-5-released.md
@@ -7,7 +7,7 @@ lang: ko
 
 루비 1.8.5 버전이 배포되었습니다.
 
-소스 코드는 [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz][1]에서 다운로드할
+소스 코드는 [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz][1]에서 다운로드할
 수 있고, md5sum은 3fbb02294a8ca33d4684055adba5ed6f입니다. 용량은 4,438,603
 바이트입니다.
 
@@ -15,5 +15,5 @@ lang: ko
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5.tar.gz
+[1]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5.tar.gz
 [2]: http://eigenclass.org/hiki.rb?ruby+1.8.5+changelog

--- a/ko/news/_posts/2007-01-01-ruby-1-8-5-p12.md
+++ b/ko/news/_posts/2007-01-01-ruby-1-8-5-p12.md
@@ -9,7 +9,7 @@ lang: ko
 
 아래 주소에서 소스 코드를 내려 받을 수 있습니다.
 
-* [https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz][2]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p12.tar.gz][2]
 
 md5sum은 d7d12dd9124c9b7d55cdbbee313e3931이고 파일 크기는 4,526,961 바이트입니다.
 
@@ -19,4 +19,4 @@ md5sum은 d7d12dd9124c9b7d55cdbbee313e3931이고 파일 크기는 4,526,961 바�
 
 
 [1]: https://blade.ruby-lang.org/ruby-list/43074
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.8.5-p12.tar.gz
+[2]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p12.tar.gz

--- a/ko/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/ko/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -29,19 +29,19 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 ## 다운로드
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/pl/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/pl/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -31,19 +31,19 @@ Możesz przeczytać oryginalny raport o błędzie:
 
 ## Pobieranie
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/pt/news/_posts/2009-05-15-ruby-1-9-1-p129-j-disponvel-para-download.md
+++ b/pt/news/_posts/2009-05-15-ruby-1-9-1-p129-j-disponvel-para-download.md
@@ -14,19 +14,19 @@ façam esta actualização.
 
 #### Disponível a partir de
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2&gt;][1]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
 
       SIZE:   7183891 bytes
       MD5:    6fa62b20f72da471195830dec4eb2013
       SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz&gt;][2]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
 
       SIZE:   9034947 bytes
       MD5:    c71f413514ee6341c627be2957023a5c
       SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
 
-* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip&gt;][3]
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
 
       SIZE:   10299369 bytes
       MD5:    156305e9633758eb60b419fabc33b6e4
@@ -44,6 +44,6 @@ $SAFE &gt; 0
 
 
 
-[1]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.bz2
-[2]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.tar.gz
-[3]: https://cache.ruby-lang.org/pub/ruby/ruby-1.9.1-p129.zip
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/vi/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/vi/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -32,19 +32,19 @@ Bạn có thể đọc bản báo cáo gốc trên bug tracker:
 
 ## Download
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/zh_cn/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/zh_cn/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -26,19 +26,19 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 ## 下载
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5

--- a/zh_tw/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
+++ b/zh_tw/news/_posts/2014-08-19-ruby-1-9-2-p330-released.md
@@ -24,19 +24,19 @@ ruby -v -ruri -e'URI.decode_www_form_component "A string that causes catastrophi
 
 ## 下載
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.bz2>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2>
 
       SIZE:   9081661 bytes
       MD5:    8ba4aaf707023e76f80fc8f455c99858
       SHA256: 6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.tar.gz>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz>
 
       SIZE:   11416473 bytes
       MD5:    4b9330730491f96b402adc4a561e859a
       SHA256: 23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9
 
-* <https://cache.ruby-lang.org/pub/ruby/ruby-1.9.2-p330.zip>
+* <https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.zip>
 
       SIZE:   12732739 bytes
       MD5:    42d261b28d1b7e500dd3bdbdbfba7fa5


### PR DESCRIPTION
I have a plan to clean up archive files from top level of `pub/ruby`. I replaced that url to `pub/ruby/X.Y/` instead of that.