### PR TITLE
Update translation for es/community

### DIFF
--- a/es/community/index.md
+++ b/es/community/index.md
@@ -10,11 +10,11 @@ amigable a todas las personas sin discriminarlas por su nivel de
 habilidades.
 {: .summary}
 
-Si estás interesado en involucrarte, aquí tienes algunos lugares por
+Si te interesa involucrarte, aquí tienes algunos lugares por
 donde empezar:
 
 [Grupos de usuarios](/es/community/user-groups/)
-: El grupo de usuarios de tu localidad es un buen lugar donde establecer
+: Tu grupo de usuarios local es un buen lugar donde establecer
   contacto con otros desarrolladores Ruby. Estos grupos se están
   autogestionando y típicamente realizan reuniones mensuales, y/o tienen
   listas de correo, un sitio web y si tienes suerte, fiestas de
@@ -25,18 +25,23 @@ donde empezar:
   idiomas. Si tienes preguntas acerca de Ruby, una buena forma de
   obtener respuestas es preguntarlas en una lista de correo.
 
+[Servidor de Discord de Ruby (invitación)](https://discord.gg/ad2acQFtkh)
+: El servidor de Discord del lenguaje Ruby es un lugar donde puedes chatear
+  con otros Rubyistas, obtener ayuda con preguntas de Ruby o ayudar a otras personas.
+  Discord es un buen punto de reunión para desarrolladores y es fácil unirse.
+
 [Ruby en IRC (#ruby)](https://web.libera.chat/#ruby)
 : El canal IRC The Ruby Language es un buen lugar para chatear con otros
   compañeros Rubyistas.
 
 [El Core de Ruby](/es/community/ruby-core/)
-: Con Ruby 2.0 en camino, ahora es un buen momento para seguir cómo va
-  su desarrollo. Si estás interesado en ayudar con Ruby, comienza por
-  aquí.
+: Ahora es un momento fantástico para seguir el desarrollo de Ruby.
+  Si te interesa ayudar con Ruby, comienza por aquí.
 
-[Blogs sobre Ruby](/en/community/weblogs/) (en inglés)
-: Es muy poco lo que sucede en la comunidad Ruby y no se comenta en los
-  blogs. Tenemos una gran lista de sugerencias para que te suscribas.
+[Blogs y boletines de correo sobre Ruby](/en/community/weblogs/) (en inglés)
+: La mayoría de las actividades y actualizaciones en la comunidad de Ruby
+  se discuten en blogs y boletines de correo. Aquí hay una lista revisada
+  para que puedas conectarte e informarte.
 
 [Conferencias sobre Ruby](/en/community/conferences/) (en inglés)
 : Los desarrolladores Ruby de todo el mundo se están involucrando cada
@@ -44,19 +49,18 @@ donde empezar:
   experiencias en sus desarrollos, discutir sobre el futuro de Ruby, y
   dar una bienvenida a los recién llegados a la comunidad Ruby.
 
+  Además, puedes visitar [RubyEvents.org](https://www.rubyevents.org/) para
+  encontrar vídeos de conferencias y charlas de Ruby.
+
 [Podcasts](podcasts/)
 : Si prefieres escuchar conversaciones sobre Ruby en lugar de leer,
   puedes sintonizar uno de estos increíbles podcast de Ruby. Estos Rubistas
   usan sus podcast para cubrir nuevos lanzamientos, noticias de la comunidad y
   entrevistar a sus compañeros desarrolladores de Ruby.
 
-Información general sobre Ruby
-: * [Ruby Central][ruby-central]
-  * [Ruby en el Open Directory Project][ruby-opendir]
-  * [Rails en el Open Directory Project][rails-opendir]
+[Ruby Central][ruby-central]
+: Ruby Central es una organización sin ánimo de lucro dedicada a apoyar a la comunidad global de Ruby.
 
 
 
 [ruby-central]: http://rubycentral.org/
-[ruby-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
-[rails-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/


### PR DESCRIPTION
I originally intended to just update the translation for the _Ruby Core_ paragraph to update the wording. It still said that Ruby 2.0 was underway. This was removed from the English version in commit 6587577efe17df2b57f02a838f5380af9a38943c, more than 12 years ago.

While I was at it, I've made a quick side by side comparison between the English and the Spanish page and also made a few minor updates to other parts of this page:

- Added the Discord server paragraph.
- The "weblogs about Ruby" was now "weblogs and newsletters about Ruby"
- Added link to RubyEvents
- Removed links to DMOZ (deadlinks not present anymore in the English version)

(Just in case I need to clarify: no computers were used to choose the translations, a human brain wrote the words.)