### PR TITLE
Translate CVE-2026-46727 and Ruby 4.0.5 (zh_cn)

### DIFF
--- a/zh_cn/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
+++ b/zh_cn/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
@@ -1,0 +1,40 @@
+---
+layout: news_post
+title: "CVE-2026-46727: 基于 pthread 的 getaddrinfo 超时处理中存在释放后使用(Use-after-free)漏洞"
+author: "hsbt"
+translator: "GAO Jun"
+date: 2026-05-20 00:00:00 +0000
+tags: security
+lang: zh_cn
+---
+
+我们发现 Ruby 中基于 pthread 的 `getaddrinfo` 在超时处理中存在释放后使用(Use-after-free)漏洞。
+此漏洞的 CVE 标号为 [CVE-2026-46727](https://www.cve.org/CVERecord?id=CVE-2026-46727)。Ruby 4.0.5 已经修复了此漏洞。我们建议您升级 Ruby。
+
+## 详情
+
+`rb_getaddrinfo` 的超时取消逻辑中存在竞争条件，该函数被 `Addrinfo.getaddrinfo(..., timeout:)` 和 `Socket.tcp(..., resolv_timeout:)` 调用。
+如果远程攻击者可以延迟 DNS 响应到指定超时时间附近，可能会导致 Ruby 进程引用已释放的内存并崩溃。
+
+## 推荐操作
+
+请将 Ruby 升级到 4.0.5 或更高版本。
+
+## 变通方案
+
+如果您无法立即升级，请避免向 `Addrinfo.getaddrinfo` 传递 `timeout:` 参数，避免向 `Socket.tcp` 传递 `resolv_timeout:` 参数。
+
+## 受影响版本
+
+* Ruby 4.0.0 至 4.0.4
+* 在此修复之前的 Ruby 4.1.0-dev (master)
+
+Ruby 3.4 系列及更早版本不受影响。
+
+## 致谢
+
+感谢 [cantina-security](https://hackerone.com/cantina-security) 发现此漏洞。同样感谢 [shioimm](https://github.com/shioimm) 修补了此漏洞。
+
+## 历史
+
+* 最初发布于 2026-05-20 00:00:00 (UTC)

--- a/zh_cn/news/_posts/2026-05-20-ruby-4-0-5-released.md
+++ b/zh_cn/news/_posts/2026-05-20-ruby-4-0-5-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 4.0.5 已发布"
+author: k0kubun
+translator: "GAO Jun"
+date: 2026-05-20 00:12:20 +0000
+lang: zh_cn
+---
+
+Ruby 4.0.5 已发布。
+
+此版本仅包含漏洞补丁
+[CVE-2026-46727: 基于 pthread 的 getaddrinfo 超时处理中存在释放后使用(Use-after-free)漏洞](/zh_cn/news/2026/05/20/getaddrinfo-cve-2026-46727/)
+以及 C 程序在特定区域设置下的构建问题 [[Bug #22065]](https://bugs.ruby-lang.org/issues/22065)。
+
+详情可参考 [GitHub 发布说明](https://github.com/ruby/ruby/releases/tag/v4.0.5)。
+
+## 发布计划
+
+我们计划在每次 **常规** 发布后的 2 个月为最新的 Ruby 稳定版本（目前是 Ruby 4.0）发布更新。
+Ruby 4.0.6 将于七月发布，4.0.7 将于九月发布，4.0.8 将于十一月发布。
+
+如果存在会影响到大量用户的重大变更，我们也可能会提前发布新版本，后续版本的发布计划也将进行相应调整。
+
+## 下载
+
+{% assign release = site.data.releases | where: "version", "4.0.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      文件大小: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      文件大小: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      文件大小: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 发布说明
+
+许多提交者、开发人员以及用户提供了问题报告，帮助我们完成了此版本。
+感谢他们的贡献。


### PR DESCRIPTION
Translate CVE-2026-46727 and Ruby 4.0.5 Released.