### PR TITLE
Remove Ruby 3.5 from downloads.yml

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -5,7 +5,6 @@
 preview:
 
   - 4.0.0-preview3
-  - 3.5.0-preview1
 
 stable:
 


### PR DESCRIPTION
On the "Download Ruby" page, both Ruby 3.5.0-preview1 and Ruby 4.0.0-preview3 are listed as preview releases:
https://www.ruby-lang.org/en/downloads/

The latest preview release for the upcoming Ruby 4.0.0 is Ruby 4.0.0-preview3. Ruby 3.5.0-preview1 is an older preview for the Ruby 4.0.0 release, equivalent to Ruby 4.0.0-preview2, which is not included in the preview list. Like Ruby 4.0.0-preview2, it likely doesn't need to be listed.