### PR TITLE
Follow up "Fix Exercism anchor text on documentation index"

### DIFF
--- a/ko/documentation/index.md
+++ b/ko/documentation/index.md
@@ -41,7 +41,7 @@ Ruby를 배울 수 있는 매뉴얼과 튜토리얼, 코딩할 때 도움이 되
 [The Odin Project][odin]
 : 오픈소스 풀스택 커리큘럼입니다.
 
-[excercism][exercism]
+[Exercism][exercism]
 : 자동 분석과 개인 멘토링이 포함된 120개의 연습문제가 제공됩니다.
 
 [Codecademy][codecademy]

--- a/zh_tw/documentation/index.md
+++ b/zh_tw/documentation/index.md
@@ -38,7 +38,7 @@ lang: zh_tw
 [The Odin Project][odin]
 : 開源的全端課程。
 
-[excercism][exercism]
+[Exercism][exercism]
 : 包含 120 個題目、自動分析與個人指導。
 
 [Codecademy][codecademy]


### PR DESCRIPTION
:link: #3461

Follow up https://github.com/ruby/www.ruby-lang.org/pull/3575
with this pr:

```
$ git grep '\[excercism\]\[exercism\]'

```

