### PR TITLE
Use CRuby 3.4 to run example codes

### DIFF
--- a/javascripts/try-ruby-examples.js
+++ b/javascripts/try-ruby-examples.js
@@ -23,7 +23,7 @@ var TryRubyExamples = {
 
   generateTryRubyUrl: function(code) {
     var encodedCode = encodeURIComponent(code);
-    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode + '&engine=cruby-3.3.0';
+    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode + '&engine=cruby-3.4.1';
   },
 
   onExampleLoaded: function() {


### PR DESCRIPTION
TryRuby supports CRuby 3.4. So let's use the latest version. Ref: https://github.com/ruby/TryRuby/pull/216