### PR TITLE
Remove needless English words from Tempfile explanation in ja

### DIFF
--- a/ja/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/ja/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -157,7 +157,7 @@ Ruby 3.3 までは上記の2つのメソッドは名前解決と接続試行を�
 
 * Tempfile
 
-    * `Tempfile.create` に `anonymous: true` キーワードが追加されました。is implemented for .
+    * `Tempfile.create` に `anonymous: true` キーワードが追加されました。
       `Tempfile.create(anonymous: true)` は作成した一時ファイルを即座に削除します。この機能を用いることで、アプリケーションは独自にファイル削除を行う必要がなくなります。 [[Feature #20497]]
 
 * win32/sspi.rb


### PR DESCRIPTION
<img width="629" alt="スクリーンショット 2024-12-25 20 55 44" src="https://github.com/user-attachments/assets/c08aeb54-8509-4e8a-aa5d-5d1463a083c4" />


It seemed that some English words unexpectedly remained in the ja md.
https://github.com/ruby/www.ruby-lang.org/blob/ced8733207718d383eacb62fabddc2a8c448a32b/en/news/_posts/2024-12-25-ruby-3-4-0-released.md?plain=1#L178