### PR TITLE
There is an issue regarding variable namings in the tutorials and pedagogy

### DIFF
--- a/en/documentation/quickstart/2/index.md
+++ b/en/documentation/quickstart/2/index.md
@@ -77,8 +77,8 @@ point. You can also use this to make sure that someone’s name is
 properly capitalized:
 
 {% highlight irb %}
-irb(main):019:0> def hi(name = "World")
-irb(main):020:1> puts "Hello #{name.capitalize}!"
+irb(main):019:0> def hi(var = "World")
+irb(main):020:1> puts "Hello #{var.capitalize}!"
 irb(main):021:1> end
 => :hi
 irb(main):022:0> hi "chris"
@@ -103,8 +103,8 @@ an object for that. Let’s create a “Greeter” class.
 
 {% highlight irb %}
 irb(main):024:0> class Greeter
-irb(main):025:1>   def initialize(name = "World")
-irb(main):026:2>     @name = name
+irb(main):025:1>   def initialize(var = "World")
+irb(main):026:2>     @name = var
 irb(main):027:2>   end
 irb(main):028:1>   def say_hi
 irb(main):029:2>     puts "Hi #{@name}!"

--- a/en/documentation/quickstart/2/index.md
+++ b/en/documentation/quickstart/2/index.md
@@ -57,8 +57,8 @@ What if we want to say hello to one person, and not the whole world?
 Just redefine `hi` to take a name as a parameter.
 
 {% highlight irb %}
-irb(main):015:0> def hi(name)
-irb(main):016:1> puts "Hello #{name}!"
+irb(main):015:0> def hi(text)
+irb(main):016:1> puts "Hello #{text}!"
 irb(main):017:1> end
 => :hi
 irb(main):018:0> hi("Matz")
@@ -70,15 +70,15 @@ So it works… but let’s take a second to see what’s going on here.
 
 ## Holding Spots in a String
 
-What’s the `#{name}` bit? That’s Ruby’s way of inserting something into
+What’s the `#{text}` bit? That’s Ruby’s way of inserting something into
 a string. The bit between the braces is turned into a string (if it
 isn’t one already) and then substituted into the outer string at that
 point. You can also use this to make sure that someone’s name is
 properly capitalized:
 
 {% highlight irb %}
-irb(main):019:0> def hi(var = "World")
-irb(main):020:1> puts "Hello #{var.capitalize}!"
+irb(main):019:0> def hi(text = "World")
+irb(main):020:1> puts "Hello #{text.capitalize}!"
 irb(main):021:1> end
 => :hi
 irb(main):022:0> hi "chris"
@@ -103,9 +103,9 @@ an object for that. Let’s create a “Greeter” class.
 
 {% highlight irb %}
 irb(main):024:0> class Greeter
-irb(main):025:1>   def initialize(var = "World")
-irb(main):026:2>     @name = var
-irb(main):027:2>   end
+irb(main):025:1>   def initialize(text = "World")
+irb(main):026:2>     @name = text
+irb(main):027:2>   en
 irb(main):028:1>   def say_hi
 irb(main):029:2>     puts "Hi #{@name}!"
 irb(main):030:2>   end


### PR DESCRIPTION
Imagining you are a new programmer, the ruby tutorial on the website does not do as clear as could be in regards to calling the name input for the method called "name" when this may be unclear to new programmers who may be unclear about notion "method name". this lack of clarity can be solved by calling the input variable "text" which becomes clearer than the tutorial is as now.

For instance:

irb(main):019:0> def hi(name = "World")
irb(main):020:1> puts "Hello #{name.capitalize}!"
irb(main):021:1> end

hi is the "method name". While experience programmers know this it is the method name and "name" refers to the variable someone may not know this"

Let me know if you'd like this edit translated into the other languages and I can do this too. I can also go back and change it to "textVar" or "inputTxt". 

I am also willing to rewrite tutorial to include this kind of basic programming info or create a tutorial thats more aimed at new programmers. It'd be better if I got info from the more active devs on this project if this is even going to be accepted as a commit so I can know if this is even worthwhile edit.