### PR TITLE
Spelling Fixes in the Spanish Translation of "quickstart" and "to-ruby-from-python"

### DIFF
--- a/es/documentation/quickstart/2/index.md
+++ b/es/documentation/quickstart/2/index.md
@@ -28,9 +28,9 @@ irb(main):012:1> end
 {% endhighlight %}
 
 La expresión `def h` inicia la definición del método. Le dice a Ruby que
-estamos definiendo un método, cuyo nombre es `h`. La siguiente linea es
+estamos definiendo un método, cuyo nombre es `h`. La siguiente línea es
 el cuerpo del método, la misma expresión que vimos anteriormente: `puts
-"Hola Mundo"`. Finalmente, la última linea `end` la dice a Ruby que
+"Hola Mundo"`. Finalmente, la última línea `end` la dice a Ruby que
 terminamos de definir el método. La respuesta de Ruby `=> nil` nos
 comunica que él sabe que terminamos de definir el método.
 
@@ -99,7 +99,7 @@ por defecto `"Mundo"`”.
 
 ¿Qué hacemos si queremos tener un anfitrión más “en serio”? Uno que
 recuerde tu nombre, te dé la bienvenida y te trate con respeto. Puedes
-querer utilizar un objeto para eso. Vamos a crear la clase “Anfitrion”.
+querer utilizar un objeto para eso. Vamos a crear la clase “Anfitrion” (ojo, sin acento)
 
 {% highlight irb %}
 irb(main):024:0> class Anfitrion

--- a/es/documentation/quickstart/4/index.md
+++ b/es/documentation/quickstart/4/index.md
@@ -17,10 +17,10 @@ header: |
 
 ---
 
-Así que, investigando nuestro programa, notarás que las primeras lineas
+Así que, investigando nuestro programa, notarás que las primeras líneas
 comienzan con un numeral (#). En Ruby, todo lo que esté detrás de un
-numeral es un comentario y es ignorado por el intérprete. La primer
-linea del archivo es un caso especial y en los sistemas operativos del
+numeral es un comentario y es ignorado por el intérprete. La primera
+línea del archivo es un caso especial y en los sistemas operativos del
 estilo Unix determina cómo ejecutar el archivo. El resto de los
 comentarios están únicamente para aportar claridad al significado del
 código.
@@ -44,7 +44,7 @@ def decir_hola
 end
 {% endhighlight %}
 
-Ahora usa el atributo `@nombres` para tomar decisiones. Si es nil, sólo
+Ahora usa el atributo `@nombres` para tomar decisiones. Si es `nil`, sólo
 imprime tres puntos. No hay razón para saludar a nadie, ¿cierto?
 
 ## Iterando
@@ -128,7 +128,7 @@ otras listas, todo funcionará como fue planeado.
 
 Así que eso es la clase MegaAnfitrion, el resto del archivo sólo llama a
 los métodos de la clase. Hay un último truco para tener en cuenta, y es
-la linea:
+la línea:
 
 {% highlight ruby %}
 if __FILE__ == $0
@@ -144,10 +144,10 @@ está siendo usado como un ejecutable, entonces ejecuta ese código.
 ## Considérate iniciado
 
 Eso es todo en este rápido paseo por Ruby. Hay mucho más por explorar,
-las estructuras de control diferentes que ofrece Ruby; el uso e los
+las estructuras de control diferentes que ofrece Ruby; el uso de los
 bloques y `yield`; módulos como mixins; y más. Espero que esta pequeña
 muestra de Ruby te despierte el interés por saber más.
 
-Si es así, por favor dirígete a nuestra area de
+Si es así, por favor dirígete a nuestra área de
 [Documentación](/es/documentation/), donde encontrarás vínculos a cursos
 y manuales, todos disponibles gratuitamente en internet.

--- a/es/documentation/quickstart/index.md
+++ b/es/documentation/quickstart/index.md
@@ -55,7 +55,7 @@ irb(main):001:0> "Hola Mundo"
 ## ¡Ruby te obedeció!
 
 ¿Qué fue lo que pasó? ¿Acaso acabamos de escribir el programa “Hola
-Mundo” más corto del mundo? No exactamente. La segunda linea sólo es la
+Mundo” más corto del mundo? No exactamente. La segunda línea sólo es la
 forma que tiene IRB para decirnos el resultado de la última expresión
 evaluada. Si queremos que el programa escriba “Hola Mundo” necesitamos
 un poco más:
@@ -83,7 +83,7 @@ irb(main):003:0> 3+2
 Tres más dos. Bastante fácil. ¿Y qué tal tres *veces* dos? Podrías
 escribirlo, es bastante corto, pero también podrías subir y simplemente
 cambiar lo que ya ingresaste. Prueba presionando la **flecha hacia
-arriba** en tu teclado y verifica si aparece la linea con `3+2` escrito.
+arriba** en tu teclado y verifica si aparece la línea con `3+2` escrito.
 Si es así, puedes usar la **flecha hacia la izquierda** para
 posicionarte junto al signo `+` y cambiarlo por un `*`.
 

--- a/es/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
+++ b/es/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
@@ -22,11 +22,11 @@ salto de línea).
 * Los corchetes son para listas, y las llaves para diccionarios
   (los cuales son llamdos “hashes” en Ruby).
 * Los Arreglos funcionan de forma similar (al sumarlos se hace uno
- mas grande, pero una composición como ésta
+ más grande, pero una composición como esta
  `a3 = [ a1, a2 ]` crea un arreglo de arreglos).
 * Los objetos están fuerte y dinámicamente tipados.
 * Todo es un objeto, las variables son sólo referencias a objetos.
-* Anque las palabras claves son un poco diferentes, las excepciones
+* Aunque las palabras claves son un poco diferentes, las excepciones
   funcionan casi del mismo modo.
 * Tiene herramientas de documentación embebidas (la de Ruby se llama
   RDoc).
@@ -39,16 +39,16 @@ A diferencia de Python, en Ruby...
 
 * Las cadenas son mutables.
 * Puedes tener constantes (variables cuyo valor no pretendes sea modificado).
-* Existen algunas convenciones sobre mayúsculas o minísculas (por ejemplo, los
+* Existen algunas convenciones sobre mayúsculas o minúsculas (por ejemplo, los
   nombres de las clases empiezan con mayúscula, las variables comienzan con
   minúscula).
-* Existe solo un tipo de contenedores para listas (Array), y es mutable.
+* Existe sólo un tipo de contenedores para listas (Array), y es mutable.
 * Las cadenas con doble comilla permiten secuencias de escape (como `\t`)
   y una sintaxis especial de "expresiones de substitución" (lo que permite
   insertar los resultados de una expresión Ruby directamente en otra cadena
   sin tener que `"sumar" + "cadenas " + "con operadores"`). Las cadenas
   con comilla sencilla son idénticas a los `r"raw strings"` de Python.
-* No existe un “nuevo” o “viejo” estilo para definir clases. Solo uno.
+* No existe un “nuevo” o “viejo” estilo para definir clases. Sólo uno.
   (Python 3+ no tiene este problema, pero no es completamente compatible
   con Python 2).
 * Nunca tienes acceso directo a atributos. En Ruby todo se basa en ejecutar
@@ -71,7 +71,7 @@ A diferencia de Python, en Ruby...
 * El estilo habitual de comentarios es *sobre* la(s) línea(s)
   (en vez de los docstrings debajo de estas) para generar la documentación.
 * Hay un cierto número de atajos que, a pesar de que tendrías más cosas
-  que recordar, aprenderas rápido. Estos tienden a hacer Ruby divertido y
+  que recordar, aprenderás rápido. Estos tienden a hacer Ruby divertido y
   muy productivo.
 * No existe una forma de quitar una variable una vez que ha sido establecida
   (como el comando `del` de Python). Puedes poner una variable a `nil`,


### PR DESCRIPTION
With a bit of free time on my hands, I decided to dive into Ruby. While going through the Spanish documentation, I spotted some spelling issues, so I jumped in to help clean things up. **No code examples were changed**—just tweaks to explanations and comments for clarity.