### PR TITLE
Add 'and' to MINASWAN motto translations

### DIFF
--- a/_data/locales/home/bg.yml
+++ b/_data/locales/home/bg.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Разработчици от цял свят се подкрепят взаимно.<br />Топла, активна общност.
       copy: |
-        Общността на Ruby приема културата "Matz is nice so we are nice (MINASWAN)",
+        Общността на Ruby приема културата "Matz is nice and so we are nice (MINASWAN)",
         приветствайки всички от начинаещи до експерти. Конференции и срещи по целия свят насърчават споделянето на знания и връзките.
         Това е топла, устойчива общност, където хората си помагат взаимно и растат заедно.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Универсалният девиз е"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Научете повече за общността"
       url: "/community/"

--- a/_data/locales/home/de.yml
+++ b/_data/locales/home/de.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Entwickler weltweit unterstützen sich gegenseitig.<br />Eine herzliche, aktive Community.
       copy: |
-        Die Ruby-Community pflegt die Kultur von "Matz is nice so we are nice (MINASWAN)"
+        Die Ruby-Community pflegt die Kultur von "Matz is nice and so we are nice (MINASWAN)"
         und heißt jeden willkommen, vom Anfänger bis zum Experten. Konferenzen und Meetups auf der ganzen Welt fördern den Wissensaustausch und Verbindungen.
         Es ist eine herzliche, nachhaltige Community, in der sich Menschen gegenseitig helfen und gemeinsam wachsen.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Das universelle Motto ist"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Mehr über die Community erfahren"
       url: "/community/"

--- a/_data/locales/home/en.yml
+++ b/_data/locales/home/en.yml
@@ -72,7 +72,7 @@ why_ruby:
       title: Community
       read: Developers worldwide support each other.<br />A warm, active community.
       copy: |
-        The Ruby community embraces the culture of "Matz is nice so we are nice (MINASWAN),"
+        The Ruby community embraces the culture of "Matz is nice and so we are nice (MINASWAN),"
         welcoming everyone from beginners to experts. Conferences and meetups around the world foster knowledge sharing and connections.
         It's a warm, sustainable community where people help each other and grow together.
       comment:
@@ -97,7 +97,7 @@ community:
   motto_prefix: "The universal motto is"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Learn more about the community"
       url: "/community/"

--- a/_data/locales/home/es.yml
+++ b/_data/locales/home/es.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Desarrolladores de todo el mundo se apoyan mutuamente.<br />Una comunidad cálida y activa.
       copy: |
-        La comunidad Ruby abraza la cultura de "Matz is nice so we are nice (MINASWAN),"
+        La comunidad Ruby abraza la cultura de "Matz is nice and so we are nice (MINASWAN),"
         dando la bienvenida a todos desde principiantes hasta expertos. Conferencias y meetups alrededor del mundo fomentan el intercambio de conocimientos y conexiones.
         Es una comunidad cálida y sostenible donde las personas se ayudan mutuamente y crecen juntas.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "El lema universal es"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Aprende más sobre la comunidad"
       url: "/community/"

--- a/_data/locales/home/fr.yml
+++ b/_data/locales/home/fr.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Des développeurs du monde entier se soutiennent mutuellement.<br />Une communauté chaleureuse et active.
       copy: |
-        La communauté Ruby embrasse la culture de "Matz is nice so we are nice (MINASWAN),"
+        La communauté Ruby embrasse la culture de "Matz is nice and so we are nice (MINASWAN),"
         accueillant tout le monde des débutants aux experts. Des conférences et des meetups dans le monde entier favorisent le partage des connaissances et les connexions.
         C'est une communauté chaleureuse et durable où les gens s'entraident et grandissent ensemble.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "La devise universelle est"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "En savoir plus sur la communauté"
       url: "/community/"

--- a/_data/locales/home/id.yml
+++ b/_data/locales/home/id.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Developer di seluruh dunia saling mendukung.<br />Komunitas yang hangat dan aktif.
       copy: |
-        Komunitas Ruby menganut budaya "Matz is nice so we are nice (MINASWAN),"
+        Komunitas Ruby menganut budaya "Matz is nice and so we are nice (MINASWAN),"
         menyambut semua orang dari pemula hingga ahli. Konferensi dan meetup di seluruh dunia mendorong berbagi pengetahuan dan koneksi.
         Ini adalah komunitas yang hangat dan berkelanjutan di mana orang-orang saling membantu dan tumbuh bersama.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Motto universal adalah"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Pelajari lebih lanjut tentang komunitas"
       url: "/community/"

