### PR TITLE
Add news post for KansaiRubyKaigi08 registration opening

### DIFF
--- a/ja/news/_posts/2025-02-18-kansai-rubykaigi-registration-is-open.md
+++ b/ja/news/_posts/2025-02-18-kansai-rubykaigi-registration-is-open.md
@@ -1,0 +1,26 @@
+---
+layout: news_post
+title: "関西Ruby会議08の参加登録が開始されました"
+author: "Yudai Takada（@ydah）"
+translator:
+date: 2025-02-18 14:30:00 +0000
+lang: ja
+---
+
+日本Rubyの会が後援する、[地域Ruby会議(RegionalRubyKaigi)][1]の1つである[関西Ruby会議08](https://regional.rubykaigi.org/kansai08/)の参加登録が開始されました。
+
+* 開催日: 2025年6月28日(土) 10:00 〜 18:00（時刻は変更となる場合があります）
+* 会場: [先斗町 歌舞練場](https://maps.app.goo.gl/tf7ucg1ijkSjVjTr9)
+* 主催: Ruby関西(るびーかんさい)、Kyoto.rb(きょうとあーるびー)、Kobe.rb(こうべあーるびー)、Kyobashi.rb(きょうばしあーるびー)、Ruby Tuesday(るびーちゅーずでー)、Ruby舞鶴(るびーまいづる)、AKASHI.rb(あかしあーるびー)、Shinosaka.rb(しんおおさかあーるびー)、naniwa.rb(なにわあーるびー)
+* 参加費: 無料
+* 公式タグ: [#kanrk08](https://twitter.com/search?q=kanrk08&src=typd&f=realtime)
+
+## 参加登録
+
+Tito にて申し込みを受け付けています。
+
+* [イベントサイト](https://regional.rubykaigi.org/kansai08/)
+* [参加受付](https://ti.to/kansairubykaigi/08)
+* [発表者募集](https://forms.gle/ijBZ6WM63XJ4rdc58)
+
+[1]: http://regional.rubykaigi.org/


### PR DESCRIPTION
References: https://github.com/ruby/www.ruby-lang.org/pull/1176 and https://scrapbox.io/ruby-no-kai/Regional_RubyKaigi

>## 参加申し込みを開始したら
> ruby-listにアナウンスしましょう
> https://ruby-lang.org のnewsに載せよう
>	 https://github.com//ruby/www.ruby-lang.org/ から PR を送れば news に載せることができます