### PR TITLE
Translate "Ruby 4.0.6 Released" (ko)

### DIFF
--- a/ko/news/_posts/2026-07-14-ruby-4-0-6-released.md
+++ b/ko/news/_posts/2026-07-14-ruby-4-0-6-released.md
@@ -1,24 +1,24 @@
 ---
 layout: news_post
-title: "Ruby 4.0.6 Released"
+title: "Ruby 4.0.6 릴리스"
 author: k0kubun
-translator:
+translator: "shia"
 date: 2026-07-14 01:41:20 +0000
-lang: en
+lang: ko
 ---
 
-Ruby 4.0.6 has been released.
+Ruby 4.0.6이 릴리스되었습니다.
 
-This is a routine update that includes bugfixes.
-Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v4.0.6) for further details.
+이번 릴리스는 버그 수정을 포함하는 일반적인 업데이트입니다.
+자세한 내용은 [GitHub 릴리스](https://github.com/ruby/ruby/releases/tag/v4.0.6)를 참조하세요.
 
-## Release Schedule
+## 릴리스 일정
 
-We intend to release the latest stable Ruby version (currently Ruby 4.0) every two months following the most recent release. Ruby 4.0.7 will be released in September, and 4.0.8 in November.
+Ruby의 최신 안정 버전(현재 Ruby 4.0)을 최신 릴리스 이후 2개월마다 릴리스할 계획입니다. Ruby 4.0.7은 9월에, 4.0.8은 11월에 릴리스될 예정입니다.
 
-If a change arises that significantly affects users, a release may occur earlier than planned, and the subsequent schedule may shift accordingly.
+만약 사용자에게 큰 영향을 미치는 변경 사항이 있을 경우, 해당 버전은 예정보다 빨리 릴리스될 수 있고, 이후 일정도 그에 따라 조정될 수 있습니다.
 
-## Download
+## 다운로드
 
 {% assign release = site.data.releases | where: "version", "4.0.6" | first %}
 
@@ -43,7 +43,7 @@ If a change arises that significantly affects users, a release may occur earlier
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Release Comment
+## 릴리스 코멘트
 
-Many committers, developers, and users who provided bug reports helped us make this release.
-Thanks for their contributions.
+많은 커미터, 개발자, 버그를 보고해 준 사용자들이 이 릴리스를 만드는 데 도움을 주었습니다.
+그들의 기여에 감사드립니다.

--- a/ko/news/_posts/2026-07-14-ruby-4-0-6-released.md
+++ b/ko/news/_posts/2026-07-14-ruby-4-0-6-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 4.0.6 Released"
+author: k0kubun
+translator:
+date: 2026-07-14 01:41:20 +0000
+lang: en
+---
+
+Ruby 4.0.6 has been released.
+
+This is a routine update that includes bugfixes.
+Please see the [GitHub releases](https://github.com/ruby/ruby/releases/tag/v4.0.6) for further details.
+
+## Release Schedule
+
+We intend to release the latest stable Ruby version (currently Ruby 4.0) every two months following the most recent release. Ruby 4.0.7 will be released in September, and 4.0.8 in November.
+
+If a change arises that significantly affects users, a release may occur earlier than planned, and the subsequent schedule may shift accordingly.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "4.0.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Release Comment
+
+Many committers, developers, and users who provided bug reports helped us make this release.
+Thanks for their contributions.


### PR DESCRIPTION
:link: https://github.com/ruby/www.ruby-lang.org/issues/3461
Translation of: https://github.com/ruby/www.ruby-lang.org/pull/3973
Actual diff is: e0d9c702048d81ce95e97a24362faec17584c9fa