### PR TITLE
[Data] Normalize all dates to Date instead of String

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -339,7 +339,7 @@
 # 3.3 series
 
 - version: 3.3.10
-  date: '2025-10-23'
+  date: 2025-10-23
   post: "/en/news/2025/10/23/ruby-3-3-10-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.10.tar.gz
@@ -363,7 +363,7 @@
     zip: 70ee931fe6ceca0f105e270c882fc019299450fbe75b3da4cadc14a544270eda876eb8cba47a164cac2ada3116b70e6c24efa7061ceab62c1d4af20a16caaf35
 
 - version: 3.3.9
-  date: '2025-07-24'
+  date: 2025-07-24
   post: "/en/news/2025/07/24/ruby-3-3-9-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.9.tar.gz
@@ -727,7 +727,7 @@
 # 3.2 series
 
 - version: 3.2.9
-  date: '2025-07-24'
+  date: 2025-07-24
   post: "/en/news/2025/07/24/ruby-3-2-9-released/"
   url:
     gz: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz


### PR DESCRIPTION
In `_data/releases.yml`, 3 of the total 229 dates under the `date:` key are written with quotes instead of without quotes.

This has the side effect that when the file is YAML-parsed, these dates are parsed as `String`s instead of `Date`s, creating an unwanted inconsistency of classes.

This PR normalizes the 3 dates removing the quotes so that they're all parsed as `Date` class.

```ruby
require 'yaml'
yaml = YAML.unsafe_load_file('_data/releases.yml')

# master
yaml.filter_map { |i| i['version'] unless i['date'].is_a?(Date) }
# => ["3.3.10", "3.3.9", "3.2.9"]
yaml.find { |i| i['version'] == '3.3.9' }['date']
# => "2025-07-24"


# this branch
yaml.filter_map { |i| i['version'] unless i['date'].is_a?(Date) }
# => []
yaml.find { |i| i['version'] == '3.3.9' }['date']
# => #<Date: 2025-07-24 ((2460881j,0s,0n),+0s,-Infj)>
```

(see #3566, #3375 and #3146 for the same fix some time ago)