### PR TITLE
Ruby 4.0.0 preview2 uses Unicode version 17.0

### DIFF
--- a/en/news/_posts/2025-11-17-ruby-4-0-0-preview2-released.md
+++ b/en/news/_posts/2025-11-17-ruby-4-0-0-preview2-released.md
@@ -8,7 +8,7 @@ lang: en
 ---
 
 {% assign release = site.data.releases | where: "version", "4.0.0-preview2" | first %}
-We are pleased to announce the release of Ruby {{ release.version }}. Ruby 4.0 updates its Unicode version to 15.1.0, and so on.
+We are pleased to announce the release of Ruby {{ release.version }}. Ruby 4.0 updates its Unicode version to 17,0.0, and so on.
 
 ## Language changes
 
@@ -32,7 +32,7 @@ Note: We're only listing notable updates of Core class.
 
 * String
 
-    * Update Unicode to Version 15.1.0 and Emoji Version 15.1. [[Feature #19908]]
+    * Update Unicode to Version 17.0.0 and Emoji Version 17.0. [[Feature #19908]][[Feature #20724]][[Feature #21275]]
         (also applies to Regexp)
 
 

--- a/ja/news/_posts/2025-11-17-ruby-4-0-0-preview2-released.md
+++ b/ja/news/_posts/2025-11-17-ruby-4-0-0-preview2-released.md
@@ -8,7 +8,7 @@ lang: ja
 ---
 
 {% assign release = site.data.releases | where: "version", "4.0.0-preview2" | first %}
-Ruby {{ release.version }} が公開されました。Ruby 4.0では、Unicodeバージョンの15.1.0へのアップデートなど様々な改善が行われています。
+Ruby {{ release.version }} が公開されました。Ruby 4.0では、Unicodeバージョンの17.0.0へのアップデートなど様々な改善が行われています。
 
 
 
@@ -36,7 +36,7 @@ Ruby {{ release.version }} が公開されました。Ruby 4.0では、Unicode�
 
 * String
 
-    * Update Unicode to Version 15.1.0 and Emoji Version 15.1. [[Feature #19908]]
+    * Update Unicode to Version 17.0.0 and Emoji Version 17.0. [[Feature #19908]][[Feature #20724]][[Feature #21275]]
         (also applies to Regexp)
 
 


### PR DESCRIPTION
This pull request updates the Unicode version used in the Ruby 4.0.0 preview2 Released announcements.

https://www.ruby-lang.org/en/news/2025/11/17/ruby-4-0-0-preview2-released/
https://www.ruby-lang.org/ja/news/2025/11/17/ruby-4-0-0-preview2-released/

Ref https://github.com/ruby/ruby/pull/15170

```
$ ruby -v -e 'p RbConfig::CONFIG["UNICODE_VERSION"]'
ruby 4.0.0preview2 (2025-11-17 master 4fa6e9938c) +PRISM [x86_64-linux]
"17.0.0"
$ ruby -v -e 'p RbConfig::CONFIG["UNICODE_EMOJI_VERSION"]'
ruby 4.0.0preview2 (2025-11-17 master 4fa6e9938c) +PRISM [x86_64-linux]
"17.0"
```