### PR TITLE
Add CVE-2025-43857: DoS vulnerability in net-imap

### DIFF
--- a/en/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
+++ b/en/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "CVE-2025-43857: DoS vulnerability in net-imap"
+author: "nevans"
+translator:
+date: 2025-04-28 16:02:04 +0000
+tags: security
+lang: en
+---
+
+There is a possibility for DoS by in the net-imap gem.  This vulnerability has been assigned the CVE identifier [CVE-2025-43857].  We recommend upgrading the net-imap gem.
+
+## Details
+
+A malicious server can send can send a "literal" byte count which is automatically read by the client's receiver thread.  The response reader immediately allocates memory for the number of bytes indicated by the server response.  This should not be an issue when securely connecting to trusted IMAP servers that are well-behaved.  It affects insecure connections and buggy, untrusted, or compromised servers (for example, connecting to a user supplied hostname).
+
+Please update net-imap gem to version 0.2.5, 0.3.9, 0.4.20, 0.5.7, or later.
+
+When connecting to untrusted servers or using an insecure connection, `max_response_size` and response handlers must be configured appropriately to limit memory consumption.  See [GHSA-j3g3-5qv5-52mj] for more details.
+
+## Affected versions
+
+net-imap gem versions <= 0.2.4, 0.3.0 to 0.3.8, 0.4.0 to 0.4.19, and 0.5.0 to 0.5.6.
+
+## Credits
+
+Thanks to [Masamune] for discovering this issue.
+
+## History
+
+* Originally published at 2025-04-28 16:02:04 (UTC)
+
+[CVE-2025-43857]:      https://www.cve.org/CVERecord?id=CVE-2025-43857
+[GHSA-j3g3-5qv5-52mj]: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+[Masamune]:            https://hackerone.com/masamune_


### PR DESCRIPTION
This advisory was published a couple of days ago, but I hadn't gotten to creating this PR until now.  (sorry!)
* CVE-2025-43857
* GHSA-j3g3-5qv5-52mj

Cc: @Masamuneee