### PR TITLE
Follow up "Use docs.ruby-lang.org instead of ruby-doc.org"

### DIFF
--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -202,7 +202,7 @@ Ruby를 위한 가장 인기 있는 언어 서버 중 하나이며,
 [5]: https://poignant.guide
 [7]: https://www.techotopia.com/index.php/Ruby_Essentials
 [8]: https://pine.fm/LearnToProgram/
-[9]: https://www.ruby-doc.org/docs/ProgrammingRuby/
+[9]: https://ruby-doc.com/docs/ProgrammingRuby/
 [10]: https://pragprog.com/titles/ruby5/programming-ruby-3-3-5th-edition/
 [12]: https://en.wikibooks.org/wiki/Ruby_programming_language
 [16]: https://www.rubydoc.info/
@@ -211,10 +211,9 @@ Ruby를 위한 가장 인기 있는 언어 서버 중 하나이며,
 [25]: https://www.vim.org/
 [26]: https://github.com/vim-ruby/vim-ruby
 [27]: https://www.jetbrains.com/ruby/
-[34]: https://ruby-doc.org/
 [37]: https://www.sublimetext.com/
 [38]: https://learncodethehardway.org/ruby/
-[39]: https://www.ruby-doc.org/
+[39]: https://ruby-doc.org/
 [40]: https://devdocs.io/ruby/
 [42]: https://www.zenspider.com/ruby/quickref.html
 [43]: https://rubyreferences.github.io/


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461

Follow up #3576