### PR TITLE
Translate Ruby 3.3.12 Released (zh_tw)

### DIFF
--- a/zh_tw/news/_posts/2026-07-16-ruby-3-3-12-released.md
+++ b/zh_tw/news/_posts/2026-07-16-ruby-3-3-12-released.md
@@ -1,0 +1,48 @@
+---
+layout: news_post
+title: "Ruby 3.3.12 發布"
+author: hsbt
+translator: "Bear Su"
+date: 2026-07-16 05:08:11 +0000
+lang: zh_tw
+---
+
+Ruby 3.3.12 已經發布了。
+
+本次發布包含安全性修復。
+詳細內容請參閱以下項目。
+
+* [CVE-2026-41316: ERB @\_init 透過 def\_module / def\_method / def\_class 繞過反序列化保護]({% link zh_tw/news/_posts/2026-04-21-erb-cve-2026-41316.md %})
+
+此版本將預設 gem erb 更新至 4.0.3.1，並將隨附 gem net-imap 更新至 0.4.25。net-imap 的更新修復了 CVE-2026-42245、CVE-2026-42246、CVE-2026-42256、CVE-2026-42257、CVE-2026-42258、CVE-2026-47240、CVE-2026-47241 及 CVE-2026-47242。詳細修復內容請參閱 [net-imap v0.4.24](https://github.com/ruby/net-imap/releases/tag/v0.4.24) 與 [net-imap v0.4.25](https://github.com/ruby/net-imap/releases/tag/v0.4.25) 的發布說明。
+
+詳細的變動請參閱 [GitHub 發布](https://github.com/ruby/ruby/releases/tag/v3_3_12)。
+
+## 下載
+
+{% assign release = site.data.releases | where: "version", "3.3.12" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## 發布紀錄
+
+許多提交者、開發者和漏洞回報者幫助了此版本的發布，在此感謝所有人的貢獻。


### PR DESCRIPTION
Translate Ruby 3.3.12 release news

Thank you.