### PR TITLE
Fix broken link to "Programming Ruby (first edition)" 

### DIFF
--- a/en/documentation/index.md
+++ b/en/documentation/index.md
@@ -195,7 +195,7 @@ These links were more prominent but haven't been updated in ages.
 [5]: https://poignant.guide
 [7]: https://www.techotopia.com/index.php/Ruby_Essentials
 [8]: https://pine.fm/LearnToProgram/
-[9]: https://ruby-doc.com/docs/ProgrammingRuby/
+[9]: https://web.archive.org/web/20250512022451/https://ruby-doc.com/docs/ProgrammingRuby/
 [10]: https://pragprog.com/titles/ruby5/programming-ruby-3-3-5th-edition/
 [12]: https://en.wikibooks.org/wiki/Ruby_programming_language
 [16]: https://www.rubydoc.info/


### PR DESCRIPTION
This PR replaces the broken link to “Programming Ruby (first edition)” with a working Web Archive version, as discussed in #3658.

I understand that this book is primarily of historical interest now, but I believe it's important for documentation links to be functional and lead to the intended resource to ensure a better experience for readers.

Closes #3658