### PR TITLE
Update RubyKaigi link to year-agnostic URL

### DIFF
--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -117,7 +117,7 @@ navigation:
   - text: Събития и конференции
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -119,7 +119,7 @@ navigation:
   - text: Events & Konferenzen
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -133,7 +133,7 @@ navigation:
   - text: Events & Conferences
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -115,7 +115,7 @@ navigation:
   - text: Eventos y conferencias
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -117,7 +117,7 @@ navigation:
   - text: Événements et conférences
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -119,7 +119,7 @@ navigation:
   - text: Acara & Konferensi
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -117,7 +117,7 @@ navigation:
   - text: Eventi e Conferenze
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -133,7 +133,7 @@ navigation:
   - text: イベント・カンファレンス
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -131,7 +131,7 @@ navigation:
   - text: 이벤트 & 컨퍼런스
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -113,7 +113,7 @@ navigation:
   - text: Wydarzenia i Konferencje
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -117,7 +117,7 @@ navigation:
   - text: Eventos e Conferências
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -117,7 +117,7 @@ navigation:
   - text: События и конференции
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -125,7 +125,7 @@ navigation:
   - text: Etkinlikler ve Konferanslar
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -131,7 +131,7 @@ navigation:
   - text: Події та конференції
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -117,7 +117,7 @@ navigation:
   - text: Sự kiện & Hội nghị
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/zh_cn.yml
+++ b/_data/locales/zh_cn.yml
@@ -121,7 +121,7 @@ navigation:
   - text: 活动与会议
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/

--- a/_data/locales/zh_tw.yml
+++ b/_data/locales/zh_tw.yml
@@ -119,7 +119,7 @@ navigation:
   - text: 活動與研討會
     submenu:
     - text: RubyKaigi
-      url: https://rubykaigi.org/2025/
+      url: https://rubykaigi.org/
       external: true
     - text: Ruby Events
       url: https://www.rubyevents.org/


### PR DESCRIPTION
Change RubyKaigi URL from https://rubykaigi.org/2025/ to https://rubykaigi.org/ across all locale files.

This ensures the link always points to the latest conference information instead of a specific year.