### PR TITLE
Use docs.ruby-lang.org for 3.4 release news

### DIFF
--- a/en/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/en/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -273,7 +273,7 @@ Note: Excluding feature bug fixes.
   warning (`-W:performance` or `Warning[:performance] = true`).
   [[Feature #20429]]
 
-See [NEWS](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
+See [NEWS](https://docs.ruby-lang.org/en/3.4/NEWS_md.html)
 or [commit logs](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }})
 for more details.
 


### PR DESCRIPTION
With improved auto-linking, https://docs.ruby-lang.org/en/3.4/NEWS_md.html will be even more easier for readers to access updated classes/modules/methods from the page.

I used a fix url because existing `_data` attributes don't have the short-form version docs.ruby-lang.org uses.