### PR TITLE
Fix broken links in Ruby 4.0.0-preview3 release pages

### DIFF
--- a/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -14,7 +14,7 @@ Ruby 4.0 introduces Ruby::BOX and "ZJIT", and adds many improvements.
 ## Ruby::BOX
 
 A new (experimental) feature to provide separation about definitions.
-For the detail of "Ruby Box", see [doc/language/box.md](doc/language/box.md).
+For the detail of "Ruby Box", see [doc/language/box.md](https://github.com/ruby/ruby/blob/master/doc/language/box.md).
 [[Feature #21311]] [[Misc #21385]]
 
 ## Language changes
@@ -175,7 +175,7 @@ Note: We're only listing outstanding class updates.
 * Ruby::Box
 
     * A new (experimental) feature to provide separation about definitions.
-      For the detail of "Ruby Box", see [doc/language/box.md](doc/language/box.md).
+      For the detail of "Ruby Box", see [doc/language/box.md](https://github.com/ruby/ruby/blob/master/doc/language/box.md).
       [[Feature #21311]] [[Misc #21385]]
 
 * Set

--- a/ja/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/ja/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -133,7 +133,7 @@ Ruby {{ release.version }} が公開されました。
 
 * Ruby::Box
 
-    * 定義の分離を提供するための新しい (実験的な) 機能です。"Ruby Box" の詳細については、[doc/language/box.md](doc/language/box.md) を参照してください。
+    * 定義の分離を提供するための新しい (実験的な) 機能です。"Ruby Box" の詳細については、[doc/language/box.md](https://github.com/ruby/ruby/blob/master/doc/language/box.md) を参照してください。
       [[Feature #21311]] [[Misc #21385]]
 
 * Set


### PR DESCRIPTION
`docs/language/box.md` is a path in the ruby/ruby repository, not a relative path from www.ruby-lang.org.