### PR TITLE
I translated the latest Ruby releases into Ukrainian

### DIFF
--- a/uk/news/_posts/2026-06-30-ruby-3-4-10-released.md
+++ b/uk/news/_posts/2026-06-30-ruby-3-4-10-released.md
@@ -1,0 +1,44 @@
+---
+layout: news_post
+title: "Вийшов Ruby 3.4.10"
+author: nagachika
+translator: "Andrii Furmanets"
+date: 2026-06-30 12:00:00 +0000
+lang: uk
+---
+
+Вийшов Ruby 3.4.10.
+
+Цей звичайний реліз стабільної версії містить оновлення версії gem net-imap, що постачається разом із Ruby. Оновлення net-imap.gem містить кілька виправлень безпеки. Докладніше про оновлення net-imap.gem див. у [примітках до релізу net-imap v0.5.15](https://github.com/ruby/net-imap/releases/tag/v0.5.15).
+
+Докладніше див. [примітки до релізу на GitHub](https://github.com/ruby/ruby/releases/tag/v3_4_10).
+
+## Завантаження
+
+{% assign release = site.data.releases | where: "version", "3.4.10" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Коментар до релізу
+
+Багато комітерів, розробників і користувачів, які надсилали звіти про помилки, допомогли нам зробити цей реліз.
+Дякуємо за їхній внесок.

--- a/uk/news/_posts/2026-07-14-ruby-4-0-6-released.md
+++ b/uk/news/_posts/2026-07-14-ruby-4-0-6-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Вийшов Ruby 4.0.6"
+author: k0kubun
+translator: "Andrii Furmanets"
+date: 2026-07-14 01:41:20 +0000
+lang: uk
+---
+
+Вийшов Ruby 4.0.6.
+
+Це звичайне оновлення, що містить виправлення помилок.
+Докладніше див. [примітки до релізу на GitHub](https://github.com/ruby/ruby/releases/tag/v4.0.6).
+
+## Розклад релізів
+
+Ми плануємо випускати найновішу стабільну версію Ruby (наразі Ruby 4.0) кожні два місяці після останнього релізу. Ruby 4.0.7 вийде у вересні, а 4.0.8 — у листопаді.
+
+Якщо з'явиться зміна, яка суттєво впливає на користувачів, реліз може відбутися раніше запланованого терміну, а наступний графік може відповідно зміститися.
+
+## Завантаження
+
+{% assign release = site.data.releases | where: "version", "4.0.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Коментар до релізу
+
+Багато комітерів, розробників і користувачів, які надсилали звіти про помилки, допомогли нам зробити цей реліз.
+Дякуємо за їхній внесок.

--- a/uk/news/_posts/2026-07-16-ruby-3-3-12-released.md
+++ b/uk/news/_posts/2026-07-16-ruby-3-3-12-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Вийшов Ruby 3.3.12"
+author: hsbt
+translator: "Andrii Furmanets"
+date: 2026-07-16 05:08:11 +0000
+lang: uk
+---
+
+Вийшов Ruby 3.3.12.
+
+Цей реліз містить виправлення безпеки.
+Докладніше див. у матеріалах нижче.
+
+* [CVE-2026-41316: обхід захисту ERB `@_init` під час десеріалізації через `def_module` / `def_method` / `def_class`](/uk/news/2026/04/21/erb-cve-2026-41316/)
+
+У цьому релізі gem erb за замовчуванням оновлено до версії 4.0.3.1, а gem net-imap, що постачається разом із Ruby, — до версії 0.4.25. Оновлення net-imap усуває CVE-2026-42245, CVE-2026-42246, CVE-2026-42256, CVE-2026-42257, CVE-2026-42258, CVE-2026-47240, CVE-2026-47241 і CVE-2026-47242. Докладніше про ці виправлення див. у примітках до релізів [net-imap v0.4.24](https://github.com/ruby/net-imap/releases/tag/v0.4.24) і [net-imap v0.4.25](https://github.com/ruby/net-imap/releases/tag/v0.4.25).
+
+Докладніше див. [примітки до релізу на GitHub](https://github.com/ruby/ruby/releases/tag/v3_3_12).
+
+## Завантаження
+
+{% assign release = site.data.releases | where: "version", "3.3.12" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Коментар до релізу
+
+Багато комітерів, розробників і користувачів, які надсилали звіти про помилки, допомогли нам зробити цей реліз.
+Дякуємо за їхній внесок.


### PR DESCRIPTION
I translated the Ukrainian versions of the Ruby 3.4.10, 4.0.6, and 3.3.12 release announcements.

I also linked the Ruby 3.3.12 announcement to the existing Ukrainian ERB security advisory.