### PR TITLE
Fix typos in Ruby 4.0.0 and 3.4.0 zh_tw translations

### DIFF
--- a/zh_tw/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/zh_tw/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -8,7 +8,7 @@ lang: zh_tw
 ---
 
 {% assign release = site.data.releases | where: "version", "3.4.0" | first %}
-我們很高興宣布 Ruby {{ release.version }} 發佈了。 Ruby 3.4 加入了 `it` 區塊參數參考變數，
+我們很高興宣布 Ruby {{ release.version }} 發布了。Ruby 3.4 加入了 `it` 區塊參數參考變數，
 將 Prism 作為預設的解析器，為 socket 函式庫加入 Happy Eyeballs Version 2 支援，改進 YJIT，加入 Modular GC，與其他更多。
 
 ## 導入 `it`
@@ -23,7 +23,7 @@ p ary.map { it.upcase } #=> ["FOO", "BAR", "BAZ"]
 
 `it` 行為與 `_1` 類似。當意圖在區塊中只想使用 `_1` 時，其他編號的參數例如 `_2` 也可能會出現，這會對讀者造成額外的認知負擔。因此 `it` 被導入作為一個方便的別名。在使用 `it` 能表示自身的簡單情境下使用 `it`，例如在單行區塊中。
 
-## Prism 先在是預設解析器
+## Prism 現在是預設解析器
 
 預設的解析器從 parse.y 切換為 Prism。 [[Feature #20564]]
 
@@ -50,9 +50,9 @@ socket 函式庫引入新功能[Happy Eyeballs 版本2 (RFC 8305)](https://datat
 
 ### TL;DR
 
-* 在 x86-64 與 arn64 平台上的大多數基準測試都有更好的效能
-* 減少編輯後設資料的的記憶體用量
-* 修復多個錯誤。YJIT 現在更加勇健且有更好的測試。
+* 在 x86-64 與 arm64 平台上的大多數基準測試都有更好的效能
+* 減少編譯後設資料的記憶體用量
+* 修復多個錯誤。YJIT 現在更加穩健且有更好的測試。
 
 ### 新功能
 
@@ -69,8 +69,8 @@ socket 函式庫引入新功能[Happy Eyeballs 版本2 (RFC 8305)](https://datat
 
 * 透過壓縮上下文來減少儲存 YJIT 後設資料所需的記憶體空間
 * 改善後的分配器能為本地變數分配暫存器
-* 當啟用 YJIT 時，使用更多用 Ruby 邊寫的核心程式：
-  * 使用 Ruby 改寫`Array#each`、`Array#select`、`Array#map` 提高效能 [[Feature #20182]].
+* 當啟用 YJIT 時，使用更多用 Ruby 編寫的核心程式：
+  * 使用 Ruby 改寫 `Array#each`、`Array#select`、`Array#map` 提高效能 [[Feature #20182]].
 * 能夠內聯小型/簡單的方法，例如：
   * 空方法
   * 回傳常數的方法
@@ -79,7 +79,7 @@ socket 函式庫引入新功能[Happy Eyeballs 版本2 (RFC 8305)](https://datat
 * 適用於更多執行環境方法的程式碼產生器
 * 改善 `String#getbyte`、`String#setbyte` 和其他字串方法
 * 改善位元計算來加速低階位元/位元組操作
-* 各種其他的增量改善
+* 各種其他的漸進式改善
 
 ## 模組化垃圾收集器
 

--- a/zh_tw/news/_posts/2025-12-25-ruby-4-0-0-released.md
+++ b/zh_tw/news/_posts/2025-12-25-ruby-4-0-0-released.md
@@ -13,21 +13,20 @@ Ruby 4.0 導入了 Ruby::Box 和 "ZJIT"，以及許多改進功能。
 
 ## Ruby Box
 
-Ruby Box 是一項用來提供定義區隔的(實驗性質)新功能。
+Ruby Box 是一項用來提供定義隔離的 (實驗性質) 新功能。
 可以透過設定環境變數 `RUBY_BOX=1` 啟用 Ruby Box。類別是 `Ruby::Box`。
 
 在 Ruby Box 中載入的定義是互相隔離的。
-Ruby Box 可以將從其他 boxes 載入的 monkey patches、全域/類別變數、類別/模組定義、和載入的原生/Ruby 函式庫做隔離。
+Ruby Box 可以將從其他 Box 載入的 monkey patches、全域/類別變數、類別/模組定義、和載入的原生/Ruby 函式庫做隔離。
 
 預期的使用場景有：
 
-* Run test cases in box to protect other tests when the test case uses monkey patches to override something
-* 當測試案例使用 monkey patches 覆蓋時，在 box 環境中執行測試案例可以保護其他測試。
-* 在 Ruby 進程中平行執行 Web 應用伺服器 boxes，以在應用程式伺服器上執行藍綠部署。
-* 執行 Web 應用伺服器 boxes 來用 Ruby 程式碼檢查回應差異，評估特定時間段內的依賴更新。
+* 當測試案例使用 monkey patches 覆蓋時，在 Box 環境中執行測試案例可以保護其他測試。
+* 在 Ruby 進程中平行執行 Web 應用伺服器 Box，以在應用程式伺服器上執行藍綠部署。
+* 執行 Web 應用伺服器 Box 來用 Ruby 程式碼檢查回應差異，評估特定時間段內的依賴更新。
 * 作為基礎（底層）API，以實現某種「套件」（高層）API（尚未設計）。
 
-參見  [Ruby::Box](https://docs.ruby-lang.org/en/master/Ruby/Box.html) 以了解更多關於「Ruby Box」的細節。
+參見 [Ruby::Box](https://docs.ruby-lang.org/en/master/Ruby/Box.html) 以了解更多關於「Ruby Box」的細節。
 [[Feature #21311]] [[Misc #21385]]
 
 ## ZJIT
@@ -46,7 +45,7 @@ ZJIT 比直譯器快，但還不如 YJIT 快。
 
 Ruby 的平行執行機制 Ractor 已經得到了多項改進。
 導入了一個新的類別 `Ractor::Port`，用於解決與訊息發送和接收相關的問題。 (參見 [我們的部落格文章](https://dev.to/ko1/ractorport-revamping-the-ractor-api-98))。
-此外，`Ractor.shareable proc` 讓在 Reactor 之間共用 `Proc` 物件變得更加容易。
+此外，`Ractor.shareable proc` 讓在 Ractor 之間共用 `Proc` 物件變得更加容易。
 
 在效能方面，許多內部資料結構都得到了改進，顯著減少了對全域鎖定的競爭，從而提高了平行執行的效率。
 此外，Ractor 共用的內部資料也減少了，因此在平行執行時，CPU 快取競爭也相應降低。
@@ -261,7 +260,7 @@ Ractor 最初在 Ruby 3.0 中作為一項實驗性功能導入。我們計劃明
 
 * Ruby::Box
 
-    * 這是一項用來提供定義區隔的(實驗性質)新功能。關於「Ruby Box」的詳細資訊，請參閱[doc/language/box.md](https://docs.ruby-lang.org/en/4.0/language/box_md.html)。
+    * 這是一項用來提供定義隔離的 (實驗性質) 新功能。關於「Ruby Box」的詳細資訊，請參閱 [doc/language/box.md](https://docs.ruby-lang.org/en/4.0/language/box_md.html)。
       [[Feature #21311]] [[Misc #21385]]
 
 * Set


### PR DESCRIPTION
Fixed several typos and inconsistencies in the Traditional Chinese translations:

- Ruby 4.0.0: Unified terminology for Box isolation, removed duplicate English text, fixed spacing
- Ruby 3.4.0: Fixed typos (發佈→發布, arn64→arm64, etc.) and improved wording consistency