### PR TITLE
remove discord from community page

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -23,11 +23,6 @@ to start:
   languages. If you have questions about Ruby, asking them on a mailing
   list is a great way to get answers.
 
-[Ruby Discord Server (invite link)][ruby-discord]
-: The Ruby Language Discord Server is a place where you can
-  chat with other Rubyists, get help with Ruby questions, or help others.
-  Discord is a good entry point for new developers and it is easy to join.
-
 [Ruby on IRC (#ruby)](https://web.libera.chat/#ruby)
 : The Ruby Language IRC Channel is a wonderful way to chat with fellow
   Rubyists.
@@ -57,4 +52,3 @@ to start:
 : Ruby Central is a non-profit organization dedicated to supporting the worldwide Ruby community.
 
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh

--- a/fr/community/index.md
+++ b/fr/community/index.md
@@ -25,12 +25,6 @@ Quelques liens à visiter:
   disponibles. Si vous avez des questions sur Ruby, les poser sur une de
   ces listes est un moyen efficace pour obtenir rapidement des réponses.
 
-[Server Discord Ruby (lien d'invitation)][ruby-discord]
-: Le serveur Discord Ruby est un endroit où vous pouvez discuter avec
-  d'autres rubyistes, obtenir de l'aide pour vos questions sur Ruby ou
-  aider les autres. Discord est un bon point d'entrée pour les nouveaux
-  développeurs et il est facile à rejoindre.
-
 [IRC (#ruby)](https://web.libera.chat/#ruby)
 : Le canal IRC anglophone #ruby est un endroit fantastique pour
   discuter en temps réel avec d’autres rubyistes.
@@ -59,6 +53,5 @@ Informations générales
 
 
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh
 [ruby-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
 [rails-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/id/community/index.md
+++ b/id/community/index.md
@@ -24,12 +24,6 @@ untuk memulai petualangan Anda:
   di beberapa bahasa. Jika Anda memiliki pertanyaan terkait Ruby,
   menanyakannya di milis adalah cara yang bagus untuk mendapatkan jawaban.
 
-[Ruby Discord Server (undangan tautan)][ruby-discord]
-: Ruby Language Discord Server adalah sebuah tempat di mana Anda dapat
-  mengobrol dengan Rubyist, mendapatkan bantuan, atau membantu Rubyist lainnya.
-  *Discord* adalah sebuah pintu masuk yang baik bagi pengembang-pengembang baru
-  karena pengembang dapat bergabung dengan mudah.
-
 **Ruby di IRC**
 : Anda bisa berbincang-bincang (*chatting*) dengan pengguna Ruby lainnya
   di *channel* IRC untuk Ruby. Bergabunglah dengan [#ruby](https://web.libera.chat/#ruby) untuk
@@ -73,7 +67,6 @@ Informasi Umum Tentang Ruby
 
 
 
-[ruby-discord]: https://discord.gg/ad2acQFtkh
 [ruby-id-group]: http://tech.groups.yahoo.com/group/id-ruby/
 [ruby-central]: http://rubycentral.org/
 [ruby-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/

--- a/ko/community/index.md
+++ b/ko/community/index.md
@@ -27,11 +27,6 @@ Ruby의 장점, 특징에 대한 설명에서 빠지지 않고 등장하는 것�
 : Ruby는 여러 언어에 걸쳐 다른 주제를 다루는 다양한 메일링 리스트를 가지고 있습니다.
   Ruby에 관해 질문이 있다면, 메일링 리스트에 질문하시면 됩니다.
 
-[Ruby Discord 서버 (초대 링크)][ruby-discord]
-: Ruby 언어 Discord 서버에서 다른 Ruby 사용자와 채팅하고, Ruby 질문을 통해
-  도움을 받고, 다른 사람을 도울 수 있습니다.
-  Discord는 초보 개발자가 시작하기 좋은 곳이고, 참여하기도 쉽습니다.
-
 [IRC에서의 Ruby(#ruby)](https://web.libera.chat/#ruby)
 : Ruby 언어 IRC 채널에서 동료 루비스트와 채팅할 수 있습니다.
 
@@ -58,4 +53,3 @@ Ruby의 장점, 특징에 대한 설명에서 빠지지 않고 등장하는 것�
 : Ruby Central은 전 세계의 Ruby 커뮤니티를 지원하는 비영리 단체입니다.
 
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh

--- a/tr/community/index.md
+++ b/tr/community/index.md
@@ -25,12 +25,6 @@ başlangıç önerisi var:
   e-posta listeleri cevap aramak için başvuracağınız ilk kaynaklardan
   biridir.
 
-[Ruby Discord Sunucusu][ruby-discord] (İngilizce)
-: Ruby Dili Discord Sunucusu, şunları yapabileceğiniz bir ortamdır:
-  Diğer Rubyciler ile konuşma, Ruby sorularınıza yanıt bulma ya da
-  diğerlerine yardım etme. Discord, genç geliştiriciler için iyi bir
-  giriş noktasıdır ve katılması kolaydır.
-
 [Ruby Türkiye Slack Kanalı][ruby-turkiye-slack]
 : Kendi dilinizde sohbet etmek için IRC kanalına alternatif olarak oldukça
   popüler olan bu Slack kanalını da kullanabilirsiniz.
@@ -66,7 +60,6 @@ Genel Ruby Kaynakları
 
 
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh
 [ruby-opendir]: https://dmoztools.net
 [rails-opendir]: https://dmoztools.net
 [ruby-turkiye-slack]: https://rubytr.herokuapp.com/

--- a/zh_tw/community/index.md
+++ b/zh_tw/community/index.md
@@ -20,10 +20,6 @@ lang: zh_tw
 [Ruby 郵件論壇和新聞群組](/zh_tw/community/mailing-lists/)
 : Ruby 擁有各種不同主題及語言的郵件論壇。如果你有 Ruby 的問題，透過論壇發問是個不錯的方式。
 
-[Ruby Discord 伺服器 (邀請連結)][ruby-discord]
-: Ruby 語言 Discord 伺服器是一個你可以與其他 Rubyists 聊天、互助的地方。
-  Discord 對於新開發者是一個很好的進入點，而且很容易加入。
-
 [Ruby 的 IRC (#ruby)][ruby-irc]
 : 您可以在 Ruby 的 IRC 頻道上與其他 Ruby 愛好者聊天。
 
@@ -49,5 +45,4 @@ lang: zh_tw
 [ruby-tw-discord]: https://discord.gg/yaYHWQsmcz
 [ruby-irc]: https://web.libera.chat/#ruby
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh
 [rubyvideo]: https://rubyvideo.dev


### PR DESCRIPTION
The Ruby Discord community isn’t limited to the one linked from the community page and there are plenty of other ones. The listed one isn't official, so in the name of fairness, I don't think it should be promoted on this website, unless we add all of them and people can freely choose which one they would prefer to join.