### PR TITLE
Fix broken NEWS link in Ruby 4.0.0 release post

### DIFF
--- a/en/news/_posts/2025-12-25-ruby-4-0-0-released.md
+++ b/en/news/_posts/2025-12-25-ruby-4-0-0-released.md
@@ -624,7 +624,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
     * `--rjit` is removed. We will move the implementation of the third-party JIT API
       to the [ruby/rjit](https://github.com/ruby/rjit) repository.
 
-See [NEWS](https://docs.ruby-lang.org/en/{{ release.tag }}/NEWS_md.html)
+See [NEWS](https://docs.ruby-lang.org/en/4.0/NEWS_md.html)
 or [commit logs](https://github.com/ruby/ruby/compare/v3_4_0...{{ release.tag }})
 for more details.
 


### PR DESCRIPTION
The NEWS link in the [4.0.0 release post](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) points to `https://docs.ruby-lang.org/en/v4.0.0/NEWS_md.html`, which returns 404.

The template `{{ release.tag }}` resolves to `v4.0.0`, but docs.ruby-lang.org uses a `major.minor` path without the `v` prefix. The correct URL is `https://docs.ruby-lang.org/en/4.0/NEWS_md.html`, as confirmed by @hsbt in the issue.

Fixes #3764