### PR TITLE
Extract hardcoded homepage strings to locale files (Fixes #3802)

### DIFF
--- a/_data/locales/home/en.yml
+++ b/_data/locales/home/en.yml
@@ -6,6 +6,7 @@ hero:
   download_button: "Download"
   or: "or"
   learn_more: "Learn More"
+  tagline: "A Programmer's Best Friend"
 
 try_ruby:
   title: "Try Ruby!"
@@ -13,6 +14,8 @@ try_ruby:
   button_url: "https://try.ruby-lang.org/"
   bottom_text: "Want to learn more or try Ruby?"
   bottom_link_url: "https://try.ruby-lang.org/"
+  button_text: "TRY!"
+  bottom_link_text: "Try Ruby"
 
 why_ruby:
   title: Why Ruby?

--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -1,4 +1,5 @@
 {% assign home = site.data.locales.home[page.lang] %}
+{% assign en_home = site.data.locales.home.en %}
 {% assign latest_stable_version = nil %}
 {% for r in site.data.releases %}
   {% unless r.version contains '-preview' or r.version contains '-rc' %}
@@ -85,7 +86,7 @@
       <div data-hero-layer="content" class="absolute inset-0 flex flex-col items-center opacity-0 pointer-events-auto">
         <!-- Tagline -->
         <div class="h-[7.5rem] md:h-[9.375rem] flex items-center justify-center mb-10">
-          <p class="text-lg md:text-2xl font-extrabold text-stone-900 dark:text-stone-100 text-center whitespace-nowrap tracking-[0.2em]"><span class="inline-block bg-gold-150 dark:bg-stone-770">A Programmer's Best Friend</span></p>
+          <p class="text-lg md:text-2xl font-extrabold text-stone-900 dark:text-stone-100 text-center whitespace-nowrap tracking-[0.2em]"><span class="inline-block bg-gold-150 dark:bg-stone-770">{{ home.hero.tagline | default: en_home.hero.tagline }}</span></p>
         </div>
 
         <!-- Content below tagline -->

--- a/_includes/home/try_ruby.html
+++ b/_includes/home/try_ruby.html
@@ -1,4 +1,5 @@
 {% assign home = site.data.locales.home[page.lang] %}
+{% assign en_home = site.data.locales.home.en %}
 {% assign examples = "i_love_ruby,cities,greeter" | split: "," %}
 
 <!-- Try Ruby Section -->
@@ -24,7 +25,7 @@
              target="_blank"
              rel="noopener noreferrer"
              class="inline-flex items-center justify-center gap-2 bg-gold-500 dark:bg-gold-500 text-stone-800 hover:bg-ruby-600 dark:hover:bg-ruby-600 hover:text-white text-lg px-8 py-2.5 rounded-full font-bold tracking-wide transition-all duration-200 shadow-sm hover:scale-105">
-            TRY!
+            {{ home.try_ruby.button_text | default: en_home.try_ruby.button_text }}
             <span class="icon-external text-xs transition-colors" aria-hidden="true"></span>
           </a>
         </div>
@@ -40,7 +41,7 @@
            target="_blank"
            rel="noopener noreferrer"
            class="text-semantic-text-link text-lg font-bold hover:underline inline-flex items-center gap-1">
-          <span class="icon-arrow-forward" aria-hidden="true"></span>Try Ruby
+          <span class="icon-arrow-forward" aria-hidden="true"></span>{{ home.try_ruby.bottom_link_text | default: en_home.try_ruby.bottom_link_text }}
           <span class="icon-external text-xs" aria-hidden="true"></span>
         </a>
       </p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,8 @@ layout: root
 
   {% capture homepage_path %}/{{ page.lang }}/{% endcapture %}
   {% if page.url == homepage_path %}
-    {% assign meta_description = "A Programmer's Best Friend" %}
+  {% assign en_home = site.data.locales.home.en %}
+  {% assign meta_description = site.data.locales.home[page.lang].hero.tagline | default: en_home.hero.tagline %}
   {% elsif page.description %}
     {% assign meta_description = page.description %}
   {% elsif page.excerpt %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -12,7 +12,8 @@ layout: root
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  {% assign meta_description = "A Programmer's Best Friend" %}
+  {% assign en_home = site.data.locales.home.en %}
+  {% assign meta_description = site.data.locales.home[page.lang].hero.tagline | default: en_home.hero.tagline %}
   {% assign meta_title = page.title | default: "Ruby Programming Language" %}
 
   <meta name="description" content="{{ meta_description }}">


### PR DESCRIPTION
This PR resolves #3802 by extracting the remaining hardcoded English strings on the homepage into the locale system, enabling full localization for non-English users.

Specifically, the following strings were extracted to _data/locales/home/en.yml:
   1. The "A Programmer's Best Friend" tagline in the Hero section and SEO meta tags (hero.tagline).
   2. The "TRY!" button text (try_ruby.button_text).
   3. The "Try Ruby" link text at the bottom of the section (try_ruby.bottom_link_text).

**Implementation Details & Fallback Mechanism**
To avoid breaking the homepage for languages that do not yet have these translations, I implemented a strict string-level English fallback using the Liquid default filter:

```
   1 {% assign en_home = site.data.locales.home.en %}
   2 {{ home.hero.tagline | default: en_home.hero.tagline }}
```

**Instructions for Locale Maintainers**
Other language maintainers do not need to do anything immediately; their pages will continue to display the English strings safely.

To localize these strings for your language, simply add the following keys to your respective _data/locales/home/*.yml file:

```
   1 hero:
   2   # ...
   3   tagline: "Your translation here"
   4
   5 try_ruby:
   6   # ...
   7   button_text: "Your translation here"
   8   bottom_link_text: "Your translation here"
```