### PR TITLE
Fix CVE-2025-58767's reporter name correctly.

### DIFF
--- a/en/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/en/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -21,7 +21,7 @@ Please update REXML gem to version 3.4.2 or later.
 
 ## Credits
 
-Thanks to [Sofi Aberegg](https://github.com/sofiaaberegg) for discovering this issue.
+Thanks to [Sofia Aberegg](https://github.com/sofiaaberegg) for discovering this issue.
 
 ## History
 

--- a/es/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/es/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -24,7 +24,7 @@ Por favor actualice  la gema REXML a la versión 3.4.2 o posterior.
 
 ## Créditos
 
-Agradecemos a [Sofi Aberegg](https://github.com/sofiaaberegg) por
+Agradecemos a [Sofia Aberegg](https://github.com/sofiaaberegg) por
 descubrir este problema.
 
 ## Historia

--- a/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -21,7 +21,7 @@ REXML gem을 3.4.2나 그 이상으로 업데이트하세요.
 
 ## 도움을 준 사람
 
-이 문제를 발견해 준 [Sofi Aberegg](https://github.com/sofiaaberegg)에게 감사를 표합니다.
+이 문제를 발견해 준 [Sofia Aberegg](https://github.com/sofiaaberegg)에게 감사를 표합니다.
 
 ## 수정 이력
 

--- a/zh_cn/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/zh_cn/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -21,7 +21,7 @@ lang: zh_cn
 
 ## 致谢
 
-感谢 [Sofi Aberegg](https://github.com/sofiaaberegg) 发现此问题。
+感谢 [Sofia Aberegg](https://github.com/sofiaaberegg) 发现此问题。
 
 ## 历史
 

--- a/zh_tw/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
+++ b/zh_tw/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
@@ -24,7 +24,7 @@ lang: zh_tw
 
 ## 致謝
 
-感謝 [Sofi Aberegg](https://github.com/sofiaaberegg) 發現此問題。
+感謝 [Sofia Aberegg](https://github.com/sofiaaberegg) 發現此問題。
 
 ## 歷史
 


### PR DESCRIPTION
On the following CVE-2025-58767 pages, the CVE reporter was written as Sofi Aberegg. However, according to the reporter's GitHub page <https://github.com/sofiaaberegg>, the correct name is Sofia Aberegg.

https://www.ruby-lang.org/en/news/2025/09/18/dos-rexml-cve-2025-58767/
https://www.ruby-lang.org/es/news/2025/09/18/dos-rexml-cve-2025-58767/
https://www.ruby-lang.org/ko/news/2025/09/18/dos-rexml-cve-2025-58767/
https://www.ruby-lang.org/zh_cn/news/2025/09/18/dos-rexml-cve-2025-58767/
https://www.ruby-lang.org/zh_tw/news/2025/09/18/dos-rexml-cve-2025-58767/

I checked the target pages by the following commands.

```
$ grep -rl CVE-2025-58767
.git/logs/HEAD
.git/HEAD
en/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
es/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
zh_cn/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
zh_tw/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md

$ grep -rl 'Sofi Aberegg'
en/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
es/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
ko/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
zh_cn/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
zh_tw/news/_posts/2025-09-18-dos-rexml-cve-2025-58767.md
```
