### PR TITLE
Add Ukrainian translations for Ruby 4.0.5

### DIFF
--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -98,6 +98,8 @@ navigation:
   submenu:
   - text: Розробка ядра Ruby
     url: /uk/community/ruby-core/
+  - text: Посібник з репозиторію
+    url: /uk/documentation/repository-guide/
   - text: Поштові розсилки
     url: /uk/community/mailing-lists/
   - text: Правила поштових розсилок

--- a/uk/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
+++ b/uk/news/_posts/2026-05-20-getaddrinfo-cve-2026-46727.md
@@ -1,0 +1,38 @@
+---
+layout: news_post
+title: "CVE-2026-46727: вразливість use-after-free в обробнику таймауту getaddrinfo на основі pthread"
+author: "hsbt"
+translator: "Andrii Furmanets"
+date: 2026-05-20 00:00:00 +0000
+tags: security
+lang: uk
+---
+
+В обробнику таймауту `getaddrinfo` Ruby на основі pthread виявлено вразливість use-after-free. Цій вразливості присвоєно ідентифікатор CVE [CVE-2026-46727](https://www.cve.org/CVERecord?id=CVE-2026-46727). Цю проблему виправлено в Ruby 4.0.5. Рекомендуємо оновити Ruby.
+
+## Деталі
+
+У шляху скасування таймауту `rb_getaddrinfo`, який використовується в `Addrinfo.getaddrinfo(..., timeout:)` та `Socket.tcp(..., resolv_timeout:)`, існує race condition. Віддалений зловмисник, який може затримати DNS-відповіді близько до вказаного таймауту, може змусити процес Ruby розіменувати звільнену пам'ять і аварійно завершитися.
+
+## Рекомендовані дії
+
+Будь ласка, оновіть Ruby до версії 4.0.5 або новішої.
+
+## Обхідний шлях
+
+Якщо ви не можете оновитися негайно, уникайте передавання `timeout:` до `Addrinfo.getaddrinfo` та `resolv_timeout:` до `Socket.tcp`.
+
+## Уражені версії
+
+* Ruby 4.0.0 до 4.0.4 включно
+* Ruby 4.1.0-dev (master) до виправлення
+
+Серія Ruby 3.4 і старіші не уражені.
+
+## Подяки
+
+Дякуємо [cantina-security](https://hackerone.com/cantina-security) за виявлення цієї проблеми. Також дякуємо [shioimm](https://github.com/shioimm) за створення патча.
+
+## Історія
+
+* Початково опубліковано 2026-05-20 00:00:00 (UTC)

--- a/uk/news/_posts/2026-05-20-ruby-4-0-5-released.md
+++ b/uk/news/_posts/2026-05-20-ruby-4-0-5-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Вийшов Ruby 4.0.5"
+author: k0kubun
+translator: "Andrii Furmanets"
+date: 2026-05-20 00:12:20 +0000
+lang: uk
+---
+
+Вийшов Ruby 4.0.5.
+
+Цей реліз містить лише виправлення безпеки для
+[CVE-2026-46727: вразливість use-after-free в обробнику таймауту getaddrinfo на основі pthread](/uk/news/2026/05/20/getaddrinfo-cve-2026-46727/)
+та виправлення регресії системи збірки в Ruby 4.0.4 у локалі C [[Bug #22065]](https://bugs.ruby-lang.org/issues/22065).
+
+Докладніше див. [примітки до релізу на GitHub](https://github.com/ruby/ruby/releases/tag/v4.0.5).
+
+## Розклад релізів
+
+Ми плануємо випускати найновішу стабільну версію Ruby (наразі Ruby 4.0) кожні два місяці після останнього *планового* релізу. Ruby 4.0.6 вийде у липні, 4.0.7 — у вересні, а Ruby 4.0.8 — у листопаді.
+
+Якщо з'явиться зміна, яка суттєво впливає на користувачів, реліз може відбутися раніше запланованого терміну, а наступний графік може відповідно зміститися.
+
+## Завантаження
+
+{% assign release = site.data.releases | where: "version", "4.0.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Коментар до релізу
+
+Багато комітерів, розробників і користувачів, які надсилали звіти про помилки, допомогли нам зробити цей реліз.
+Дякуємо за їхній внесок.


### PR DESCRIPTION
## Summary
- add Ukrainian translations for the Ruby 4.0.5 release announcement
- add Ukrainian translation for CVE-2026-46727
- align the Ukrainian contribution navigation with the English Repository Guide item

## Validation
- bundle exec rake lint
- bundle exec rake build
- bundle exec rake test-linter
