### PR TITLE
chore: Updating the URL for the On Rails podcast to podcast.rubyonrails.org

### DIFF
--- a/en/community/podcasts/index.md
+++ b/en/community/podcasts/index.md
@@ -35,7 +35,7 @@ wisdom to share, get in touch with the creators of these shows.
 
 You can also start your own Ruby podcast and get added to this list!
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rooftop_ruby]: https://www.rooftopruby.com
 [remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com

--- a/es/community/podcasts/index.md
+++ b/es/community/podcasts/index.md
@@ -29,6 +29,6 @@ shows.
 ¡También puedes comenzar tu propio podcast sobre Ruby y ser agregado
 a esta lista!
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com

--- a/id/community/podcasts/index.md
+++ b/id/community/podcasts/index.md
@@ -36,7 +36,7 @@ Ruby untuk dibagi, hubungi pembuat *podcast* tersebut.
 Anda juga dapat memulai *podcast* Ruby sendiri and menambahkan pada daftar
 berikut!
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rooftop_ruby]: https://www.rooftopruby.com
 [remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com

--- a/ko/community/podcasts/index.md
+++ b/ko/community/podcasts/index.md
@@ -34,7 +34,7 @@ Ruby와 Ruby 커뮤니티에 대한 뉴스, 인터뷰, 토론을 들어보세요
 
 당신의 Ruby 팟캐스트를 시작하고 이 목록에 추가할 수도 있습니다!
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rooftop_ruby]: https://www.rooftopruby.com
 [remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com

--- a/tr/community/podcasts/index.md
+++ b/tr/community/podcasts/index.md
@@ -31,6 +31,6 @@ Ruby bilgisine sahipseniz, bu gösterilerin sahipleri ile temasa geçin.
 
 Ayrıca kendi Ruby podcast'inizi başlatıp bu listeye ekleyebilirsiniz.
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com

--- a/uk/community/podcasts/index.md
+++ b/uk/community/podcasts/index.md
@@ -35,7 +35,7 @@ lang: uk
 
 Ви також можете створити власний Ruby-подкаст і додати його до цього списку!
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rooftop_ruby]: https://www.rooftopruby.com
 [remote_ruby]: https://www.remoteruby.com
 [rorpodcast]: https://www.therubyonrailspodcast.com

--- a/zh_tw/community/podcasts/index.md
+++ b/zh_tw/community/podcasts/index.md
@@ -16,6 +16,6 @@ lang: zh_tw
 [Ruby on Rails Podcast][rorpodcast]
 : Ruby on Rails Podcast，每週更新的談話性節目，討論有關 Ruby on Rails、開源軟體和工程師的專業。
 
-[onrails]: https://onrails.buzzsprout.com/
+[onrails]: https://podcast.rubyonrails.org/
 [rorpodcast]: https://www.therubyonrailspodcast.com
 [rogues]: https://rubyrogues.com


### PR DESCRIPTION
The **_On Rails_** podcast has officially moved to a new hostname. The old URL redirects, so this isn't urgent, but I wanted to update the locations where this appears on the web.