### PR TITLE
Add robots.txt explicitly allowing all crawlers

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.ruby-lang.org/sitemap.xml


### PR DESCRIPTION
`https://www.ruby-lang.org/robots.txt` currently returns 404, so the crawler policy is only implicit. This adds a static `robots.txt` that explicitly allows all crawlers, including AI crawlers such as GPTBot, ClaudeBot and CCBot, as recommended by Layer 0 of the Evil Martians LLM discoverability scorecard (https://ruby.evilmartians.com/). Jekyll copies the file to `_site/robots.txt` as-is, verified with `bundle exec jekyll build`.

The `Sitemap:` line points to `https://www.ruby-lang.org/sitemap.xml`, which does not exist yet. It will be added in a separate task introducing `jekyll-sitemap`. A `Sitemap` directive pointing to a not-yet-existing URL is harmless.

Generated with [Claude Code](https://claude.com/claude-code)
