### PR TITLE
Remove Ruby 3.5 from branches.yml

### DIFF
--- a/_data/branches.yml
+++ b/_data/branches.yml
@@ -13,11 +13,6 @@
   date:
   eol_date:
 
-- name: 3.5
-  status: preview
-  date:
-  eol_date:
-
 - name: 3.4
   status: normal maintenance
   date: 2024-12-25


### PR DESCRIPTION
On the "Ruby Maintenance Branches" page, both Ruby 3.5 and Ruby 4.0 are listed as branches:
https://www.ruby-lang.org/en/downloads/branches/

Ruby 3.5 was renamed to Ruby 4.0, so there is no separate maintenance policy for Ruby 3.5. Similar to the relationship between Ruby 2.8 and Ruby 3.0, Ruby 3.5 should be removed and only Ruby 4.0 should remain.