### PR TITLE
Translation of CVE-2025-43857 vulnerability report for net-imap in fr

### DIFF
--- a/fr/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
+++ b/fr/news/_posts/2025-04-28-dos-net-imap-cve-2025-43857.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "CVE-2025-43857 : vulnérabilité DoS dans net-imap"
+author: "nevans"
+translator: Florent Drousset
+date: 2025-04-28 16:02:04 +0000
+tags: security
+lang: fr
+---
+
+Il existe une possibilité d’attaque par déni de service (DoS) dans la gem net-imap.
+Cette vulnérabilité a reçu l’identifiant CVE [CVE-2025-43857].
+Nous recommandons de mettre à jour la gem net-imap.
+
+## Détails
+
+Un serveur malveillant peut envoyer un compteur d’octets « literal » qui est automatiquement lu par le thread récepteur du client.
+Le lecteur de réponses alloue immédiatement la mémoire correspondant au nombre d’octets indiqué par la réponse du serveur.
+Cela ne pose pas de problème lors d’une connexion sécurisée à des serveurs IMAP de confiance et bien configurés.
+En revanche, cela affecte les connexions non sécurisées et les serveurs défectueux, non fiables ou compromis (par exemple, une connexion vers un nom d’hôte fourni par un utilisateur).
+
+Veuillez mettre à jour la gem net-imap vers la version 0.2.5, 0.3.9, 0.4.20, 0.5.7 ou ultérieure.
+
+Lors d’une connexion à des serveurs non fiables ou en utilisant une connexion non sécurisée, il est nécessaire de configurer correctement `max_response_size` et les gestionnaires de réponses afin de limiter la consommation mémoire.
+Voir [GHSA-j3g3-5qv5-52mj] pour plus de détails.
+
+## Versions affectées
+
+Les versions de la gem net-imap affectées sont :
+<= 0.2.4, 0.3.0 à 0.3.8, 0.4.0 à 0.4.19, et 0.5.0 à 0.5.6.
+
+## Crédits
+
+Merci à [Masamune] pour avoir découvert ce problème.
+
+## Historique
+
+* Publié initialement le 2025-04-28 16:02:04 (UTC)
+
+[CVE-2025-43857]:      https://www.cve.org/CVERecord?id=CVE-2025-43857
+[GHSA-j3g3-5qv5-52mj]: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+[Masamune]:            https://hackerone.com/masamune_


### PR DESCRIPTION
Translation of the post 2025-04-28-dos-net-imap-cve-2025-43857.md to french (fr).

Thank you for reviewing my PR.