### PR TITLE
Read the Pagefind entry as UTF-8

### DIFF
--- a/lib/search_index.rb
+++ b/lib/search_index.rb
@@ -86,8 +86,13 @@ class SearchIndex
     lang.tr("_", "-").downcase
   end
 
+  # The entry is UTF-8 no matter what locale the build runs under: Pagefind
+  # lists the word characters it splits on in `include_characters`, and those
+  # reach past ASCII. Build hosts that leave the locale at POSIX, Cloudflare
+  # Pages among them, give `File.read` a US-ASCII string, and JSON.parse raises
+  # on the first of those bytes as it converts the source to UTF-8.
   def read_entry
-    JSON.parse(File.read(@entry_path))
+    JSON.parse(File.read(@entry_path, encoding: Encoding::UTF_8))
   rescue Errno::ENOENT
     raise Error, "#{@entry_path} is missing, Pagefind wrote no index"
   rescue JSON::ParserError => e

--- a/test/test_search_index.rb
+++ b/test/test_search_index.rb
@@ -17,12 +17,31 @@ describe SearchIndex do
     teardown_tempdir
   end
 
+  # `include_characters` is the list of characters Pagefind counts as part of a
+  # word. It reaches past ASCII, which is what makes the entry a UTF-8 file.
   def write_entry(languages)
-    File.write(@entry_path, JSON.generate({ "version" => "1.5.2", "languages" => languages }))
+    entry = {
+      "version" => "1.5.2",
+      "languages" => languages,
+      "include_characters" => ["_", "‿", "⁀", "＿"],
+    }
+    File.write(@entry_path, JSON.generate(entry))
   end
 
   def read_entry
-    JSON.parse(File.read(@entry_path))
+    JSON.parse(File.read(@entry_path, encoding: Encoding::UTF_8))
+  end
+
+  # Stands in for a build host that leaves the locale at POSIX, which is what
+  # Cloudflare Pages does.
+  def with_default_external(encoding)
+    original = Encoding.default_external
+    verbose, $VERBOSE = $VERBOSE, nil
+    Encoding.default_external = encoding
+    yield
+  ensure
+    Encoding.default_external = original
+    $VERBOSE = verbose
   end
 
   def search_index(pagefind: SearchIndex::PAGEFIND)
@@ -146,6 +165,14 @@ describe SearchIndex do
 
       error = _(-> { search_index.apply_fallbacks }).must_raise SearchIndex::Error
       _(error.message).must_match(/missing index "en"/)
+    end
+
+    it "reads the entry as UTF-8 whatever locale the build runs under" do
+      write_entry({ "en" => { "hash" => "en_abc", "wasm" => "en", "page_count" => 560 } })
+
+      with_default_external(Encoding::US_ASCII) { search_index.apply_fallbacks }
+
+      _(read_entry["languages"]["bg"]["hash"]).must_equal "en_abc"
     end
 
     it "raises when the bundle has no languages" do


### PR DESCRIPTION
Cloudflare Pages has failed every build since #3989 merged.

```
/opt/buildhome/repo/lib/search_index.rb:90:in `read_entry'
"\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
```

Pagefind lists the word characters it splits on in `include_characters`, so `pagefind-entry.json` reaches past ASCII. `read_entry` used a bare `File.read`, which tags the string with `Encoding.default_external`. Cloudflare's build container leaves the locale at POSIX, so that is US-ASCII and `JSON.parse` raises as it converts the source to UTF-8. GitHub Actions sets a UTF-8 locale, which is why CI stayed green.

The fixture now carries `include_characters` the way Pagefind writes it, and one case runs `apply_fallbacks` under a US-ASCII `Encoding.default_external`.
