### PR TITLE
[Data] Normalize all dates in releases.yml to Date instead of String

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -243,7 +243,7 @@
 # 3.3 series
 
 - version: 3.3.8
-  date: '2025-04-09'
+  date: 2025-04-09
   post: "/en/news/2025/04/09/ruby-3-3-8-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz
@@ -583,7 +583,7 @@
 # 3.2 series
 
 - version: 3.2.8
-  date: '2025-03-26'
+  date: 2025-03-26
   post: "/en/news/2025/03/26/ruby-3-2-8-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz
@@ -921,7 +921,7 @@
 # 3.1 series
 
 - version: 3.1.7
-  date: '2025-03-26'
+  date: 2025-03-26
   post: "/en/news/2025/03/26/ruby-3-1-7-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz


### PR DESCRIPTION
In `_data/releases.yml`, 3 of the total 222 dates under the `date:` key are represented with quotes instead of without.

This has the side effect that when the file is YAML-parsed, these dates are parsed as `String`s instead of `Date`s, creating an unwanted inconsistency of classes.

This PR normalizes the 3 dates removing the quotes so that they're all parsed as `Date` class.

```ruby
require 'yaml'
yaml = YAML.unsafe_load_file('_data/releases.yml')

# master
yaml.filter_map { |i| i['version'] unless i['date'].is_a?(Date) }
# => ["3.3.8", "3.2.8", "3.1.7"]
yaml.find { |i| i['version'] == '3.2.8' }['date']
# => "2025-03-26"


# this branch
yaml.filter_map { |i| i['version'] unless i['date'].is_a?(Date) }
# => []
yaml.find { |i| i['version'] == '3.2.8' }['date']
# => #<Date: 2025-03-26 ((2460761j,0s,0n),+0s,-Infj)>
```

(see #3375 and #3146 for a similar fix some time ago)