--- a/_data/locales/home/it.yml
+++ b/_data/locales/home/it.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Sviluppatori di tutto il mondo si supportano a vicenda.<br />Una comunità calorosa e attiva.
       copy: |
-        La comunità Ruby abbraccia la cultura di "Matz is nice so we are nice (MINASWAN),"
+        La comunità Ruby abbraccia la cultura di "Matz is nice and so we are nice (MINASWAN),"
         accogliendo tutti dai principianti agli esperti. Conferenze e meetup in tutto il mondo favoriscono la condivisione delle conoscenze e le connessioni.
         È una comunità calorosa e sostenibile dove le persone si aiutano a vicenda e crescono insieme.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Il motto universale è"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Scopri di più sulla comunità"
       url: "/community/"

--- a/_data/locales/home/ja.yml
+++ b/_data/locales/home/ja.yml
@@ -71,7 +71,7 @@ why_ruby:
       title: Community
       read: 世界中の開発者が支え合う。<br />温かく、活発なコミュニティ。
       copy: |
-        Rubyコミュニティは「Matz is nice so we are nice（Matzが優しいから私たちも優しい）」という文化を持ち、
+        Rubyコミュニティは「Matz is nice and so we are nice（Matzが優しいから私たちも優しい）」という文化を持ち、
         初心者から熟練者まで歓迎する雰囲気があります。世界各地でカンファレンスやミートアップが開催され、知識の共有や交流が盛んです。
         困ったときには助け合い、共に成長していく、温かく持続可能なコミュニティです。
       comment:
@@ -96,7 +96,7 @@ community:
   motto_prefix: "世界共通の合言葉は"
   motto_minaswan: "MINASWAN"
   motto_separator: "──"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "コミュニティについて詳しく"
       url: "/community/"

--- a/_data/locales/home/ko.yml
+++ b/_data/locales/home/ko.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: 전 세계의 개발자들이 서로를 지원합니다.<br />따뜻하고 활발한 커뮤니티.
       copy: |
-        Ruby 커뮤니티는 "Matz is nice so we are nice (MINASWAN)" 문화를 받아들여,
+        Ruby 커뮤니티는 "Matz is nice and so we are nice (MINASWAN)" 문화를 받아들여,
         초보자부터 전문가까지 모두를 환영합니다. 전 세계의 컨퍼런스와 밋업은 지식 공유와 연결을 장려합니다.
         사람들이 서로 돕고 함께 성장하는 따뜻하고 지속 가능한 커뮤니티입니다.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "보편적인 모토는"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "커뮤니티에 대해 더 알아보기"
       url: "/community/"

--- a/_data/locales/home/pl.yml
+++ b/_data/locales/home/pl.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Programiści na całym świecie wspierają się nawzajem.<br />Ciepła, aktywna społeczność.
       copy: |
-        Społeczność Ruby przyjmuje kulturę "Matz is nice so we are nice (MINASWAN),"
+        Społeczność Ruby przyjmuje kulturę "Matz is nice and so we are nice (MINASWAN),"
         witając wszystkich od początkujących po ekspertów. Konferencje i spotkania na całym świecie sprzyjają dzieleniu się wiedzą i nawiązywaniu kontaktów.
         To ciepła, zrównoważona społeczność, gdzie ludzie pomagają sobie nawzajem i rozwijają się razem.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Uniwersalne motto to"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Dowiedz się więcej o społeczności"
       url: "/community/"

--- a/_data/locales/home/pt.yml
+++ b/_data/locales/home/pt.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Desenvolvedores em todo o mundo se apoiam mutuamente.<br />Uma comunidade calorosa e ativa.
       copy: |
-        A comunidade Ruby abraça a cultura de "Matz is nice so we are nice (MINASWAN),"
+        A comunidade Ruby abraça a cultura de "Matz is nice and so we are nice (MINASWAN),"
         dando boas-vindas a todos, desde iniciantes até especialistas. Conferências e meetups ao redor do mundo promovem o compartilhamento de conhecimento e conexões.
         É uma comunidade calorosa e sustentável onde as pessoas se ajudam mutuamente e crescem juntas.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "O lema universal é"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Saiba mais sobre a comunidade"
       url: "/community/"

