### PR TITLE
Update generateTryRubyUrl to remove engine version

### DIFF
--- a/javascripts/try-ruby-examples.js
+++ b/javascripts/try-ruby-examples.js
@@ -23,7 +23,7 @@ var TryRubyExamples = {
 
   generateTryRubyUrl: function(code) {
     var encodedCode = encodeURIComponent(code);
-    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode + '&engine=cruby-3.3.0';
+    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode;
   },
 
   onExampleLoaded: function() {


### PR DESCRIPTION
Currently, the Try Ruby link is hardcoded to use the Ruby 3.3.0 engine.

It would be better to remove the engine parameter so it always runs with the latest available engine.

I have confirmed that Try Ruby uses the latest version of CRuby by default.
https://github.com/ruby/TryRuby/blob/160a65252987348a1a0ad7b33d2b627292a984e4/app/try_ruby.rb#L19