### PR TITLE
Fix "Ruby 3.5.0 preview1 released" typo

### DIFF
--- a/en/news/_posts/2025-04-18-ruby-3-5-0-preview1-released.md
+++ b/en/news/_posts/2025-04-18-ruby-3-5-0-preview1-released.md
@@ -8,7 +8,7 @@ lang: en
 ---
 
 {% assign release = site.data.releases | where: "version", "3.5.0-preview1" | first %}
-We are pleased to announce the release of Ruby {{ release.version }}. Ruby 3.4 updates its Unicode version to 15.1.0, and so on.
+We are pleased to announce the release of Ruby {{ release.version }}. Ruby 3.5 updates its Unicode version to 15.1.0, and so on.
 
 ## Language changes
 


### PR DESCRIPTION
3.5 is correct, isn't it? :eyes: