### PR TITLE
Fix PowerShell language name for Rouge

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -227,7 +227,7 @@ latest version of Ruby.
 On Windows, you can use the [Windows Package Manager CLI](https://github.com/microsoft/winget-cli)
 to install Ruby:
 
-{% highlight ps1 %}
+{% highlight powershell %}
 > winget install RubyInstallerTeam.Ruby.{MAJOR}.{MINOR}
 # Example
 > winget install RubyInstallerTeam.Ruby.3.2

--- a/ko/documentation/installation/index.md
+++ b/ko/documentation/installation/index.md
@@ -227,7 +227,7 @@ $ pkg install runtime/ruby
 Windows에서 [Windows 패키지 관리자 CLI](https://github.com/microsoft/winget-cli)를
 사용해서 Ruby를 설치할 수 있습니다.
 
-{% highlight ps1 %}
+{% highlight powershell %}
 > winget install RubyInstallerTeam.Ruby.{MAJOR}.{MINOR}
 # 예시
 > winget install RubyInstallerTeam.Ruby.3.2


### PR DESCRIPTION
`highlight ps1` is intended to syntax highlight as PowerShell I think, but the correct language name in Rouge is powershell.
https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers