### PR TITLE
Remove the saying that pacman installs the latest version

### DIFF
--- a/en/documentation/installation/index.md
+++ b/en/documentation/installation/index.md
@@ -149,8 +149,6 @@ To get Ruby, just do this:
 $ sudo pacman -S ruby
 {% endhighlight %}
 
-This should install the latest stable Ruby version.
-
 
 ### Homebrew (macOS)
 {: #homebrew}


### PR DESCRIPTION
It doesn't. It is updated a few monts later. Right now (6th of February) Arch Linux's [Ruby package](https://archlinux.org/packages/extra/x86_64/ruby/) is v3.4.8 but latest Ruby is v4.0.1.