### PR TITLE
Translate Ruby 3.3.10 Released (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2025-10-23-ruby-3-3-10-released.md
+++ b/zh_tw/news/_posts/2025-10-23-ruby-3-3-10-released.md
@@ -1,0 +1,45 @@
+---
+layout: news_post
+title: "Ruby 3.3.10 發布"
+author: nagachika
+translator: "Bear Su"
+date: 2025-10-23 11:00:00 +0000
+lang: zh_tw
+---
+
+Ruby 3.3.10 已經發布了。
+
+本次發布包含 [修復 CVE-2025-61594 的 uri gem 更新](https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/)，與修復其他小型錯誤。
+
+詳細的變動請參閱 [GitHub 發布](https://github.com/ruby/ruby/releases/tag/v3_3_10)。
+
+我們建議更新您的 uri gem 版本。本次發布是為了方便那些希望繼續將其作為預設 gem 的使用者。
+
+## 下載
+
+{% assign release = site.data.releases | where: "version", "3.3.10" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 發布紀錄
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發布，在此感謝所有人的貢獻。


### PR DESCRIPTION
Translate Ruby 3.3.10 Released (zh_tw)

Thank you.