### PR TITLE
Generate sitemap.xml with jekyll-sitemap

### DIFF
--- a/404.md
+++ b/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Not Found"
 lang: en
 permalink: /404.html
+sitemap: false
 ---
 
 <script>

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "jekyll"
+gem "jekyll-sitemap"
 gem "rouge"
 
 # We didn't use development group for them

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       webrick (~> 1.7)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.19.9)
@@ -249,6 +251,7 @@ DEPENDENCIES
   csv
   html-proofer
   jekyll
+  jekyll-sitemap
   logger
   minitest
   rake
@@ -299,6 +302,7 @@ CHECKSUMS
   io-event (1.10.0) sha256=e4e1f5bf01a1a8b8484db3c5d99b431eb3609dbc988b96622d14d77993e0e9dc
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ kramdown:
 include:
   - _headers
 
+plugins:
+  - jekyll-sitemap
+
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/admin/index.md
+++ b/admin/index.md
@@ -3,6 +3,7 @@ layout: page
 title: "Admin Area"
 lang: en
 searchable: false
+sitemap: false
 ---
 
 - [News Post Translation Status](translation-status)

--- a/admin/translation-status/index.html
+++ b/admin/translation-status/index.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 ---
 
 <!DOCTYPE html>

--- a/bg/404.md
+++ b/bg/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Страницата не е намерена"
 lang: bg
 permalink: /bg/404.html
+sitemap: false
 ---
 
 Заявената страница не съществува.

--- a/de/404.md
+++ b/de/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Seite nicht gefunden"
 lang: de
 permalink: /de/404.html
+sitemap: false
 ---
 
 Die angeforderte Seite existiert nicht.

--- a/es/404.md
+++ b/es/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Página no encontrada"
 lang: es
 permalink: /es/404.html
+sitemap: false
 ---
 
 La página solicitada no existe.

--- a/fr/404.md
+++ b/fr/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Page non trouvée"
 lang: fr
 permalink: /fr/404.html
+sitemap: false
 ---
 
 La page demandée n'existe pas.

--- a/id/404.md
+++ b/id/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Halaman tidak ditemukan"
 lang: id
 permalink: /id/404.html
+sitemap: false
 ---
 
 Halaman yang diminta tidak ada.

--- a/it/404.md
+++ b/it/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Pagina non trovata"
 lang: it
 permalink: /it/404.html
+sitemap: false
 ---
 
 La pagina richiesta non esiste.

--- a/ja/404.md
+++ b/ja/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: ページが見つかりません"
 lang: ja
 permalink: /ja/404.html
+sitemap: false
 ---
 
 お探しのページは存在しません。

--- a/ko/404.md
+++ b/ko/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: 페이지를 찾을 수 없습니다"
 lang: ko
 permalink: /ko/404.html
+sitemap: false
 ---
 
 요청하신 페이지가 존재하지 않습니다.

--- a/pl/404.md
+++ b/pl/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Strona nie znaleziona"
 lang: pl
 permalink: /pl/404.html
+sitemap: false
 ---
 
 Żądana strona nie istnieje.

--- a/pt/404.md
+++ b/pt/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Página não encontrada"
 lang: pt
 permalink: /pt/404.html
+sitemap: false
 ---
 
 A página solicitada não existe.

--- a/ru/404.md
+++ b/ru/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Страница не найдена"
 lang: ru
 permalink: /ru/404.html
+sitemap: false
 ---
 
 Запрашиваемая страница не существует.

--- a/tr/404.md
+++ b/tr/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Sayfa bulunamadı"
 lang: tr
 permalink: /tr/404.html
+sitemap: false
 ---
 
 İstenen sayfa mevcut değil.

--- a/uk/404.md
+++ b/uk/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: Сторінку не знайдено"
 lang: uk
 permalink: /uk/404.html
+sitemap: false
 ---
 
 Запитувана сторінка не існує.

--- a/zh_cn/404.md
+++ b/zh_cn/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: 页面未找到"
 lang: zh_cn
 permalink: /zh_cn/404.html
+sitemap: false
 ---
 
 请求的页面不存在。

--- a/zh_tw/404.md
+++ b/zh_tw/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404: 頁面未找到"
 lang: zh_tw
 permalink: /zh_tw/404.html
+sitemap: false
 ---
 
 請求的頁面不存在。


### PR DESCRIPTION
`https://www.ruby-lang.org/sitemap.xml` currently returns 404. Serving a sitemap is a Layer 0 recommendation of the LLM discoverability scorecard at https://ruby.evilmartians.com/. This adds the `jekyll-sitemap` plugin, which generates `sitemap.xml` covering all 17 language trees and a `robots.txt` pointing at it. The 404 pages and the `admin/` area are excluded with `sitemap: false`.

Generated with [Claude Code](https://claude.com/claude-code)
