### PR TITLE
Fix Ruby Box documentation link

### DIFF
--- a/vi/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
+++ b/vi/news/_posts/2025-12-18-ruby-4-0-0-preview3-released.md
@@ -14,7 +14,7 @@ Ruby 4.0 giới thiệu Ruby::Box và "ZJIT", cùng nhiều cải tiến khác.
 ## Ruby::Box
 
 Một tính năng mới (thử nghiệm) cung cấp sự phân tách về các định nghĩa.
-Để biết chi tiết về "Ruby Box", xem [doc/language/box.md](https://github.com/ruby/ruby/blob/master/doc/language/box.md).
+Để biết chi tiết về "Ruby Box", xem [doc/language/box.md](https://docs.ruby-lang.org/en/4.0/language/box_md.html).
 [[Feature #21311]] [[Misc #21385]]
 
 ## Thay đổi ngôn ngữ


### PR DESCRIPTION
Updated the link for 'Ruby Box' documentation to the correct URL.

Related to https://github.com/ruby/www.ruby-lang.org/pull/3813/changes