### PR TITLE
added mise-en-place

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -339,6 +339,11 @@ from source.
 {: #mise-en-place}
 
 [mise-en-place][mise-en-place] allows you to switch between multiple Rubies.
+It uses [ruby-build](#ruby-build) under the hood but can also be configured to use [ruby-install](#ruby-install)
+—neither of which needs to be manually installed first. mise-en-place is a polyglot
+version manager supporting many programming languages including [ruby][mise-en-place-ruby].
+mise-en-place also has a [gem backend](https://mise.jdx.dev/dev-tools/backends/gem.html) which can be used to manage
+versions of CLIs written in ruby.
 It supports UNIX-like and Windows operating systems.
 
 
@@ -430,4 +435,5 @@ though, because the installed Ruby won't be managed by any tools.
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby
 [mise-en-place]: https://mise.jdx.dev
+[mise-en-place-ruby]: https://mise.jdx.dev/lang/ruby.html
 [openbsd-current-ruby-ports]: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD

--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -338,12 +338,8 @@ from source.
 ### mise-en-place
 {: #mise-en-place}
 
-[mise-en-place][mise-en-place] allows you to switch between multiple Rubies.
-It uses [ruby-build](#ruby-build) under the hood but can also be configured to use [ruby-install](#ruby-install)
-—neither of which needs to be manually installed first. mise-en-place is a polyglot
-version manager supporting many programming languages including [ruby][mise-en-place-ruby].
-mise-en-place also has a [gem backend](https://mise.jdx.dev/dev-tools/backends/gem.html) which can be used to manage
-versions of CLIs written in ruby.
+[mise-en-place][mise-en-place] allows you to switch between multiple Rubies without requiring additional tools.
+It manages installations automatically and includes a [gem backend](https://mise.jdx.dev/dev-tools/backends/gem.html) to manage versions of CLIs written in Ruby.
 It supports UNIX-like and Windows operating systems.
 
 

--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -57,6 +57,7 @@ Here are available installation methods:
 * [Managers](#managers)
   * [asdf-vm](#asdf-vm)
   * [chruby](#chruby)
+  * [mise-en-place](#mise-en-place)
   * [rbenv](#rbenv)
   * [rbenv for Windows](#rbenv-for-windows)
   * [RVM](#rvm)
@@ -334,6 +335,13 @@ manage Rubies installed by [ruby-install](#ruby-install) or even built
 from source.
 
 
+### mise-en-place
+{: #mise-en-place}
+
+[mise-en-place][mise-en-place] allows you to switch between multiple Rubies.
+It supports UNIX-like and Windows operating systems.
+
+
 ### rbenv
 {: #rbenv}
 
@@ -421,4 +429,5 @@ though, because the installed Ruby won't be managed by any tools.
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby
+[mise-en-place]: https://mise.jdx.dev
 [openbsd-current-ruby-ports]: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD


### PR DESCRIPTION
Because mise is the recommended install in the [new rails guides](https://edgeguides.rubyonrails.org/install_ruby_on_rails.html) it makes sense to at least include it here.

rvm and rbenv are explicitly called out here as well, not sure if mise is important enough to be added there or not:

https://github.com/ruby/www.ruby-lang.org/blob/989940d7d3f891d9596b330f95d159f43c96a479/en/downloads/index.md?plain=1#L16-L19

I feel like with each of the tools mentioned it would be nice to break the operating system support out into something common like this, but I was curious what y'all think before I added this:

```md
### mise-en-place
{: #mise-en-place}

**OS:** UNIX-like, Windows

[mise-en-place][mise-en-place] allows you to switch between multiple Rubies.
```

I'm happy to also add this to the translated pages once we're happy with the English text—though the only language I'll be able to do without blindly using Google translate will be French.