### PR TITLE
Added a release date format check to the linter

### DIFF
--- a/lib/linter.rb
+++ b/lib/linter.rb
@@ -125,6 +125,7 @@ class Linter
       errors[release] << invalid_url_message(release.post)  if release.post_url_invalid?
       errors[release] << "release date and post date do not match"  if release.date_mismatch?
       errors[release] << missing_post_message(release.post_filename)  if release.post_missing?
+      errors[release] << "release date is a string, not a Date object"  if release.date.is_a?(String)
     end
   end
 

--- a/test/test_linter_invalid_release_data.rb
+++ b/test/test_linter_invalid_release_data.rb
@@ -57,4 +57,15 @@ describe Linter do
     create_file("_data/releases.yml", content)
     _(linter_output).must_match "release date and post date do not match"
   end
+
+  it "reports release data with wrong date format" do
+    content = <<~YAML
+      - version: 2.7.1
+        date: '2020-01-01'
+        post: /en/news/2020/01/01/post/
+    YAML
+
+    create_file("_data/releases.yml", content)
+    _(linter_output).must_match "release date is a string, not a Date object"
+  end
 end


### PR DESCRIPTION
Historically, [releases.yml](https://github.com/ruby/www.ruby-lang.org/blob/master/_data/releases.yml) included dates of the Ruby releases in a format compatible with YAML decoder. In the past few releases, specifically 3.2.9, 3.3.9 and 3.3.10, dates are encoded as strings. Loading the file now with `permitted_classes: [Date]` results in a date being a string instead of `Date` object for just the 3 releases mentioned.

This merge request introduces a linter check to catch such discrepancies:

```
$ bundle exec rake lint
Checking markdown files...
Ruby 3.2.9 release data (in `_data/releases.yml')
  release date is a string, not a Date object
Ruby 3.3.10 release data (in `_data/releases.yml')
  release date is a string, not a Date object
Ruby 3.3.9 release data (in `_data/releases.yml')
  release date is a string, not a Date object
```

The data has been normalized in https://github.com/ruby/www.ruby-lang.org/pull/3672 (and [not](https://github.com/ruby/www.ruby-lang.org/pull/3566) for the [first](https://github.com/ruby/www.ruby-lang.org/pull/3375) [time](https://github.com/ruby/www.ruby-lang.org/pull/3146)). Linter rule will prevent this from happening in the future.