### PR TITLE
Translate "Ruby 3.2.10 Released" (ko)

### DIFF
--- a/ko/news/_posts/2026-01-14-ruby-3-2-10-released.md
+++ b/ko/news/_posts/2026-01-14-ruby-3-2-10-released.md
@@ -1,17 +1,17 @@
 ---
 layout: news_post
-title: "Ruby 3.2.10 Released"
+title: "Ruby 3.2.10 릴리스"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2026-01-14 01:22:04 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 3.2.10 has been released.
+Ruby 3.2.10이 릴리스되었습니다.
 
-Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_10) for further details.
+자세한 내용은 [GitHub 릴리스 노트](https://github.com/ruby/ruby/releases/tag/v3_2_10)를 참조하세요.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "3.2.10" | first %}
 
@@ -36,7 +36,7 @@ Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v3_2_
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461

Translation of: #3790
Actual diff is: dd06a10da3220f14e74a77e2c9218b8fe26416ca