### PR TITLE
Translate "Ruby 3.3.10 Released" (ko)

### DIFF
--- a/ko/news/_posts/2025-10-23-ruby-3-3-10-released.md
+++ b/ko/news/_posts/2025-10-23-ruby-3-3-10-released.md
@@ -1,20 +1,20 @@
 ---
 layout: news_post
-title: "Ruby 3.3.10 Released"
+title: "Ruby 3.3.10 릴리스"
 author: nagachika
-translator:
+translator: "shia"
 date: 2025-10-23 11:00:00 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.3.10 has been released.
+Ruby 3.3.10이 릴리스되었습니다.
 
-This release includes [an update to the uri gem addressing CVE-2025-61594](https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/),
-along with other bug fixes. Please refer to [the release notes on GitHub](https://github.com/ruby/ruby/releases/tag/v3_3_10) for further details.
+이 릴리스는 [CVE-2025-61594에 대응하는 uri gem 업데이트](https://www.ruby-lang.org/ko/news/2025/10/07/uri-cve-2025-61594/) 및
+기타 버그 수정이 포함되어 있습니다. 자세한 내용은 [GitHub 릴리스 노트](https://github.com/ruby/ruby/releases/tag/v3_3_10)를 참조하세요.
 
-We recommend updating your version of the uri gem. This release has been made for the convenience of those who wish to continue using it as a default gem.
+uri gem을 업데이트할 것을 권장합니다. 이 릴리스는 기본 gem으로 계속 사용하려는 분들의 편의를 위해 제공됩니다.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.3.10" | first %}
 
@@ -39,7 +39,7 @@ We recommend updating your version of the uri gem. This release has been made fo
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461

Translation of: #3656

Actual diff e9e3a34c3cdd644a584070b929190f58b9df996e