### PR TITLE
Exclude CLAUDE.md from site generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ exclude:
   - test
   - vendor
   - tsconfig.json
+  - CLAUDE.md
 
 url: https://www.ruby-lang.org
 


### PR DESCRIPTION
The CLAUDE.md file is present in the generated site: https://www.ruby-lang.org/CLAUDE.md

Also if you run `bundle exec rake test && bundle exec rake test` it makes it fail.
