### PR TITLE
Document javascripts/ as plain JavaScript and drop tsconfig.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,7 @@ bundle exec rake new_post:fr    # French
 - `lib/`: Ruby utilities (linter, markup checker, draft release)
 - `test/`: Test files for plugins and linter
 - `stylesheets/`: CSS source and compiled output
-- `_javascripts_src/`: TypeScript source files
-- `javascripts/`: Compiled JavaScript output
+- `javascripts/`: Hand-written JavaScript, served as-is
 
 ### Design System (Tailwind CSS)
 
@@ -158,12 +157,12 @@ lang: en
 ---
 ```
 
-## TypeScript/JavaScript
+## JavaScript
 
-- Source files in `_javascripts_src/` (TypeScript)
-- Compiled to `javascripts/` (JavaScript)
-- Files: `examples.ts`, `page.ts`
-- No build command specified - likely manual compilation or external process
+- Plain JavaScript in `javascripts/`, edited in place and served directly by Jekyll
+- No build, bundling, or transpilation step
+- Files: `branch-timeline.js`, `header-navigation.js`, `hero-animation.js`, `navigation-toggle.js`, `theme-toggle.js`, `toc.js`, `try-ruby-examples.js`
+- Loaded via `<script>` tags in `_layouts/default.html`, `_layouts/homepage.html`, and `_includes/branches-timeline.html`
 
 ## Dependencies
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ exclude:
   - lib
   - test
   - vendor
-  - tsconfig.json
   - CLAUDE.md
 
 url: https://www.ruby-lang.org

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "outDir": "./javascripts",
-
-    "target": "es5",
-    "strict": true
-  },
-  "include": ["./_javascripts_src/**/*"]
-}


### PR DESCRIPTION
`CLAUDE.md` still described a TypeScript build that was removed years ago. It pointed at a `_javascripts_src/` directory that no longer exists and named `examples.ts` and `page.ts`, both deleted. In practice `javascripts/` holds seven hand-written JavaScript files that are edited in place and served directly by Jekyll, with no compile step anywhere in the `Rakefile` or `package.json`.

I rewrote that section to describe the actual layout and dropped the `_javascripts_src/` entry from Key Directories.

`tsconfig.json` went with it. Its only `include` was `./_javascripts_src/**/*`, so it configured a compile over a directory that does not exist, and nothing ever invoked `tsc`. The `_config.yml` `exclude` entry for it is gone too since there is no longer a file to keep out of `_site/`.
