### PR TITLE
Translate "Ruby 3.4.1 released" (ko)

### DIFF
--- a/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
+++ b/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "Ruby 3.4.1 Released"
+author: "naruse"
+translator:
+date: 2024-12-25 10:00:00 +0000
+lang: en
+---
+
+Ruby 3.4.1 has been released.
+
+This fixes the version description.
+
+See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_4_1) for further details.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.4.1" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}

--- a/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
+++ b/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
@@ -2,18 +2,18 @@
 layout: news_post
 title: "Ruby 3.4.1 Released"
 author: "naruse"
-translator:
+translator: "shia"
 date: 2024-12-25 10:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.4.1 has been released.
+Ruby 3.4.1이 릴리스되었습니다.
 
-This fixes the version description.
+이번 릴리스는 버전 설명을 수정합니다.
 
-See the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_4_1) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v3_4_1)를 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.4.1" | first %}
 

--- a/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
+++ b/ko/news/_posts/2024-12-25-ruby-3-4-1-released.md
@@ -1,9 +1,9 @@
 ---
 layout: news_post
-title: "Ruby 3.4.1 Released"
+title: "Ruby 3.4.1 릴리스"
 author: "naruse"
 translator: "shia"
-date: 2024-12-25 10:00:00 +0000
+date: 2024-12-25 00:00:00 +0000
 lang: ko
 ---
 


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/2818

Translate of #3445

Actual diff is 2719c2a