### PR TITLE
Remove link to Discord

### DIFF
--- a/en/community/index.md
+++ b/en/community/index.md
@@ -23,11 +23,6 @@ to start:
   languages. If you have questions about Ruby, asking them on a mailing
   list is a great way to get answers.
 
-[Ruby Discord Server (invite link)][ruby-discord]
-: The Ruby Language Discord Server is a place where you can
-  chat with other Rubyists, get help with Ruby questions, or help others.
-  Discord is a good entry point for new developers and it is easy to join.
-
 [Ruby on IRC (#ruby)](https://web.libera.chat/#ruby)
 : The Ruby Language IRC Channel is a wonderful way to chat with fellow
   Rubyists.
@@ -57,4 +52,3 @@ to start:
 : Ruby Central is a non-profit organization dedicated to supporting the worldwide Ruby community.
 
 [ruby-central]: http://rubycentral.org/
-[ruby-discord]: https://discord.gg/ad2acQFtkh


### PR DESCRIPTION
Given Ruby core isn't willing to make calls about proper or improper moderation in this Discord server (see https://github.com/ruby/www.ruby-lang.org/pull/3639#issuecomment-3432951293), it should not be recommending it in its website.

Having links listed here make them look official, vetted and endorsed by the Ruby Core, which I don't believe it is the case.

While I agree with not accepting the other PR to add additional server, the reason to reject that one should apply to also not have the existent one.

If it isn't official, it doesn't belongs here.