### PR TITLE
Use `Ruby::Box` instead of `Ruby::BOX`

### DIFF
--- a/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -9,9 +9,9 @@ lang: en
 
 {% assign release = site.data.releases | where: "version", "4.0.0-preview3" | first %}
 We are pleased to announce the release of Ruby {{ release.version }}.
-Ruby 4.0 introduces Ruby::BOX and "ZJIT", and adds many improvements.
+Ruby 4.0 introduces Ruby::Box and "ZJIT", and adds many improvements.
 
-## Ruby::BOX
+## Ruby::Box
 
 A new (experimental) feature to provide separation about definitions.
 For the detail of "Ruby Box", see [doc/language/box.md](https://github.com/ruby/ruby/blob/master/doc/language/box.md).


### PR DESCRIPTION
`Ruby::Box` (or “Ruby Box”) appears to be the appropriate notation. This PR updates the wording to `Ruby::Box` to match the following Japanese document:
https://github.com/ruby/www.ruby-lang.org/blob/master/ja/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md