### PR TITLE
Remove links to scam rubinius website.

### DIFF
--- a/bg/about/index.md
+++ b/bg/about/index.md
@@ -208,7 +208,7 @@ Ruby притежава множество други черти, като ня�
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/de/about/index.md
+++ b/de/about/index.md
@@ -242,7 +242,7 @@ November 2001.
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/en/about/index.md
+++ b/en/about/index.md
@@ -230,7 +230,7 @@ For a more complete list, see [Awesome Rubies][awesome-rubies].
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [truffleruby]: https://github.com/oracle/truffleruby
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net

--- a/es/about/index.md
+++ b/es/about/index.md
@@ -230,7 +230,7 @@ del 2003.
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [truffleruby]: https://github.com/oracle/truffleruby
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net

--- a/id/about/index.md
+++ b/id/about/index.md
@@ -246,7 +246,7 @@ di Ruby, dalam Bahasa Inggris), 22 Desember 2003.
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [sigil]: http://en.wikipedia.org/wiki/Sigil_%28computer_programming%29
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [truffleruby]: https://github.com/oracle/truffleruby
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net

--- a/id/news/_posts/2008-04-07-fresh-overview-dari-rubinius.md
+++ b/id/news/_posts/2008-04-07-fresh-overview-dari-rubinius.md
@@ -26,5 +26,5 @@ Sumber: [Ruby Inside-A Fresh Overview of Rubinius][3]
 
 
 [1]: http://programblings.com/2008/04/01/rubinius-for-the-layman-part-1-rubies-all-the-way-down/
-[2]: http://rubini.us/
+[2]: http://rubinius.com/
 [3]: http://www.rubyinside.com/a-fresh-overview-of-rubinius-835.html

--- a/id/news/_posts/2008-05-19-rubinius-on-rails-rubinius-telah-menjadi-implementasi-ruby-ketiga-yang-menjalankan-rails.md
+++ b/id/news/_posts/2008-05-19-rubinius-on-rails-rubinius-telah-menjadi-implementasi-ruby-ketiga-yang-menjalankan-rails.md
@@ -26,7 +26,7 @@ Run Rails][6]
 
 
 [1]: http://twitter.com/evanphx
-[2]: http://rubini.us/
+[2]: http://rubinius.com/
 [3]: http://blog.fallingsnow.net/2008/05/17/rails-on-rubinius/
 [4]: http://www.chadfowler.com/2008/5/17/ruby-on-rails-on-rubinius
 [5]: http://www.ironruby.net/

--- a/ja/about/index.md
+++ b/ja/about/index.md
@@ -200,7 +200,7 @@ MRI以外のRuby処理系には以下のようなものがあります。
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [truffleruby]: https://github.com/oracle/truffleruby
 [ironruby]: http://www.ironruby.net

--- a/ko/about/index.md
+++ b/ko/about/index.md
@@ -180,7 +180,7 @@ MRI가 지원하지 않는 특별한 기능을 가지거나 합니다.
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/pl/about/index.md
+++ b/pl/about/index.md
@@ -231,7 +231,7 @@ Tu jest lista:
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/pt/about/index.md
+++ b/pt/about/index.md
@@ -242,7 +242,7 @@ Nov. 2001.
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: https://www.tiobe.com/tiobe-index/
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/ru/about/index.md
+++ b/ru/about/index.md
@@ -238,7 +238,7 @@ Ruby как язык имеет несколько разных реализац
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io

--- a/tr/about/index.md
+++ b/tr/about/index.md
@@ -213,7 +213,7 @@ Daha tam bir liste için, [Müthiş Ruby'ler][awesome-rubies]e bakın.
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [truffleruby]: https://github.com/oracle/truffleruby
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net

--- a/zh_cn/about/index.md
+++ b/zh_cn/about/index.md
@@ -147,7 +147,7 @@ Ruby 还有其他众多特性，下面列举一些：
 [artima]: http://www.artima.com/intv/closures2.html
 [tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
 [jruby]: http://jruby.org
-[rubinius]: http://rubini.us
+[rubinius]: http://rubinius.com
 [mruby]: http://www.mruby.org/
 [ironruby]: http://www.ironruby.net
 [maglev]: http://maglev.github.io


### PR DESCRIPTION
The existing url http://rubini.us leads to some sort of SEO scam website, not the actual project page. The updated http://rubinius.com has no real content on it, but is the website linked from the official GitHub repository: https://github.com/rubinius/rubinius so that seems like an improvement.

