### PR TITLE
Update README: Add Node.js and npm install to setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is the [Jekyll](http://www.jekyllrb.com/) source code for the official [Rub
 ### Prerequisites
 
 - **Ruby** (latest stable version recommended) - [Install Ruby](https://www.ruby-lang.org/en/documentation/installation/)
+- **Node.js** (for Tailwind CSS) - [Install Node.js](https://nodejs.org/)
 - **Git** - [Install Git](https://git-scm.com/downloads)
 
 ### Get It Running
@@ -29,6 +30,7 @@ This is the [Jekyll](http://www.jekyllrb.com/) source code for the official [Rub
    cd www.ruby-lang.org/
    bundle config set --local without production
    bundle install
+   npm install
    ```
 
 3. **Start the development server**:


### PR DESCRIPTION
Since the recent changes in commit b1ca28f (which added the build-css task as a mandatory prerequisite for build and serve), the project now strictly requires Node.js and local npm dependencies to generate compiled.css.

  Currently, the Quick Start section in README.md is missing these steps, causing errors for contributors who follow the existing instructions.

  **Problem**
  Running` bundle exec rake serve` without running npm install first results in the following error:

```
   1 npm run build-css
   2
   3 > www.ruby-lang.org@1.0.0 build-css
   4 > tailwindcss -i ./stylesheets/tailwind.css -o ./stylesheets/compiled.css
   5
   6 /home/artem/.local/share/mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/rubygems_integration.rb:236:in 'block in Gem.replace_bin_path': can't find executable tailwindcss for gem tailwindcss-ruby. tailwindcss-ruby is not
     currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
   7 ...
   8 rake aborted!
   9 Command failed with status (1): [npm run build-css]
```

  **Changes**
   - Added Node.js to the Prerequisites list.
   - Added npm install to the Get It Running setup instructions.