### PR TITLE
Rename v4_0_0_preview2 to v4.0.0-preview2

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -24,7 +24,7 @@
 - version: 4.0.0-preview2
   date: 2025-11-17
   post: /en/news/2025/11/17/ruby-4-0-0-preview2-released/
-  tag: v4_0_0_preview2
+  tag: v4.0.0-preview2
   stats:
     files_changed: 3607
     insertions: 197451


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21774

The `v4_0_0_preview2` git tag has been renamed to `v4.0.0-preview2`.