### PR TITLE
Don't mutate a string literal in main code sample

### DIFF
--- a/bg/examples/i_love_ruby.md
+++ b/bg/examples/i_love_ruby.md
@@ -8,7 +8,7 @@ say = "I love Ruby"
 puts say
 
 # Output "I *LOVE* RUBY"
-say['love'] = "*love*"
+say = say.sub("love", "*love*")
 puts say.upcase
 
 # Output "I *love* Ruby"


### PR DESCRIPTION
I know this is still being debated, but as of the current version of Ruby, the first code sample does emit a deprecation warning (hidden by default but still).

I think it's would be better to not mutate a string literal.