### PR TITLE
Serve Markdown alternates for pages and news posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,6 +68,7 @@ layout: root
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Noto+Sans+KR:wght@100..900&family=Noto+Sans+SC:wght@100..900&family=Noto+Sans+TC:wght@100..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Material+Icons&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..24,200..700,0,0&display=swap" rel="stylesheet">
   <link rel="canonical" href="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
+  {% if page.markdown_url %}<link rel="alternate" type="text/markdown" href="{{ page.markdown_url }}" title="Markdown">{% endif %}
 
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="icon" href="/images/icon-192.png" type="image/png" sizes="192x192">

--- a/_plugins/markdown_alternates.rb
+++ b/_plugins/markdown_alternates.rb
@@ -19,7 +19,7 @@ module MarkdownAlternates
   end
 
   def self.markdown_for(site, page)
-    raw = File.read(site.in_source_dir(page.path))
+    raw = File.read(site.in_source_dir(page.path), encoding: "bom|utf-8")
     raw = Regexp.last_match.post_match if raw =~ FRONT_MATTER
 
     payload = site.site_payload

--- a/_plugins/markdown_alternates.rb
+++ b/_plugins/markdown_alternates.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Publishes the Markdown source of every page and news post next to its
+# HTML page, so /en/about/ can also be fetched as /en/about.md. The copy
+# is the source with the front matter stripped and Liquid evaluated,
+# matching what the HTML page was rendered from.
+module MarkdownAlternates
+  FRONT_MATTER = Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+
+  def self.documents(site)
+    site.pages + site.posts.docs
+  end
+
+  def self.alternate_url(page)
+    return unless File.extname(page.relative_path) == ".md"
+    return unless page.url.end_with?("/")
+
+    page.url == "/" ? "/index.md" : "#{page.url.chomp("/")}.md"
+  end
+
+  def self.markdown_for(site, page)
+    raw = File.read(site.in_source_dir(page.path))
+    raw = Regexp.last_match.post_match if raw =~ FRONT_MATTER
+
+    payload = site.site_payload
+    payload["page"] = page.to_liquid
+    site.liquid_renderer.file(page.path)
+        .parse(raw)
+        .render!(payload, registers: { site: site, page: page })
+  end
+end
+
+# Runs before generators, so only hand-written pages and posts are
+# tagged; pages generated later (news archives) get no alternate.
+Jekyll::Hooks.register :site, :post_read do |site|
+  MarkdownAlternates.documents(site).each do |page|
+    url = MarkdownAlternates.alternate_url(page)
+    page.data["markdown_url"] = url if url
+  end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  MarkdownAlternates.documents(site).each do |page|
+    url = page.data["markdown_url"]
+    next unless url
+
+    path = site.in_dest_dir(url.delete_prefix("/"))
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, MarkdownAlternates.markdown_for(site, page))
+  end
+end


### PR DESCRIPTION
Every Markdown page and news post now gets a `.md` route next to its HTML page, so `/en/about/` can also be fetched as `/en/about.md`. The copy is the source with front matter stripped and Liquid rendered, so pages like `/en/downloads.md` keep their expanded release version numbers. The HTML head advertises the route via `<link rel="alternate" type="text/markdown">`. This implements the `.md` routes item from the LLM discoverability scorecard at https://ruby.evilmartians.com/ and adapts `_plugins/markdown_alternates.rb` from rubygems/guides#524. Pages whose URL does not end with `/` (such as `404.md`) and pages not written in Markdown are skipped, and generated news archive pages get no alternate. GitHub Pages serves the files as `text/markdown; charset=utf-8`.
