### PR TITLE
Remove redundant "ua" localization entry from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
         "ru":    "ru",
         "tr":    "tr",
         "uk":    "uk",
-        "ua":    "uk",
         "zh-CN": "zh_cn",
         "zh-TW": "zh_tw"
       };


### PR DESCRIPTION
The Ukrainian localization has been standardized to use the ISO language code `"uk"`. Since the proper `"uk": "uk"` mapping already exists, the `"ua"` entry is no longer necessary and was flagged for removal in a recent review.