### PR TITLE
Translate "The Transition of RubyGems Repository Ownership" (ko)

### DIFF
--- a/ko/news/_posts/2025-10-17-rubygems-repository-transition.md
+++ b/ko/news/_posts/2025-10-17-rubygems-repository-transition.md
@@ -27,6 +27,6 @@ RubyGems와 Bundler는 rubygems.org와 Ruby 생태계를 위한 필수적인 공
 
 지속적인 지원과 기여에 감사드립니다.
 
-Sincerely,
+마음을 담아,
 
 Yukihiro Matsumoto, a.k.a. Matz


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461

Translation of: https://github.com/ruby/www.ruby-lang.org/blob/6751b2d28cdd54ea32f4579ca50688ecd58dfc31/en/news/_posts/2025-10-17-rubygems-repository-transition.md
Actual diff is: dd4f61327