### PR TITLE
Remove outdated link (rubydocs.org) and correlated text

### DIFF
--- a/bg/documentation/index.md
+++ b/bg/documentation/index.md
@@ -80,9 +80,6 @@ ruby -v
 [RubyDoc.info][16]
 : Документация за Ruby gem-ове и Ruby проекти, хоствани в github.com
 
-[Ruby & Rails Searchable API Docs][17]
-: Rails и Ruby документация с възможност за умно търсене.
-
 [APIdock][18]
 : Документация за Ruby, Rails и RSpec, включваща потребителски забележки и
   коментари.
@@ -136,7 +133,6 @@ ruby -v
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/es/documentation/index.md
+++ b/es/documentation/index.md
@@ -81,9 +81,6 @@ como instalar Ruby.
 : El sitio de parada obligada, con documentación de referencia, respecto
   a las gemas Ruby y a los proyectos Ruby alojados en GitHub.
 
-[Documentos de la API de Ruby y de Rails con facilidad de búsqueda][17]
-: Documentación de Rails y Ruby con búsqueda inteligente.
-
 [APIdock][18]
 : Documentación de Ruby, Rails y RSpec con notas de los usuarios.
 
@@ -149,7 +146,6 @@ comenzar.
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [rubyapi-org]: https://rubyapi.org/
 [19]: http://www.aptana.com/

--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -107,10 +107,6 @@ pour les nombreuses façons d'obtenir Ruby.
 [rubydoc.info][20]
 : Documentation auto-générée pour un grand nombre de bibliothèques Ruby.
 
-[Ruby & Rails Searchable API Docs][21]
-: Documentation sur les API Ruby et Ruby On Rails, proposant un système
-  de recherche poussé.
-
 ### Lectures additionnelles
 
 [Ruby-Doc.org][22] maintient à jour une liste presque exhaustive de la
@@ -138,6 +134,5 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [18]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
 [20]: http://rubydoc.info/
-[21]: http://rubydocs.org/
 [22]: http://ruby-doc.org
 [24]: http://rubyfrance.org/liens/livres/

--- a/id/documentation/index.md
+++ b/id/documentation/index.md
@@ -74,9 +74,6 @@ dapat membaca [panduan instalasi](installation/) untuk memasang Ruby.
 : Situs *web* lengkap untuk dokumentasi referensi tentang Ruby *gem* dan
   proyek Ruby yang di-*host* di GitHub.
 
-[Ruby & Rails Searchable API Docs][17]
-: Dokumentasi Rails dan Ruby yang dilengkapi dengan pencarian cerdas.
-
 [APIdock][18]
 : Dokumentasi Ruby, Rails, dan RSpec dengan catatan para pengguna.
 
@@ -140,7 +137,6 @@ adalah tempat yang baik untuk memulai.
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [rubyapi-org]: https://rubyapi.org/
 [19]: http://www.aptana.com/

--- a/it/documentation/index.md
+++ b/it/documentation/index.md
@@ -76,9 +76,6 @@ ed arrivano fino alla programmazione OOP e lo sviluppo web.
 : La prima fermata per documentazione di riferimento su gemme
   e progetti Ruby su GitHub.
 
-[Ruby & Rails Searchable API Docs][17]
-: Documentazione ricercabile per Rails e Ruby.
-
 [APIdock][18]
 : Documentazione con note degli utenti per Ruby, Rails e RSpec.
 
@@ -134,7 +131,6 @@ iniziare.
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/pl/documentation/index.md
+++ b/pl/documentation/index.md
@@ -80,9 +80,6 @@ Znajdziesz tutaj odnośniki do podręczników, tutoriali i materiałów
 : Strona internetowa z dokumentacją referencyjną gemów Rubiego i
   utrzymywanych na GitHubie projektów Rubiego.
 
-[Ruby & Rails Searchable API Docs][17]
-: Dokumentacja Railsów i Rubiego ze sprytnym wyszukiwaniem.
-
 [APIdock][18]
 : Dokumentacja Rubiego, Railsów i RSpeca z komentarzami użytkowników.
 
@@ -138,7 +135,6 @@ Jeśli szukasz pomocy w języku polskim, zajrzyj na [forum][pl-2].
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/pt/documentation/index.md
+++ b/pt/documentation/index.md
@@ -85,9 +85,6 @@ diversas maneiras de obter o Ruby.
 : O website essencial para documentação de referência sobre as Gems do Ruby e
   projetos Ruby hospedados no GitHub.
 
-[Ruby & Rails Searchable API Docs][17]
-: Documentação do Ruby e do Rails com busca inteligente.
-
 [APIdock][18]
 : Documentação do Ruby, Rails e RSpec com notas de usuários.
 
@@ -145,7 +142,6 @@ perguntas sobre Ruby, a [lista de e-mails](/pt/community/mailing-lists/)
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/tr/documentation/index.md
+++ b/tr/documentation/index.md
@@ -85,9 +85,6 @@ isterseniz, [kurulum kılavuzu](installation/)nu okuyabilirsiniz.
 : Ruby gem’leri ve GitHub’daki Ruby projelerinin başvuru belgelendirmeleri için
   tek site.
 
-[Ruby & Rails Aranabilir API Belgeleri][17]
-: Akıllı arama özellikleri olan Rails ve Ruby belgelendirmesi.
-
 [APIdock][18]
 : Kullanıcı notları ile Ruby, Rails ve RSpec belgelendirmesi.
 
@@ -147,7 +144,6 @@ olacaktır.
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [rubyapi-org]: https://rubyapi.org/
 [19]: http://www.aptana.com/

--- a/vi/documentation/index.md
+++ b/vi/documentation/index.md
@@ -86,9 +86,6 @@ việc cài đặt Ruby.
 : Các trang web một cửa cho tài liệu tham khảo về Ruby gems và GitHub chứa các
   dự án Ruby.
 
-[Ruby & Rails Searchable API Docs][17]
-: Tài liệu Rails và Ruby với tìm kiếm thông minh.
-
 [APIdock][18]
 : Tài liệu Ruby, Rails và RSpec với các ghi chú của người sử dụng.
 
@@ -144,7 +141,6 @@ là một nơi tuyệt vời.
 [15]: http://www.ruby-doc.org/stdlib
 [extensions]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [19]: http://www.aptana.com/
 [20]: http://www.gnu.org/software/emacs/

--- a/zh_cn/documentation/index.md
+++ b/zh_cn/documentation/index.md
@@ -63,9 +63,6 @@ ruby -v
 [RubyDoc.info][16]
 :  关于 Ruby gems 和 GitHub 上托管的 Ruby 项目的参考文档的一站式站点。
 
-[Ruby 和 Rails 可检索 API 文档][17]
-: 可以智能搜索的 Rails 和 Ruby 文档。
-
 [APIdock][18]
 : 带有用户评注的 Ruby、Rails 和 RSpec 文档。
 
@@ -117,7 +114,6 @@ ruby -v
 [14]: https://ruby.github.io/rdoc/
 [15]: http://www.ruby-doc.org/stdlib
 [16]: http://www.rubydoc.info/
-[17]: http://rubydocs.org/
 [18]: http://apidock.com/
 [rubyapi-org]: https://rubyapi.org/
 [19]: http://www.aptana.com/


### PR DESCRIPTION
This PR removes links and correlated to the outdated website `rubydocs.org`. I have applied this change across all localized languages of the documentation.

Fixes #3778 
Submitted as requested by @JuanitoFatas