### PR TITLE
 Translate "CVE-2025-43857: DoS vulnerability in net-imap" (ko)

### DIFF
--- a/ko/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
+++ b/ko/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "CVE-2025-43857: DoS vulnerability in net-imap"
+author: "nevans"
+translator:
+date: 2025-04-28 16:02:04 +0000
+tags: security
+lang: en
+---
+
+There is a possibility for DoS by in the net-imap gem.  This vulnerability has been assigned the CVE identifier [CVE-2025-43857].  We recommend upgrading the net-imap gem.
+
+## Details
+
+A malicious server can send can send a "literal" byte count which is automatically read by the client's receiver thread.  The response reader immediately allocates memory for the number of bytes indicated by the server response.  This should not be an issue when securely connecting to trusted IMAP servers that are well-behaved.  It affects insecure connections and buggy, untrusted, or compromised servers (for example, connecting to a user supplied hostname).
+
+Please update net-imap gem to version 0.2.5, 0.3.9, 0.4.20, 0.5.7, or later.
+
+When connecting to untrusted servers or using an insecure connection, `max_response_size` and response handlers must be configured appropriately to limit memory consumption.  See [GHSA-j3g3-5qv5-52mj] for more details.
+
+## Affected versions
+
+net-imap gem versions <= 0.2.4, 0.3.0 to 0.3.8, 0.4.0 to 0.4.19, and 0.5.0 to 0.5.6.
+
+## Credits
+
+Thanks to [Masamune] for discovering this issue.
+
+## History
+
+* Originally published at 2025-04-28 16:02:04 (UTC)
+
+[CVE-2025-43857]:      https://www.cve.org/CVERecord?id=CVE-2025-43857
+[GHSA-j3g3-5qv5-52mj]: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+[Masamune]:            https://hackerone.com/masamune_

--- a/ko/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
+++ b/ko/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
@@ -1,34 +1,34 @@
 ---
 layout: news_post
-title: "CVE-2025-43857: DoS vulnerability in net-imap"
+title: "CVE-2025-43857: net-imap의 DoS 취약점"
 author: "nevans"
-translator:
+translator: "shia"
 date: 2025-04-28 16:02:04 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-There is a possibility for DoS by in the net-imap gem.  This vulnerability has been assigned the CVE identifier [CVE-2025-43857].  We recommend upgrading the net-imap gem.
+net-imap gem에서 DoS 취약점이 발견되었습니다. 이 취약점은 CVE 번호 [CVE-2025-43857](https://www.cve.org/CVERecord?id=CVE-2025-43857)으로 등록되었습니다. net-imap gem을 업그레이드하기를 추천합니다.
 
-## Details
+## 세부 내용
 
-A malicious server can send can send a "literal" byte count which is automatically read by the client's receiver thread.  The response reader immediately allocates memory for the number of bytes indicated by the server response.  This should not be an issue when securely connecting to trusted IMAP servers that are well-behaved.  It affects insecure connections and buggy, untrusted, or compromised servers (for example, connecting to a user supplied hostname).
+악의적인 서버가 "문자 그대로" 바이트 수를 보낼 수 있으며, 클라이언트의 수신 스레드는 이 데이터를 자동으로 읽습니다. 응답 리더는 서버 응답에 의해 표시된 바이트 수에 대한 메모리를 즉시 할당합니다. 신뢰할 수 있는 IMAP 서버에 안전하게 연결할 때는 문제가 되지 않습니다. 그러나 보안 연결을 사용하지 않거나 버그가 있거나 신뢰할 수 없는 서버(예: 사용자 제공 호스트 이름에 연결하는 경우)에서는 문제가 발생할 수 있습니다.
 
-Please update net-imap gem to version 0.2.5, 0.3.9, 0.4.20, 0.5.7, or later.
+net-imap gem 0.2.5, 0.3.9, 0.4.20, 0.5.7 이상으로 업데이트하세요.
 
-When connecting to untrusted servers or using an insecure connection, `max_response_size` and response handlers must be configured appropriately to limit memory consumption.  See [GHSA-j3g3-5qv5-52mj] for more details.
+신뢰할 수 없는 서버에 연결하거나 보안 연결을 사용하고 있다면, `max_response_size`와 응답 핸들러를 적절히 설정하여 메모리 소비를 제한해야 합니다. 자세한 내용은 [GHSA-j3g3-5qv5-52mj]를 참조하세요.
 
-## Affected versions
+## 해당 버전
 
-net-imap gem versions <= 0.2.4, 0.3.0 to 0.3.8, 0.4.0 to 0.4.19, and 0.5.0 to 0.5.6.
+net-imap gem 0.2.4 이하, 0.3.0부터 0.3.8까지, 0.4.0부터 0.4.19까지, 또는 0.5.0부터 0.5.6까지
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [Masamune] for discovering this issue.
+이 문제를 발견해 준 [Masamune]에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2025-04-28 16:02:04 (UTC)
+* 2025-04-28 16:02:04 (UTC) 최초 공개
 
 [CVE-2025-43857]:      https://www.cve.org/CVERecord?id=CVE-2025-43857
 [GHSA-j3g3-5qv5-52mj]: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj


### PR DESCRIPTION
:link: #3461

Translate #3560
Actual diff is 92549b2a6a58e30bc199c13df45757e985e5fcca