### PR TITLE
Restore missing link to Ruby Central in the "Ruby Conferences"

### DIFF
--- a/en/community/conferences/index.md
+++ b/en/community/conferences/index.md
@@ -40,5 +40,6 @@ You can also find the GitHub repository link there to add or update information 
 
 [rc]: https://www.rubyevents.org/
 [1]: http://rubyconf.org/
+[2]: http://rubycentral.org/
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org


### PR DESCRIPTION
<img width="711" height="374" alt="image" src="https://github.com/user-attachments/assets/b69a13e4-98a7-4f64-826c-e8569e91b5e1" />
