### PR TITLE
Restore missing link to Ruby Central in the "Ruby Conferences" (ko)

### DIFF
--- a/ko/community/conferences/index.md
+++ b/ko/community/conferences/index.md
@@ -39,6 +39,6 @@ Ruby에 대한 콘퍼런스 목록입니다. 이곳에서는 행사일, 장소, 
 
 [rc]: https://www.rubyevents.org/
 [1]: http://rubyconf.org/
-[2]: http://rubycentral.org/
+[2]: https://rubycentral.org/
 [3]: http://rubykaigi.org/
 [4]: http://euruko.org


### PR DESCRIPTION
:link: #3461

Follow up #3666