--- a/_data/locales/home/ru.yml
+++ b/_data/locales/home/ru.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Разработчики по всему миру поддерживают друг друга.<br />Теплое, активное сообщество.
       copy: |
-        Сообщество Ruby придерживается культуры "Matz is nice so we are nice (MINASWAN)",
+        Сообщество Ruby придерживается культуры "Matz is nice and so we are nice (MINASWAN)",
         приветствуя всех от новичков до экспертов. Конференции и встречи по всему миру поощряют обмен знаниями и связи.
         Это теплое, устойчивое сообщество, где люди помогают друг другу и растут вместе.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Универсальный девиз"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Узнайте больше о сообществе"
       url: "/community/"

--- a/_data/locales/home/tr.yml
+++ b/_data/locales/home/tr.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Dünyanın dört bir yanındaki geliştiriciler birbirlerini destekler.<br />Sıcak, aktif bir topluluk.
       copy: |
-        Ruby topluluğu "Matz is nice so we are nice (MINASWAN)" kültürünü benimser,
+        Ruby topluluğu "Matz is nice and so we are nice (MINASWAN)" kültürünü benimser,
         yeni başlayanlardan uzmanlara kadar herkesi memnuniyetle karşılar. Dünyanın dört bir yanındaki konferanslar ve buluşmalar bilgi paylaşımını ve bağlantıları teşvik eder.
         İnsanların birbirlerine yardım ettiği ve birlikte büyüdüğü sıcak, sürdürülebilir bir topluluktur.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Evrensel sloganımız"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Topluluk hakkında daha fazla bilgi edinin"
       url: "/community/"

--- a/_data/locales/home/vi.yml
+++ b/_data/locales/home/vi.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: Các nhà phát triển trên khắp thế giới hỗ trợ lẫn nhau.<br />Cộng đồng ấm áp, năng động.
       copy: |
-        Cộng đồng Ruby chấp nhận văn hóa "Matz is nice so we are nice (MINASWAN)",
+        Cộng đồng Ruby chấp nhận văn hóa "Matz is nice and so we are nice (MINASWAN)",
         chào đón tất cả mọi người từ người mới bắt đầu đến chuyên gia. Các hội nghị và buổi gặp mặt trên khắp thế giới khuyến khích chia sẻ kiến thức và kết nối.
         Đây là một cộng đồng ấm áp, bền vững, nơi mọi người giúp đỡ lẫn nhau và cùng phát triển.
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "Khẩu hiệu chung là"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "Tìm hiểu thêm về cộng đồng"
       url: "/community/"

--- a/_data/locales/home/zh_cn.yml
+++ b/_data/locales/home/zh_cn.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: 世界各地的开发者相互支持。<br />温暖而活跃的社区。
       copy: |
-        Ruby 社区秉承"Matz is nice so we are nice (MINASWAN)"的文化，
+        Ruby 社区秉承"Matz is nice and so we are nice (MINASWAN)"的文化，
         欢迎从初学者到专家的所有人。世界各地的会议和聚会促进知识分享和联系。
         这是一个温暖、可持续的社区，人们互相帮助，共同成长。
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "通用座右铭是"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "了解更多关于社区的信息"
       url: "/community/"

--- a/_data/locales/home/zh_tw.yml
+++ b/_data/locales/home/zh_tw.yml
@@ -73,7 +73,7 @@ why_ruby:
       title: Community
       read: 世界各地的開發者相互支援。<br />溫暖而活躍的社群。
       copy: |
-        Ruby 社群秉承「Matz is nice so we are nice (MINASWAN)」的文化，
+        Ruby 社群秉承「Matz is nice and so we are nice (MINASWAN)」的文化，
         歡迎從初學者到專家的所有人。世界各地的會議和聚會促進知識分享和聯繫。
         這是一個溫暖、可持續的社群，人們互相幫助，共同成長。
       comment:
@@ -98,7 +98,7 @@ community:
   motto_prefix: "通用座右銘是"
   motto_minaswan: "MINASWAN"
   motto_separator: "—"
-  motto_translation: "Matz is nice so we are nice"
+  motto_translation: "Matz is nice and so we are nice"
   links:
     - text: "了解更多關於社群的資訊"
       url: "/community/"


### PR DESCRIPTION
Refreshed website is looking great! :sunglasses: 

I believe the full MINASWAN phrase is Matz is nice _and_ so we are nice, this commit adds the missing 'and'.

Reference: https://en.wiktionary.org/wiki/MINASWAN