### PR TITLE
ci: declare contents:read on draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,6 +11,9 @@ on:
         required: true
         default: '3.3.4'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `.github/workflows/draft-release.yml` to `permissions: contents: read` at the workflow level. The job uses `secrets.MATZBOT_AUTO_UPDATE_TOKEN` for the commit step and for `peter-evans/create-pull-request`, so every operation that writes to the repository or opens a PR goes through that PAT and not `GITHUB_TOKEN`. The default token here is only used by the implicit `actions/checkout` calls (read on contents, read on the cross-org `ruby/ruby` clone).

Even though the writes are routed through a PAT, an explicit cap matters because of CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise). A tampered third-party action exfiltrates `GITHUB_TOKEN` from workflow logs and the leaked token carries whatever scope was issued at the workflow level. Without an in-file declaration, that scope is whatever the org default is set to today, which can be broader than what this workflow actually needs. Pinning here makes the minimum enforceable, gives drift protection if the default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
