### PR TITLE
Remove engine pin for TryRuby

### DIFF
--- a/javascripts/try-ruby-examples.js
+++ b/javascripts/try-ruby-examples.js
@@ -23,7 +23,7 @@ var TryRubyExamples = {
 
   generateTryRubyUrl: function(code) {
     var encodedCode = encodeURIComponent(code);
-    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode + '&engine=cruby-3.3.0';
+    return 'https://try.ruby-lang.org/playground/#code=' + encodedCode;
   },
 
   onExampleLoaded: function() {


### PR DESCRIPTION
https://github.com/ruby/TryRuby/blob/master/app/try_ruby.rb#L19

TryRuby now uses Ruby `3.4.1` as a default engine. I didn't see a good reason to use older Ruby, `3.3.0` here, so I removed that part.