### PR TITLE
Fix missing links for CVE-2015-3900 in ko version

### DIFF
--- a/ko/news/_posts/2015-08-18-ruby-2-0-0-p647-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-0-0-p647-released.md
@@ -12,7 +12,7 @@ lang: ko
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 더 자세한 내용은 밑의 내용을 보세요.
 
-* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](https://rubykr.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
 
 그리고 이 릴리스에는 lib/resolv.rb의 회귀에 대한 수정도 포함됩니다.
 

--- a/ko/news/_posts/2015-08-18-ruby-2-0-0-p647-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-0-0-p647-released.md
@@ -12,7 +12,7 @@ lang: ko
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 더 자세한 내용은 밑의 내용을 보세요.
 
-* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](http://ruby-korea.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
 
 그리고 이 릴리스에는 lib/resolv.rb의 회귀에 대한 수정도 포함됩니다.
 

--- a/ko/news/_posts/2015-08-18-ruby-2-1-7-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-1-7-released.md
@@ -12,7 +12,7 @@ lang: ko
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 더 자세한 내용은 밑의 내용을 보세요.
 
-* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](http://ruby-korea.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
 
 또한 많은 버그가 수정되었습니다.
 자세한 내용은 [티켓](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)과

--- a/ko/news/_posts/2015-08-18-ruby-2-1-7-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-1-7-released.md
@@ -12,7 +12,7 @@ lang: ko
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 더 자세한 내용은 밑의 내용을 보세요.
 
-* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](https://rubykr.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
 
 또한 많은 버그가 수정되었습니다.
 자세한 내용은 [티켓](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)과

--- a/ko/news/_posts/2015-08-18-ruby-2-2-3-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-2-3-released.md
@@ -12,7 +12,7 @@ lang: ko
 
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 
-* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](https://rubykr.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
 
 버그 수정도 조금 있었습니다.
 자세한 내용은

--- a/ko/news/_posts/2015-08-18-ruby-2-2-3-released.md
+++ b/ko/news/_posts/2015-08-18-ruby-2-2-3-released.md
@@ -12,7 +12,7 @@ lang: ko
 
 이 릴리스에는 RubyGems 도메인 이름 확인 취약점에 관한 보안 수정이 포함됩니다.
 
-* [CVE-2015-3900 RubyGems 2.4.6 이전의 요청 가로채기 취약점](http://ruby-korea.github.io/rubygems-blog/2015/05/14/CVE-2015-3900.html)
+* [CVE-2015-3900 Request hijacking vulnerability in RubyGems 2.4.6 and earlier](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)
 
 버그 수정도 조금 있었습니다.
 자세한 내용은


### PR DESCRIPTION
The links to the pages under `ruby-korea.github.io` is missing.
I changed the links to the the page in blog.rubygems.org.