### PR TITLE
Add missing footnote to "Ruby 4.0.0 preview3 Released"

### DIFF
--- a/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/en/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -495,3 +495,4 @@ and is used all over the world especially for web development.
 [Feature #21550]: https://bugs.ruby-lang.org/issues/21550
 [Feature #21557]: https://bugs.ruby-lang.org/issues/21557
 [Bug #21654]:     https://bugs.ruby-lang.org/issues/21654
+[Feature #21552]: https://bugs.ruby-lang.org/issues/21552

--- a/ja/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/ja/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -425,3 +425,4 @@ Rubyはまつもとゆきひろ (Matz) によって1993年に開発が始めら�
 [Feature #21550]: https://bugs.ruby-lang.org/issues/21550
 [Feature #21557]: https://bugs.ruby-lang.org/issues/21557
 [Bug #21654]:     https://bugs.ruby-lang.org/issues/21654
+[Feature #21552]: https://bugs.ruby-lang.org/issues/21552

--- a/ua/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/ua/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -493,3 +493,4 @@ Ruby уперше розробив Matz (Yukihiro Matsumoto) у 1993 році,
 [Feature #21550]: https://bugs.ruby-lang.org/issues/21550
 [Feature #21557]: https://bugs.ruby-lang.org/issues/21557
 [Bug #21654]:     https://bugs.ruby-lang.org/issues/21654
+[Feature #21552]: https://bugs.ruby-lang.org/issues/21552


### PR DESCRIPTION
As title.
All three translated languages(en, ja, ua) are fixed.
It seems that the es translation doesn't translate the corresponding content, so skip it.