### PR TITLE
Link to ruby docs page for building ruby page

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -426,7 +426,7 @@ though, because the installed Ruby won't be managed by any tools.
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /en/downloads/
 [installers]: /en/documentation/installation/#installers
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/es/documentation/installation/index.md
+++ b/es/documentation/installation/index.md
@@ -396,7 +396,7 @@ ya que las versiones instaladas de esta manera no serán manejadas por ninguna o
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /es/downloads/
 [installers]: /en/documentation/installation/#installers
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/id/documentation/installation/index.md
+++ b/id/documentation/installation/index.md
@@ -411,7 +411,7 @@ diatur oleh alat bantu apa pun.
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /id/downloads/
 [installers]: /id/documentation/installation/#installers
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/ja/documentation/installation/index.md
+++ b/ja/documentation/installation/index.md
@@ -339,7 +339,7 @@ $ sudo make install
 [opensolaris-pkg]: http://opensolaris.org/os/project/pkg/
 [gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/
 [homebrew]: http://brew.sh/
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [wsl]: https://learn.microsoft.com/ja-jp/windows/wsl/about
 [ruby-build]: https://github.com/rbenv/ruby-build#readme

--- a/ko/documentation/installation/index.md
+++ b/ko/documentation/installation/index.md
@@ -426,7 +426,7 @@ $ sudo make install
 [terminal]: https://ko.wikipedia.org/wiki/%EB%8B%A8%EB%A7%90_%EC%97%90%EB%AE%AC%EB%A0%88%EC%9D%B4%ED%84%B0_%EB%AA%A9%EB%A1%9D
 [download]: /ko/downloads/
 [installers]: /ko/documentation/installation/#installers
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://docs.microsoft.com/ko-kr/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/uk/documentation/installation/index.md
+++ b/uk/documentation/installation/index.md
@@ -429,7 +429,7 @@ $ sudo make install
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
 [download]: /uk/downloads/
 [installers]: /uk/documentation/installation/#installers
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby

--- a/zh_tw/documentation/installation/index.md
+++ b/zh_tw/documentation/installation/index.md
@@ -339,7 +339,7 @@ $ sudo make install
 [freebsd-ports-collection]: https://docs.freebsd.org/en/books/handbook/ports/#ports-using
 [homebrew]: http://brew.sh/
 [terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
-[building-ruby]: https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
 [wsl]: https://learn.microsoft.com/zh-tw/windows/wsl/about
 [asdf-vm]: https://asdf-vm.com/
 [asdf-ruby]: https://github.com/asdf-vm/asdf-ruby


### PR DESCRIPTION
Looks better and keeps the user on a first-party page.

On https://www.ruby-lang.org/en/documentation/installation/#building-from-source changes the link from https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md to https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html