### PR TITLE
Use docs.ruby-lang.org instead of ruby-doc.org

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -206,7 +206,7 @@ These links were more prominent but haven't been updated in ages.
 [27]: https://www.jetbrains.com/ruby/
 [37]: https://www.sublimetext.com/
 [38]: https://learncodethehardway.org/ruby/
-[39]: https://www.ruby-doc.org/
+[39]: https://ruby-doc.org/
 [40]: https://devdocs.io/ruby/
 [42]: https://www.zenspider.com/ruby/quickref.html
 [43]: https://rubyreferences.github.io/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -195,7 +195,7 @@ These links were more prominent but haven't been updated in ages.
 [5]: https://poignant.guide
 [7]: https://www.techotopia.com/index.php/Ruby_Essentials
 [8]: https://pine.fm/LearnToProgram/
-[9]: https://www.ruby-doc.org/docs/ProgrammingRuby/
+[9]: https://ruby-doc.com/docs/ProgrammingRuby/
 [10]: https://pragprog.com/titles/ruby5/programming-ruby-3-3-5th-edition/
 [12]: https://en.wikibooks.org/wiki/Ruby_programming_language
 [16]: https://www.rubydoc.info/

--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -204,7 +204,6 @@ These links were more prominent but haven't been updated in ages.
 [25]: https://www.vim.org/
 [26]: https://github.com/vim-ruby/vim-ruby
 [27]: https://www.jetbrains.com/ruby/
-[34]: https://ruby-doc.org/
 [37]: https://www.sublimetext.com/
 [38]: https://learncodethehardway.org/ruby/
 [39]: https://www.ruby-doc.org/

--- a/ja/documentation/index.md
+++ b/ja/documentation/index.md
@@ -33,13 +33,9 @@ Rubyでプログラミングする際に役立つドキュメントを紹介し�
 
 ### リファレンス
 
-[Ruby コアリファレンス (英語)](http://www.ruby-doc.org/core/)
+[Ruby リファレンス (英語)](https://docs.ruby-lang.org/en/)
 : [RDoc](https://ruby.github.io/rdoc/)を用いてRubyのソースコードから直接生成したものです。
-  String, ArrayやSymbol等のコアクラスやモジュールのリファレンスがあります。
-
-[Ruby 標準ライブラリリファレンス (英語)](http://www.ruby-doc.org/stdlib/)
-: こちらもRDocを使用してRubyのソースコードから生成しています。
-  こちらはRubyの標準ライブラリのリファレンスになります。
+  String, ArrayやSymbol等のコアクラスやモジュールと標準ライブラリのリファレンスがあります。
 
 [RubyDoc.info (英語)](http://www.rubydoc.info/)
 : Ruby gemsやGitHubでホスティングされてるRubyプロジェクトのリファレンスが見れる


### PR DESCRIPTION
from https://bugs.ruby-lang.org/issues/21367

I replaced ruby-doc.org to docs.ruby-lang.org and fixed some dead links.