### PR TITLE
Translate "Ruby 4.0.5 Released" & "CVE-2026-46727" (ko)

### DIFF
--- a/ko/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
+++ b/ko/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
@@ -1,0 +1,38 @@
+---
+layout: news_post
+title: "CVE-2026-46727: Use-after-free in pthread-based getaddrinfo timeout handler"
+author: "hsbt"
+translator:
+date: 2026-05-20 00:00:00 +0000
+tags: security
+lang: en
+---
+
+A use-after-free vulnerability has been discovered in the pthread-based `getaddrinfo` timeout handler of Ruby. This vulnerability has been assigned the CVE identifier [CVE-2026-46727](https://www.cve.org/CVERecord?id=CVE-2026-46727). This issue has been fixed in Ruby 4.0.5. We recommend upgrading Ruby.
+
+## Details
+
+A race condition exists in the timeout cancellation path of `rb_getaddrinfo` used by `Addrinfo.getaddrinfo(..., timeout:)` and `Socket.tcp(..., resolv_timeout:)`. A remote attacker who can delay DNS responses near the specified timeout may cause the Ruby process to dereference freed memory and crash.
+
+## Recommended action
+
+Please update to Ruby 4.0.5 or later.
+
+## Workaround
+
+If you cannot upgrade immediately, avoid passing `timeout:` to `Addrinfo.getaddrinfo` and `resolv_timeout:` to `Socket.tcp`.
+
+## Affected versions
+
+* Ruby 4.0.0 through 4.0.4
+* Ruby 4.1.0-dev (master) before the fix
+
+Ruby 3.4 series and earlier are not affected.
+
+## Credits
+
+Thanks to [cantina-security](https://hackerone.com/cantina-security) for discovering this issue. Also thanks to [shioimm](https://github.com/shioimm) for creating the patch.
+
+## History
+
+* Originally published at 2026-05-20 00:00:00 (UTC)

--- a/ko/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
+++ b/ko/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
@@ -1,38 +1,38 @@
 ---
 layout: news_post
-title: "CVE-2026-46727: Use-after-free in pthread-based getaddrinfo timeout handler"
+title: "CVE-2026-46727: pthread 기반 getaddrinfo 타임아웃 핸들러의 use-after-free 취약점"
 author: "hsbt"
-translator:
+translator: "shia"
 date: 2026-05-20 00:00:00 +0000
 tags: security
-lang: en
+lang: ko
 ---
 
-A use-after-free vulnerability has been discovered in the pthread-based `getaddrinfo` timeout handler of Ruby. This vulnerability has been assigned the CVE identifier [CVE-2026-46727](https://www.cve.org/CVERecord?id=CVE-2026-46727). This issue has been fixed in Ruby 4.0.5. We recommend upgrading Ruby.
+Ruby의 pthread 기반 `getaddrinfo` 타임아웃 핸들러에서 use-after-free 취약점이 발견되었습니다. 이 취약점은 CVE 번호 [CVE-2026-46727](https://www.cve.org/CVERecord?id=CVE-2026-46727)으로 등록되었습니다. 이 문제는 Ruby 4.0.5에서 수정되었습니다. Ruby 업그레이드를 권장합니다.
 
-## Details
+## 세부 내용
 
-A race condition exists in the timeout cancellation path of `rb_getaddrinfo` used by `Addrinfo.getaddrinfo(..., timeout:)` and `Socket.tcp(..., resolv_timeout:)`. A remote attacker who can delay DNS responses near the specified timeout may cause the Ruby process to dereference freed memory and crash.
+`Addrinfo.getaddrinfo(..., timeout:)`와 `Socket.tcp(..., resolv_timeout:)`가 사용하는 `rb_getaddrinfo`의 타임아웃 취소 경로에 경쟁 조건이 존재합니다. 지정된 타임아웃 부근에서 DNS 응답을 지연시킬 수 있는 원격 공격자는 Ruby 프로세스가 해제된 메모리를 역참조하여 충돌하도록 만들 수 있습니다.
 
-## Recommended action
+## 권장 조치
 
-Please update to Ruby 4.0.5 or later.
+Ruby 4.0.5 이상으로 업데이트해 주세요.
 
-## Workaround
+## 우회 방법
 
-If you cannot upgrade immediately, avoid passing `timeout:` to `Addrinfo.getaddrinfo` and `resolv_timeout:` to `Socket.tcp`.
+즉시 업그레이드할 수 없는 경우, `Addrinfo.getaddrinfo`에 `timeout:`을 전달하거나 `Socket.tcp`에 `resolv_timeout:`을 전달하는 것을 피해 주세요.
 
-## Affected versions
+## 해당 버전
 
-* Ruby 4.0.0 through 4.0.4
-* Ruby 4.1.0-dev (master) before the fix
+* Ruby 4.0.0부터 4.0.4까지
+* 수정 전 Ruby 4.1.0-dev (master)
 
-Ruby 3.4 series and earlier are not affected.
+Ruby 3.4 시리즈와 이전 버전은 영향을 받지 않습니다.
 
-## Credits
+## 도움을 준 사람
 
-Thanks to [cantina-security](https://hackerone.com/cantina-security) for discovering this issue. Also thanks to [shioimm](https://github.com/shioimm) for creating the patch.
+이 문제를 발견해 준 [cantina-security](https://hackerone.com/cantina-security)에게 감사를 표합니다. 또한 패치를 작성해 준 [shioimm](https://github.com/shioimm)에게도 감사를 표합니다.
 
-## History
+## 수정 이력
 
-* Originally published at 2026-05-20 00:00:00 (UTC)
+* 2026-05-20 00:00:00 (UTC) 최초 공개

--- a/ko/news/_posts/2026-05-20-ruby-4-0-5-released.md
+++ b/ko/news/_posts/2026-05-20-ruby-4-0-5-released.md
@@ -1,27 +1,27 @@
 ---
 layout: news_post
-title: "Ruby 4.0.5 Released"
+title: "Ruby 4.0.5 릴리스"
 author: k0kubun
-translator:
+translator: "shia"
 date: 2026-05-20 00:12:20 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 4.0.5 has been released.
+Ruby 4.0.5가 릴리스되었습니다.
 
-This release only contains a security fix for
-[CVE-2026-46727: Use-after-free in pthread-based getaddrinfo timeout handler](/en/news/2026/05/20/getaddrinfo-cve-2026-46727/)
-and a build system regression in Ruby 4.0.4 under C locale [[Bug #22065]](https://bugs.ruby-lang.org/issues/22065).
+이번 릴리스는
+[CVE-2026-46727: pthread 기반 getaddrinfo 타임아웃 핸들러의 use-after-free 취약점](/ko/news/2026/05/20/getaddrinfo-cve-2026-46727/)에 대한 보안 수정과
+C 로케일에서 발생하는 Ruby 4.0.4의 빌드 시스템 회귀 [[Bug #22065]](https://bugs.ruby-lang.org/issues/22065)에 대한 수정만 포함되어 있습니다.
 
-Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v4.0.5) for further details.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v4.0.5)를 참조하세요.
 
-## Release Schedule
+## 릴리스 일정
 
-We intend to release the latest stable Ruby version (currently Ruby 4.0) every two months following the most recent *regular* release. Ruby 4.0.6 will be released in July, 4.0.7 in September, and 4.0.8 in November.
+Ruby의 최신 안정 버전(현재 Ruby 4.0)을 최신 *일반* 릴리스 이후 2개월마다 릴리스할 계획입니다. Ruby 4.0.6은 7월에, 4.0.7은 9월에, 4.0.8은 11월에 릴리스될 예정입니다.
 
-If a change arises that significantly affects users, a release may occur earlier than planned, and the subsequent schedule may shift accordingly.
+만약 많은 사용자에게 영향을 미치는 변경 사항이 있을 경우, 해당 버전은 예상보다 빨리 릴리스될 수 있고, 이후 일정도 그에 따라 조정될 수 있습니다.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "4.0.5" | first %}
 
@@ -46,7 +46,7 @@ If a change arises that significantly affects users, a release may occur earlier
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2026-05-20-ruby-4-0-5-released.md
+++ b/ko/news/_posts/2026-05-20-ruby-4-0-5-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Ruby 4.0.5 Released"
+author: k0kubun
+translator:
+date: 2026-05-20 00:12:20 +0000
+lang: en
+---
+
+Ruby 4.0.5 has been released.
+
+This release only contains a security fix for
+[CVE-2026-46727: Use-after-free in pthread-based getaddrinfo timeout handler](/en/news/2026/05/20/getaddrinfo-cve-2026-46727/)
+and a build system regression in Ruby 4.0.4 under C locale [[Bug #22065]](https://bugs.ruby-lang.org/issues/22065).
+
+Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v4.0.5) for further details.
+
+## Release Schedule
+
+We intend to release the latest stable Ruby version (currently Ruby 4.0) every two months following the most recent *regular* release. Ruby 4.0.6 will be released in July, 4.0.7 in September, and 4.0.8 in November.
+
+If a change arises that significantly affects users, a release may occur earlier than planned, and the subsequent schedule may shift accordingly.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "4.0.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461

Translation of: #3942

Actual diff is: e80deb354, 2eaee1ec8