### PR TITLE
Translate "CVE-2025-58767: DoS vulnerability in REXML" (ko)

### DIFF
--- a/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -1,0 +1,28 @@
+---
+layout: news_post
+title: "CVE-2025-58767: DoS vulnerability in REXML"
+author: "naitoh"
+translator:
+date: 2025-09-18 03:00:00 +0000
+tags: security
+lang: en
+---
+
+There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2025-58767](https://www.cve.org/CVERecord?id=CVE-2025-58767). We strongly recommend upgrading the REXML gem.
+
+## Details
+
+Parsing invalid XML containing multiple XML declarations may cause increased execution time and memory usage.
+Please update REXML gem to version 3.4.2 or later.
+
+## Affected versions
+
+* REXML gem from 3.3.3 to 3.4.1
+
+## Credits
+
+Thanks to [Sofi Aberegg](https://github.com/sofiaaberegg) for discovering this issue.
+
+## History
+
+* Originally published at 2025-09-18 03:00:00 (UTC)

--- a/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -1,28 +1,28 @@
 ---
 layout: news_post
-title: "CVE-2025-58767: DoS vulnerability in REXML"
+title: "CVE-2025-58767: REXML의 DoS 취약점"
 author: "naitoh"
-translator:
+translator: "shia"
 date: 2025-09-18 03:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2025-58767](https://www.cve.org/CVERecord?id=CVE-2025-58767). We strongly recommend upgrading the REXML gem.
+REXML gem에서 DoS 취약점이 발견되었습니다. 이 취약점은 CVE 번호 [CVE-2025-58767](https://www.cve.org/CVERecord?id=CVE-2025-58767)로 등록되었습니다. REXML gem 업그레이드를 강하게 추천합니다.
 
-## Details
+## 세부 내용
 
-Parsing invalid XML containing multiple XML declarations may cause increased execution time and memory usage.
-Please update REXML gem to version 3.4.2 or later.
+여러 XML 선언을 포함하는 잘못된 XML을 파싱하면 실행 시간과 메모리 사용량이 증가할 수 있습니다.
+REXML gem을 3.4.2나 그 이상으로 업데이트하세요.
 
-## Affected versions
+## 해당 버전
 
-* REXML gem from 3.3.3 to 3.4.1
+* REXML gem 3.3.3부터 3.4.1까지
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [Sofi Aberegg](https://github.com/sofiaaberegg) for discovering this issue.
+이 문제를 발견해 준 [Sofi Aberegg](https://github.com/sofiaaberegg)에게 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2025-09-18 03:00:00 (UTC)
+* 2025-09-18 03:00:00 (UTC) 최초 공개


### PR DESCRIPTION
:link: #3461 

Translate https://github.com/ruby/www.ruby-lang.org/pull/3617

Actual diff ca6eb7ae2bd296f60734f0aba26f16381d220a1e
