### PR TITLE
Fix broken link of 3.4.0 release news

### DIFF
--- a/en/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/en/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -338,8 +338,9 @@ and is used all over the world especially for web development.
 [Feature #20715]: https://bugs.ruby-lang.org/issues/20715
 [Feature #20775]: https://bugs.ruby-lang.org/issues/20775
 [Bug #20795]: https://bugs.ruby-lang.org/issues/20795
+[Bug #20433]: https://bugs.ruby-lang.org/issues/20433
 [Feature #20860]: https://bugs.ruby-lang.org/issues/20860
 [Feature #20875]: https://bugs.ruby-lang.org/issues/20875
 [Feature #20884]: https://bugs.ruby-lang.org/issues/20884
-[sigstore.dev]: sigstore.dev
+[sigstore.dev]: https://www.sigstore.dev
 [ruby/net-http-sspi]: https://github.com/ruby/net-http-sspi

--- a/ja/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/ja/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -307,6 +307,7 @@ Rubyはまつもとゆきひろ (Matz) によって1993年に開発が始めら�
 [Feature #20715]: https://bugs.ruby-lang.org/issues/20715
 [Feature #20775]: https://bugs.ruby-lang.org/issues/20775
 [Bug #20795]: https://bugs.ruby-lang.org/issues/20795
+[Bug #20433]: https://bugs.ruby-lang.org/issues/20433
 [Feature #20860]: https://bugs.ruby-lang.org/issues/20860
 [Feature #20875]: https://bugs.ruby-lang.org/issues/20875
 [Feature #20884]: https://bugs.ruby-lang.org/issues/20884


### PR DESCRIPTION
1. Add missing [Bug #20433] link
2. Fix sigstore.dev link. Previous link points to a relative link

BTW, the Japanese version may need a modification for sigstore link,
either remove the link at line 148, and modify the corresponding link at line 314
or remove the link line at 314.