### PR TITLE
Add Brazilian Portuguese translations 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ rescue LoadError => e
   exit(-1)
 end
 
-LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tr ua vi zh_cn zh_tw].freeze
+LANGUAGES = %w[bg de en es fr id it ja ko pl pt pt_br ru tr ua vi zh_cn zh_tw].freeze
 CONFIG = "_config.yml"
 
 task default: [:build]

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -32,6 +32,9 @@
 - code: pt
   name: Portuguese
   native_name: Português
+- code: pt_br
+  name: Brazilian Portuguese
+  native_name: Português do Brasil
 - code: ru
   name: Russian
   native_name: Русский

--- a/_data/locales/home/pt_br.yml
+++ b/_data/locales/home/pt_br.yml
@@ -1,0 +1,115 @@
+hero:
+  since: "Desde"
+  year: "1995"
+  title: "Ruby"
+  latest_version_label: "Última versão:"
+  download_button: "Baixar"
+  or: "ou"
+  learn_more: "Saiba mais"
+
+try_ruby:
+  title: "Experimente Ruby!"
+  description: "Experimente Ruby no seu navegador agora"
+  button_url: "https://try.ruby-lang.org/"
+  bottom_text: "Quer aprender mais ou experimentar Ruby?"
+  bottom_link_url: "https://try.ruby-lang.org/"
+
+why_ruby:
+  title: Por que Ruby?
+  description: Por que programadores de todo o mundo amam Ruby? O que o torna <strong>divertido</strong>?
+  features:
+    - id: ecosystem
+      title: Ecossistema
+      read: Gems ricas apoiam todos os tipos de desenvolvimento.<br />Ferramentas maduras prontas para uso.
+      copy: |
+        Ruby tem uma vasta coleção de bibliotecas chamadas gems, apoiando tudo desde desenvolvimento web até processamento de dados.
+        Com frameworks maduros como Rails e uma ampla cadeia de ferramentas, você pode combinar excelentes recursos existentes
+        para construir aplicações de alta qualidade rapidamente sem reinventar a roda.
+      comment:
+        author:
+          id: matz
+          name: Yukihiro "Matz" Matsumoto
+          title: Criador do Ruby
+        content: |
+          Quando lancei Ruby ao mundo, nunca imaginei que um ecossistema tão rico surgiria a partir dele.
+          Mais de 200 mil gems, Ruby on Rails, RSpec, Bundler — tudo isso foi criado e cultivado pela comunidade.
+          Meu desejo de "fazer os programadores felizes" foi realizado de formas que eu nunca poderia ter alcançado sozinho.
+
+    - id: simple
+      title: Simples
+      read: Fácil de escrever, fácil de ler.<br />Sintaxe natural como a linguagem falada.
+      copy: |
+        Ruby tem uma sintaxe simples e intuitiva que se lê como linguagem natural.
+        Ao eliminar símbolos complexos e construções verbosas, a filosofia de design do Ruby permite expressar diretamente o que você quer.
+        Com pouco código repetitivo e alta legibilidade, é amigável para iniciantes e de fácil manutenção para desenvolvedores experientes.
+      comment:
+        author:
+          id: dhh
+          name: David Heinemeier Hansson
+          title: Criador do Ruby on Rails
+        content: |
+          Ruby é simplesmente a linguagem de programação mais bonita que já vi.<br />
+          Presto bastante atenção às novas linguagens de programação que surgem,
+          novos ambientes, novos frameworks, e ainda não vi nada que iguale ou supere Ruby na pureza do seu design.
+    - id: productivity
+      title: Produtividade
+      read: Faça mais com menos código.<br />Sintaxe intuitiva acelera o desenvolvimento.
+      copy: |
+        A sintaxe expressiva do Ruby permite escrever lógica complexa de forma concisa.
+        Aproveitando recursos poderosos como metaprogramação e blocos, você pode reduzir a repetição e se concentrar em resolver os problemas principais.
+        Com frameworks de teste abrangentes, você pode manter a qualidade enquanto alcança ciclos de desenvolvimento rápidos.
+      comment:
+        author:
+          id: pragdave
+          name: Dave Thomas
+          title: Autor de "The Pragmatic Programmer"
+        content: |
+          Ruby transforma ideias em código rapidamente.
+          Sua simplicidade me mantém focado; sua expressividade me permite escrever da forma que penso.<br />
+          Parece que a linguagem sai do caminho, deixando apenas eu e o problema.
+          Com ótimas ferramentas e bibliotecas, ideias rapidamente se tornam código elegante e funcional.
+
+    - id: community
+      title: Comunidade
+      read: Desenvolvedores em todo o mundo se apoiam mutuamente.<br />Uma comunidade calorosa e ativa.
+      copy: |
+        A comunidade Ruby abraça a cultura de "Matz is nice and so we are nice (MINASWAN)".
+        Ela recebe bem todas as pessoas, desde iniciantes até especialistas. Conferências e encontros ao redor do mundo promovem o compartilhamento de conhecimento e conexões.
+        É uma comunidade acolhedora e sustentável, onde as pessoas se ajudam mutuamente e crescem juntas.
+      comment:
+        author:
+          id: amanda
+          name: Amanda Perino
+          title: Diretora executiva da Rails Foundation
+        content: |
+          A comunidade Ruby é cheia de talento e criatividade; desenvolvedores são atraídos pela sintaxe elegante do Ruby e programam pelo prazer de programar.
+          É uma comunidade vibrante e acolhedora, disposta a compartilhar esse amor pela programação com todos.
+          Esse espírito de calor e colaboração é, sem dúvida, o maior trunfo do Ruby.
+
+companies:
+  title: "Empresas"
+  heart: "♥"
+  subtitle: "Ruby"
+
+community:
+  title: "Junte-se à comunidade"
+  description_1: "Pessoas que se envolvem com Ruby além de serem apenas usuárias e usuários são chamadas de Rubyistas."
+  description_2: "Rubyistas que amam Ruby são todos agradáveis #rubyfriends. As atividades da comunidade são prósperas e divertidas."
+  motto_prefix: "O lema universal é"
+  motto_minaswan: "MINASWAN"
+  motto_separator: "—"
+  motto_translation: "Matz is nice and so we are nice"
+  links:
+    - text: "Saiba mais sobre a comunidade"
+      url: "/community/"
+    - text: "Próximas conferências internacionais"
+      url: "https://www.rubyevents.org"
+      external: true
+
+news_security:
+  news:
+    title: "Notícias"
+    more_link: "Ler mais notícias"
+  security:
+    title: "Segurança"
+    more_link: "Ler mais sobre segurança"

--- a/_data/locales/pt_br.yml
+++ b/_data/locales/pt_br.yml
@@ -1,0 +1,208 @@
+---
+
+navigation:
+- text: Downloads
+  url: /pt_br/documentation/installation/
+  submenu:
+  - text: Instalar Ruby
+    url: /pt_br/documentation/installation/
+  - text: Downloads
+    url: /pt_br/downloads/
+  - text: Gerenciadores de Pacotes
+    submenu:
+    - text: rbenv
+      url: https://github.com/rbenv/rbenv
+      external: true
+    - text: RVM
+      url: https://rvm.io/
+      external: true
+    - text: RubyInstaller for Windows
+      url: https://rubyinstaller.org/
+      external: true
+    - text: Bundler
+      url: https://bundler.io/
+      external: true
+- text: Documentação
+  url: /pt_br/documentation/
+  submenu:
+  - text: Documentação
+    url: /pt_br/documentation/
+  - text: Sobre Ruby
+    url: /pt_br/about/
+  - text: Ruby em 20 minutos
+    url: /pt_br/documentation/quickstart/
+  - text: Ruby a partir de outras linguagens
+    url: /pt_br/documentation/ruby-from-other-languages/
+    submenu:
+    - text: Ruby a partir de C e C++
+      url: /pt_br/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/
+    - text: Ruby a partir de Java
+      url: /pt_br/documentation/ruby-from-other-languages/to-ruby-from-java/
+    - text: Ruby a partir de Perl
+      url: /pt_br/documentation/ruby-from-other-languages/to-ruby-from-perl/
+    - text: Ruby a partir de PHP
+      url: /pt_br/documentation/ruby-from-other-languages/to-ruby-from-php/
+    - text: Ruby a partir de Python
+      url: /pt_br/documentation/ruby-from-other-languages/to-ruby-from-python/
+  - text: Primeiros passos e exploração
+    submenu:
+    - text: TryRuby
+      url: https://try.ruby-lang.org/
+      external: true
+    - text: Ruby Reference Manual
+      url: https://docs.ruby-lang.org/en/4.0/
+      external: true
+    - text: The Ruby Bibliography
+      url: https://rubybib.org/
+      external: true
+- text: Módulos
+  url: /pt_br/libraries/
+  submenu:
+  - text: Módulos
+    url: /pt_br/libraries/
+  - text: RubyGems
+    submenu:
+    - text: RubyGems.org
+      url: https://rubygems.org/
+      external: true
+    - text: The Ruby Toolbox
+      url: https://www.ruby-toolbox.com/
+      external: true
+  - text: Gems Populares
+    submenu:
+    - text: Bundler
+      url: https://bundler.io/
+      external: true
+    - text: Ruby on Rails
+      url: https://rubyonrails.org/
+      external: true
+    - text: Rack
+      url: https://github.com/rack/rack
+      external: true
+    - text: Rake
+      url: https://github.com/ruby/rake
+      external: true
+    - text: RSpec
+      url: https://github.com/rspec/rspec
+      external: true
+- text: Contribuição
+  url: /pt_br/community/ruby-core/
+  submenu:
+  - text: Desenvolvimento do Ruby Core
+    url: /pt_br/community/ruby-core/
+  - text: Guia do Repositório
+    url: /pt_br/documentation/repository-guide/
+  - text: Listas de E-mail
+    url: /pt_br/community/mailing-lists/
+  - text: Outros
+    submenu:
+    - text: ruby/ruby
+      url: https://github.com/ruby/ruby
+      external: true
+    - text: Wiki
+      url: https://github.com/ruby/ruby/wiki
+      external: true
+    - text: Ruby Issue Tracking System
+      url: https://bugs.ruby-lang.org/
+      external: true
+- text: Comunidade
+  url: /pt_br/community/
+  submenu:
+  - text: Comunidade
+    url: /pt_br/community/
+  - text: Grupos de Usuários
+    url: /pt_br/community/user-groups/
+  - text: Blogs
+    url: /pt_br/community/weblogs/
+  - text: Eventos e Conferências
+    submenu:
+    - text: RubyKaigi
+      url: https://rubykaigi.org/
+      external: true
+    - text: Ruby Events
+      url: https://www.rubyevents.org/
+      external: true
+- text: Notícias
+  url: /pt_br/news/
+  submenu:
+  - text: Notícias
+    url: /pt_br/news/
+  - text: Segurança
+    url: /pt_br/security/
+
+syndicate:
+  text: Feeds de notícias (RSS)
+  recent_news:
+    text: Em português do Brasil
+    url: /pt_br/feeds/news.rss
+
+languages_heading: 'Este site em outros idiomas:'
+
+toc:
+  heading: Índice
+credits:
+  <a href="/pt_br/about/website/">Este site</a>
+  é mantido com orgulho por membros da comunidade Ruby.
+
+month_names:
+- Janeiro
+- Fevereiro
+- Março
+- Abril
+- Maio
+- Junho
+- Julho
+- Agosto
+- Setembro
+- Outubro
+- Novembro
+- Dezembro
+
+posted_by: Escrito por AUTHOR em %d/%m/%Y
+translated_by: Traduzido por
+
+feed:
+  title: Notícias sobre Ruby
+  description: As notícias mais recentes do ruby-lang.org em português do Brasil.
+  lang_code: pt-BR
+
+news:
+  other_news: Outras Notícias
+  more_news: Mais Notícias...
+  continue: Continue lendo...
+  back_to_year: Voltar aos arquivos de %Y
+  recent_news: Notícias Recentes
+  yearly_archive_title: Arquivos de %Y
+  monthly_archive_title: Arquivos de %B %Y
+  yearly_archives: Arquivos por Ano
+  monthly_archives: Arquivos por Mês
+  yearly_archive_link: Arquivos de %Y
+  monthly_archive_link: "%B %Y"
+  select_year: "--- Selecionar ano ---"
+
+footer:
+  links:
+    github:
+      text: ruby/ruby
+      url: https://github.com/ruby/ruby
+    slack:
+      text: ruby-jp.slack.com
+      url: https://ruby-jp.github.io/
+    mailing_list:
+      text: Listas de e-mail
+      url: /pt_br/community/mailing-lists/
+    security:
+      text: Segurança
+      url: /pt_br/security/
+    about_website:
+      text: Sobre este site
+      url: /pt_br/about/website/
+    logo_page:
+      text: Sobre o logotipo
+      url: /pt_br/about/logo/
+    news_rss:
+      text: Notícias RSS
+      url: /pt_br/feeds/news.rss
+    ruby_license:
+      text: Ruby License
+      url: /en/about/license.txt

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         "ja":    "ja",
         "ko":    "ko",
         "pt":    "pt",
+        "pt-BR": "pt_br",
         "ru":    "ru",
         "tr":    "tr",
         "uk":    "uk",

--- a/pt_br/404.md
+++ b/pt_br/404.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: "404: Página não encontrada"
+lang: pt_br
+permalink: /pt_br/404.html
+sitemap: false
+---
+
+A página solicitada não existe.
+
+Você pode tentar começar pela [página inicial](/).

--- a/pt_br/about/index.md
+++ b/pt_br/about/index.md
@@ -1,0 +1,250 @@
+---
+layout: page
+title: "Sobre o Ruby"
+lang: pt_br
+---
+
+Já pensou porque é que o Ruby é tão popular? Os fãs dizem que é uma
+linguagem elegante, repleta de arte. E no entanto, dizem que é prática e
+conveniente. Afinal qual é o resultado?
+{: .summary}
+
+### Os Ideais do Criador do Ruby
+
+O Ruby é uma linguagem com um cuidadoso equilíbrio. O seu criador,
+[Yukihiro “Matz” Matsumoto][matz], uniu partes das suas linguagens
+favoritas (Perl, Smalltalk, Eiffel, Ada e Lisp) para formar uma nova
+linguagem que equilibra a programação funcional com a programação
+imperativa.
+
+Ele disse com frequência que está “tentando tornar o Ruby natural, não
+simples”, de uma forma que reflita a vida.
+
+Elaborando sobre isto, acrescenta:
+
+> O Ruby é simples na aparência, mas muito complexo no interior, tal
+> como o corpo humano<sup>[1](#fn1)</sup>.
+
+### Sobre o Crescimento do Ruby
+
+Desde que foi tornado público em 1995, o Ruby arrastou consigo
+programadores devotos em todo o mundo. Em 2006, o Ruby atingiu aceitação
+massiva, com a formação de grupos de usuários em todas as principais
+cidades do mundo e com as conferências sobre Ruby com lotação esgotada.
+
+A Ruby-Talk, a principal [lista de e-mails](/pt_br/community/mailing-lists/)
+para a discussão sobre a
+linguagem Ruby atingiu uma média de 200 mensagens diárias em 2006.
+Recentemente a média caiu, já que o tamanho da comunidade distribuiu
+as discussões de uma lista central em muitos grupos menores.
+
+Ruby está posicionado entre no top 10 da maioria dos índices que medem o
+crescimento da popularidade de linguagens de programação pelo mundo todo
+(tais como o [índice TIOBE][tiobe]). Muito deste crescimento é atribuído à
+popularidade de softwares escritos em Ruby, em particular o framework de
+desenvolvimento web [Ruby on Rails][ror].
+
+O Ruby também é [totalmente livre]({{ site.license.url }}). Não somente livre de
+custos, mas também livre para utilizar, copiar, modificar e distribuir.
+
+### Ver Tudo como um Objeto
+
+Inicialmente, Matz estudou outras linguagens em busca de encontrar uma
+sintaxe ideal. Recordando a sua busca, disse, “Eu queria uma linguagem
+interpretada que fosse mais poderosa do que Perl e mais orientada as
+objetos do que Python<sup>[2](#fn2)</sup>.”
+
+Em Ruby, tudo é um objeto. Cada parcela de informação e código podem
+receber as suas próprias propriedades e ações. A Programação orientada
+a objetos denomina as propriedades como *variáveis de instância* e as
+ações como *métodos*. A aproximação pura, da orientação aos objetos do
+Ruby, é geralmente demonstrada pelo seguinte trecho de código que
+aplica uma ação a um número.
+
+{% highlight ruby %}
+5.times { print "Nós *amamos* o Ruby -- ele é fantástico!" }
+{% endhighlight %}
+
+Em muitas linguagens, números e outros tipos primitivos não são
+objetos. O Ruby segue a influência da linguagem Smalltalk em atribuir
+métodos e variáveis de instância a todos os seus tipos. Esta abordagem
+facilita a utilização do Ruby, uma vez que as regras que se aplicam aos
+objetos aplicam-se a tudo em Ruby.
+
+### A Flexibilidade do Ruby
+
+O Ruby é visto como uma linguagem flexível, uma vez que permite aos seus
+utilizadores alterar partes da linguagem. Partes essenciais do Ruby
+podem ser removidas ou redefinidas à vontade. Partes existentes podem
+ser acrescentadas. O Ruby tenta não restringir o programador.
+
+Por exemplo, a adição é realizada com o operador mais (`+`). Mas, se
+preferir utilizar a palavra escrita `plus`, poderia adicionar esse
+método à classe nativa do Ruby `Numeric`.
+
+{% highlight ruby %}
+class Numeric
+  def plus(x)
+    self.+(x)
+  end
+end
+
+y = 5.plus 6
+# y agora é igual a 11
+{% endhighlight %}
+
+Os operadores do Ruby são açúcar sintático para métodos. Você também
+pode redefini-los.
+
+### Blocos, uma Característica Verdadeiramente Expressiva
+
+Os blocos do Ruby são vistos como uma fonte de grande flexibilidade. Um
+programador pode adicionar uma _closure_ a qualquer método, descrevendo como
+esse método deve se comportar. A _closure_ é chamada de *bloco* e tornou-se uma
+das características mais populares para os recém chegados ao Ruby vindos
+de outras linguagens imperativas como o PHP ou o Visual Basic.
+
+Os blocos são inspirados nas linguagens funcionais. Matz disse, “nas
+_closures_ em Ruby, eu quis respeitar a cultura do
+Lisp<sup>[3](#fn3)</sup>”.
+
+{% highlight ruby %}
+search_engines =
+  %w[Google Yahoo MSN].map do |engine|
+    "http://www." + engine.downcase + ".com"
+  end
+{% endhighlight %}
+
+No código acima, o bloco é descrito dentro do trecho `do ... end`.
+O método `map` aplica o bloco à lista de palavras fornecida.
+Existem muitos outros métodos em Ruby que deixam em aberto a
+possibilidade para o programador escrever o seu próprio bloco que
+complete os detalhes do que esse método deveria fazer.
+
+### Ruby e o _Mixin_
+
+De forma diferente a muitas linguagens de programação orientadas a
+objeto, o Ruby suporta somente herança simples, **propositadamente**.
+Mas em Ruby existe o conceito de módulos (chamados categorias em
+Objective-C). Os módulos são coleções de métodos.
+
+As classes podem fazer o _mixin_ de um modulo e receber todos os métodos do
+módulo diretamente. Por exemplo, qualquer classe que implemente o método
+`each` pode fazer o _mixin_ do módulo `Enumerable`, que adiciona um conjunto de
+métodos que utilizam `each` para iterar.
+
+{% highlight ruby %}
+class MyArray
+  include Enumerable
+end
+{% endhighlight %}
+
+Geralmente os programadores de Ruby vêm esta abordagem como uma forma
+muito mais clara do que a herança múltipla, que é complexa e pode ser
+demasiado restritiva.
+
+### A Aparência Visual do Ruby
+
+Apesar de o Ruby utilizar frequentemente pontuação muito limitada e
+geralmente preferir palavras em inglês, alguma pontuação é utilizada
+para decorar o Ruby. O Ruby não necessita de declarações de variáveis.
+Usa simples convenções de nomes para denotar o âmbito das variáveis.
+
+* `var` poderia ser uma variável local.
+* `@var` é uma variável de instância.
+* `$var` é uma variável global.
+
+Estes símbolos facilitam a leitura do código, permitindo ao programador
+identificar facilmente o papel de cada variável. Também deixa de ser
+necessário acrescentar um fastidioso sufixo `self.` a cada membro de uma
+instância.
+
+### Além do Básico
+
+O Ruby é rico em outras características, entre as quais se destacam as
+seguintes:
+
+* Capacidade de tratamento de exceções, tal como em Java ou Python, de
+  forma a facilitar o tratamento de erros.
+
+* Um verdadeiro _garbage collector_ _mark-and-sweep_ para todos os objectos
+  Ruby. Não é necessário manter contadores de referência em bibliotecas
+  de extensão (_extension libraries_). Tal como Matz diz, “Isto é melhor
+  para a sua saúde.”
+
+* Escrever extensões C em Ruby é mais fácil do que em Perl ou Python,
+  com uma API refinada para chamar Ruby a partir do código C. Isto inclui
+  chamadas para embutir Ruby em software externo, para utilizá-lo como
+  uma linguagem interpretada dentro do software. Uma interface SWIG também
+  se encontra disponível.
+
+* O Ruby pode carregar bibliotecas de extensão (_extension libraries_)
+  dinamicamente se o Sistema Operacional permitir.
+
+* O Ruby tem um sistema de _threading_ independente do Sistema Operacional.
+  Portanto, para todas as plataformas nas quais o Ruby roda, temos
+  _multithreading_ independentemente de o Sistema Operacional suportar ou
+  não, temos _multithreading_ até em MS-DOS!
+
+* O Ruby é altamente portável: é desenvolvido principalmente em ambiente
+  GNU/Linux, mas trabalha em muitos tipos de ambientes UNIX, macOS,
+  Windows, DOS, BeOS, OS/2, etc.
+
+### Outras Implementações do Ruby
+
+O Ruby, como uma linguagem, tem algumas implementações diferentes. Esta
+página tem discutido a implementação de referência, frequentemente chamada
+pela comunidade de **MRI** (“_Matz’s Ruby Interpreter_”, o "Interpretador de
+Ruby do Matz") ou **CRuby** (já que é escrito em C), mas também existem outras.
+Elas muitas vezes são úteis em determinadas situações, fornecem integração
+adicional a outras linguagens ou ambientes, ou têm características especiais
+que o MRI não possui.
+
+Segue uma lista:
+
+* [JRuby][jruby] é Ruby sobre a JVM (_Java Virtual Machine_), utilizando os
+  compiladores otimizados JIT da JVM, _garbage collectors_, threads
+  concorrentes, seu ecossistema de ferramentas e sua vasta coleção de
+  bibliotecas.
+* [Rubinius][rubinius] é “Ruby escrito em Ruby”. Construído em cima da LLVM,
+  Rubinius utiliza uma elegante máquina virtual sobre a qual outras
+  linguagens também estão sendo construídas.
+* [mruby][mruby] é uma implementação leve da linguagem Ruby que pode ser
+  vinculada e embutida em uma aplicação. Seu desenvolvimento é conduzido
+  pelo criador do Ruby, Yukihiro “Matz” Matsumoto.
+* [IronRuby][ironruby] é uma implementação “fortemente integrada ao .NET
+  Framework”.
+* [MagLev][maglev] é “uma implementação rápida e estável do Ruby, com
+  persitência de objetos integrada e cache compartilhado distribuído”.
+* [Cardinal][cardinal] é um “compilador Ruby para a Máquina Virtual
+  [Parrot][parrot]” (Perl 6).
+
+### Referências
+
+<sup>1</sup> Matz, falando na lista de e-mails Ruby-Talk, [12 Mai.
+2000][blade].
+{: #fn1}
+
+<sup>2</sup> Matz, em [An Interview with the Creator of Ruby][linuxdevcenter], 29
+Nov. 2001.
+{: #fn2}
+
+<sup>3</sup> Matz, em [Blocks and Closures in Ruby][artima], 22 December
+2003.
+{: #fn3}
+
+
+
+[matz]: http://www.rubyist.net/~matz/
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
+[ror]: http://rubyonrails.org/
+[linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
+[artima]: http://www.artima.com/intv/closures2.html
+[tiobe]: https://www.tiobe.com/tiobe-index/
+[jruby]: http://jruby.org
+[rubinius]: https://rubinius.com
+[mruby]: http://www.mruby.org/
+[ironruby]: http://www.ironruby.net
+[maglev]: http://maglev.github.io
+[cardinal]: https://github.com/parrot/cardinal
+[parrot]: http://parrot.org

--- a/pt_br/about/logo/index.md
+++ b/pt_br/about/logo/index.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: "O Logotipo do Ruby"
+lang: pt_br
+---
+
+![O Logotipo do Ruby][logo]
+
+O logotipo do Ruby está sob Copyright &copy; 2006 de Yukihiro Matsumoto.
+
+Está licenciada sob os termos do acordo da
+[Licença Creative Commons Attribution-ShareAlike 2.5][cc-by-sa].
+
+## Download
+
+O [Ruby Logo Kit][logo-kit] contém o logotipo do Ruby em diversos formatos
+(PNG, JPG, PDF, AI, SWF, XAR).
+
+
+[logo]: /images/header-ruby-logo.png
+[logo-kit]: https://cache.ruby-lang.org/pub/misc/logo/ruby-logo-kit.zip
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/2.5/

--- a/pt_br/about/website/index.md
+++ b/pt_br/about/website/index.md
@@ -1,0 +1,101 @@
+---
+layout: page
+title: "Sobre o Website do Ruby"
+lang: pt_br
+---
+
+Este website foi gerado com Ruby utilizando [Jekyll][jekyll],<br>
+seu código fonte está hospedado no [GitHub][github-repo].
+
+## Design
+
+O design visual atual é de [Taeko Akatsuka][akatsuka].
+O site foi renovado em dezembro de 2025.
+
+<img src="../../../images/about/screenshot.png" alt="Design atual do ruby-lang.org" width="400" style="border: 1px solid #d6d3d1;" />
+
+O "Happy Hacking" no rodapé é escrito à mão por [Yukihiro Matsumoto (Matz)][matz].
+
+<img src="../../../images/about/screenshot-happy-hacking.png" alt="Happy Hacking no rodapé" width="400" style="border: 1px solid #d6d3d1;" />
+
+## Design anterior
+
+Design visual antes de dezembro de 2025 por [Jason Zimdars][jzimdars].<br>
+Baseado em um design prévio do Ruby Visual Identity Team.
+
+<img src="../../../images/about/screenshot-ruby-lang-old.png" alt="Design anterior do ruby-lang.org" width="400" style="border: 1px solid #d6d3d1;" />
+
+## Logo
+
+O [logotipo do Ruby][logo] está sob Copyright &copy; 2006 de Yukihiro Matsumoto.
+
+
+## Relatando Problemas ##
+
+Para reportar um problema, use o [issue tracker][github-issues]
+ou entre em contato com nosso [webmaster][webmaster] (em inglês).
+
+
+## Como Colaborar ##
+
+Este website é mantido com orgulho por membros da comunidade Ruby.
+
+Se você deseja colaborar, leia as [instruções para colaboração][github-wiki]
+e já comece a abrir *issues* ou *pull requests*!
+
+
+## Agradecimentos ##
+
+Agradecemos a todos os committers, autores, tradutores
+e outros colaboradores deste website.
+
+Também agradecemos a todas as organizações que nos dão suporte:
+
+<table class="not-prose sponsor-table">
+  <tr>
+    <td><a href="http://www.ruby.or.jp">Ruby Association</a> (hospedagem)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/ra.png" alt="Ruby Association" /></td>
+  </tr>
+  <tr>
+    <td><a href="http://ruby-no-kai.org/">Ruby no Kai</a> (servidor de build)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/ruby-no-kai.png" alt="Ruby no Kai" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://aws.amazon.com/">AWS</a> (hospedagem)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/aws.png" alt="AWS" style="width: 150px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.heroku.com/">Heroku</a> (hospedagem)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/heroku.png" alt="Heroku" style="width: 100px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.ibm.com/">IBM</a> (hospedagem)</td>
+    <td class="sponsor-logo"></td>
+  </tr>
+  <tr>
+    <td><a href="http://www.fastly.com">Fastly</a> (CDN)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/fastly.png" alt="Fastly" style="width: 200px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="http://hatenacorp.jp/">Hatena</a> (<a href="https://mackerel.io/">Mackerel</a>, monitoramento do servidor)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/mackerel.png" alt="Mackerel" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.datadoghq.com/">Datadog</a> (monitoramento do servidor)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/dd.png" alt="Datadog" style="width: 120px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://1password.com/">1Password</a> (gerenciador de senhas)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/1password.png" alt="1Password" style="width: 250px;" /></td>
+  </tr>
+</table>
+
+[logo]: /pt_br/about/logo/
+[webmaster]: mailto:webmaster@ruby-lang.org
+[jekyll]: http://www.jekyllrb.com/
+[akatsuka]: https://x.com/ken_c_lo
+[matz]: https://x.com/yukihiro_matz
+[jzimdars]: https://twitter.com/jasonzimdars
+[github-repo]: https://github.com/ruby/www.ruby-lang.org/
+[github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
+[github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki

--- a/pt_br/community/conferences/index.md
+++ b/pt_br/community/conferences/index.md
@@ -1,0 +1,91 @@
+---
+layout: page
+title: "Conferências de Ruby"
+lang: pt_br
+---
+
+Os programadores Ruby de todo o mundo estão se envolvendo cada vez em mais
+e mais conferências, onde se juntam para compartilhar relatórios sobre projetos
+em andamento, discutir o futuro do Ruby, e dar as boas vindas a novos membros
+da comunidade Ruby.
+
+[RubyEvents.org][rc] é uma simples lista de conferência especificamente
+sobre Ruby, publicada em colaboração com a comunidade Ruby. Nela você encontrará
+datas de eventos, localizações, CFP (_Call For Proposals_) e informações sobre
+inscrições.
+
+
+### Principais Conferências Ruby
+
+[RubyConf][1]
+: Todos os anos desde 2001, a [Ruby Central, Inc.][2] organizou a
+  RubyConf, a Conferência Internacional de Ruby. O público cresceu
+  num fator de 10 entre 2001 e 2006. A RubyConf disponibilizou um fórum
+  para apresentações sobre tecnologias Ruby pelos seus criadores,
+  incluindo opiniões de Nathaniel Talbot sobre *Test Unit*, Jim Weirich
+  sobre o Rake, David Heinemeier Hansson sobre o *Ruby on Rails*,
+  Why the Lucky Stiff sobre a biblioteca *YAML* e Sasada Koichi sobre
+  a *YARV*. O Matz esteve presente e falou em todas as conferências,
+  exceto uma.
+
+[RubyKaigi][3]
+: A primeira conferência Ruby japonesa. A RubyKaigi 2006 teve lugar em
+  Odaiba. A RubyKaigi fornece muitas apresentações novas e excitantes de
+  Matz e outros programadores Ruby todos os anos.
+
+[EuRuKo <small>(European Ruby Conference)</small>][4]
+: A primeira Conferência Ruby Europeia (EuRuKo) teve lugar em Karlsruhe,
+  na Alemanha, em 2003. Organizada por uma equipe alemã de programadores
+  Ruby incluindo Armin Roehrl e Michael Neumann, a EuRuKo tornou-se o
+  segundo evento anual de Ruby, começando dois anos após a RubyConf.
+
+### Conferências Regionais de Ruby
+
+A [Ruby Central][2] administra o [Regional Conference Grant Program][5],
+para compensar despesas para grupos regionais e locais que desejem
+organizar eventos.
+
+A Ruby Central juntou-se também com a [SVForum][6] para realizar a
+“Silicon Valley Ruby Conference”, entrando no seu segundo ano em 2007.
+
+A WindyCityRails é um encontro anual para todos os que são apaixonados em
+Ruby on Rails. A conferência situada em Chicago atende à comunidade Ruby
+desde 2008. Visite [http://windycityrails.org][8] para mais detalhes.
+
+[Steel City Ruby][14]: Pittsburg, PA
+
+[GoRuCo][15]: New York City's annual Ruby conference. A one-day single-track conference.
+
+[DeccanRubyConf][16]: Conferência anual de Ruby de Pune (India),
+pautada por atividades divertidas por todo o dia.
+É um evento de um dia com uma só trilhe.
+
+### Ruby em Outras Conferências
+
+Tem havido uma _track_ de Ruby na [O’Reilly Open Source Conference][9]
+(OSCON) desde 2004, e uma crescente presença da parte do Ruby e
+Programadores Ruby em outros encontros não relacionados com Ruby. Tem
+havido também, um crescente número de conferências dedicadas a
+[Ruby on Rails][10], incluindo a [RailsConf][11] da Ruby Central, a
+RailsConf Europe (co-realizada em 2006 pela Ruby Central e pela
+[Skills Matter][13], e que em 2007 o será pela Ruby Central e
+O’Reilly) e, para finalizar a Canada on Rails.
+
+
+
+
+[rc]: https://www.rubyevents.org/
+[1]: http://rubyconf.org/
+[2]: http://rubycentral.org
+[3]: http://rubykaigi.org/
+[4]: http://euruko.org
+[5]: https://rubycentral.org/grants
+[6]: http://www.svforum.org
+[8]: http://windycityrails.org
+[9]: http://conferences.oreillynet.com/os2006/
+[10]: http://www.rubyonrails.org
+[11]: http://www.railsconf.org
+[13]: http://www.skillsmatter.com
+[14]: http://steelcityruby.org/
+[15]: http://goruco.com/
+[16]: http://www.deccanrubyconf.org/

--- a/pt_br/community/index.md
+++ b/pt_br/community/index.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: "Comunidade"
+lang: pt_br
+---
+
+A comunidade que cresce em torno de uma linguagem de programação é uma
+das suas maiores forças. O Ruby tem uma comunidade vibrante e crescente,
+que se mostra sempre amigável com pessoas pertencentes a todos os níveis
+de conhecimento.
+{: .summary}
+
+Se está interessado em colaborar, seguem alguns lugares para começar:
+
+[Grupos de Usuários de Ruby](user-groups/)
+: O seu grupo de usuários local é um ótimo lugar para se conectar com
+  outros programadores Ruby. Os grupos de usuários são auto-suficientes
+  e caracterizam-se por ter reuniões mensais, uma lista de e-mails,
+  um website e se tiver sorte, _codefests_ frequentes.
+
+[Listas de E-mail e Grupos de Novidades de Ruby](mailing-lists/)
+: O Ruby tem um leque de listas sobre diversos tópicos e em vários idiomas.
+  Se tiver dúvidas sobre o Ruby, perguntá-las em listas de e-mail é um
+  grande jeito de conseguir respostas.
+
+[Ruby no IRC (#ruby)](https://web.libera.chat/#ruby)
+: O canal de IRC do Ruby é um ótimo meio de se comunicar com outros
+  programadores de Ruby.
+
+[Núcleo do Ruby](ruby-core/)
+: Agora é um momento fantástico para seguir o desenvolvimento do Ruby.
+  Se está interessado em ajudar o Ruby, comece aqui.
+
+[Weblogs sobre Ruby](weblogs/)
+: Muito pouco acontece na comunidade Ruby que não seja dito em blogs.
+  Temos uma boa lista de sugestões para você ficar ligado.
+
+[Conferências de Ruby](conferences/)
+: Programadores Ruby de todo o mundo estão participando de mais e mais
+  conferências, onde se juntam para compartilhar relatórios sobre o trabalho
+  desenvolvido, discutir o futuro do Ruby e dar as boas vindas aos novos
+  membros da comunidade.
+
+Informação gerais sobre o Ruby
+: * [Ruby Central][ruby-central]
+  * [Ruby no Open Directory Project][ruby-opendir]
+  * [Rails no Open Directory Project][rails-opendir]
+
+
+
+[ruby-central]: http://rubycentral.org/
+[ruby-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/
+[rails-opendir]: https://dmoztools.net/Computers/Programming/Languages/Ruby/Software/Frameworks/Rails/

--- a/pt_br/community/mailing-lists/index.md
+++ b/pt_br/community/mailing-lists/index.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: "Listas de E-mail"
+lang: pt_br
+---
+
+As listas de e-mail são uma ótima forma de manter-se atualizado com
+a comunidade Ruby.
+{: .summary}
+
+O Ruby tem quatro listas de e-mail principais em inglês:
+
+Ruby-Talk
+: Esta é a lista de e-mails mais popular e trata de tópicos gerais sobre
+  o Ruby. ([Arquivos][3])
+
+Ruby-Core
+: Esta lista trata do núcleo e tópicos da implementação do Ruby.
+  Normalmente é usada para enviar *patches* para revisão. ([Aquivos][4])
+
+Ruby-Doc
+: Esta lista é para discussão sobre normas de documentação e ferramentas
+  para Ruby. ([Arquivos][5])
+
+Ruby-CVS
+: Esta lista relata todas as submissões no repositório Subversion do Ruby.
+
+The comp.lang.ruby Newsgroup
+: Aqueles que preferem Usenet ao invés de listas de e-mail, podem conferir
+  o grupo de notícias [comp.lang.ruby](news:comp.lang.ruby).
+
+Ruby &lt;&lt; portuguese
+: Esta é a lista de discussão oficial de ruby em Portugal.
+  ([Arquivos no Google Groups][ruby-pt])
+
+## Inscrever ou Desinscrever
+
+[Inscrever ou Desinscrever](https://ml.ruby-lang.org/mailman3/lists/)
+
+
+
+[3]: https://ml.ruby-lang.org/archives/list/ruby-talk@ml.ruby-lang.org/
+[4]: https://ml.ruby-lang.org/archives/list/ruby-core@ml.ruby-lang.org/
+[5]: https://ml.ruby-lang.org/archives/list/ruby-doc@ml.ruby-lang.org/
+[ruby-pt]: http://groups.google.com/group/ruby-pt

--- a/pt_br/community/ruby-core/index.md
+++ b/pt_br/community/ruby-core/index.md
@@ -1,0 +1,175 @@
+---
+layout: page
+title: "Núcleo do Ruby"
+lang: pt_br
+---
+
+Agora é um momento fantástico para seguir o desenvolvimento do Ruby. Com a
+atenção cada vez maior que o Ruby tem recebido nos últimos anos, existe uma
+necessidade crescente de bom talento para ajudar a melhorar o Ruby e
+documentá-lo. Então, por onde começar?
+{: .summary}
+
+Os tópicos relacionados com o desenvolvimento do Ruby cobertos aqui são:
+
+* [Utilizando Subversion para Seguir o Desenvolvimento do Ruby](#following-ruby)
+* [Como Usar o Git com o Repositório Principal do Ruby](#git-ruby)
+* [Melhorando o Ruby, *Patch* a *Patch*](#patching-ruby)
+* [Regras para os _Core Developers_](#coding-standards)
+
+### Utilizando Subversion para Seguir o Desenvolvimento do Ruby
+{: #following-ruby}
+
+Obter a versão mais recente do código fonte do Ruby é uma questão de fazer um
+_checkout_ anônimo do repositório [Subversion][1]. Na sua linha de comando:
+
+{% highlight sh %}
+$ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+{% endhighlight %}
+
+O diretório `ruby` conterá o código fonte mais recente da versão de
+desenvolvimento do Ruby (ruby-trunk). Os _patches_ atualmente aplicados ao
+_trunk_ são portados para os _branches_ estáveis {{ site.svn.stable.version }},
+{{ site.svn.previous.version }} e {{ site.svn.old.version }} (veja abaixo).
+
+Se você gostaria de seguir os _patches_  aplicados ao Ruby
+{{ site.svn.stable.version }}, você deve usar o _branch_
+`{{ site.svn.stable.branch }}` ao fazer o _check out_:
+
+{% highlight sh %}
+$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.stable.branch }}
+{% endhighlight %}
+
+A mesma coisa para o Ruby {{ site.svn.previous.version }}:
+
+{% highlight sh %}
+$ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
+{% endhighlight %}
+
+Isto fará o *check out* da árvore de desenvolvimento em um
+diretório `{{ site.svn.stable.branch }}` ou `{{ site.svn.previous.branch }}`.
+Espera-se que os programadores que trabalham nos _branches_ de
+manutenção migrem as suas alterações para o _trunk_ do Ruby, tão regularmente
+que os dois _branches_ estejam muito similares, com a exceção das melhorias
+feitas diretamente à linguagem por Matz e Nobu.
+
+Se você preferir, você pode navegar pelo
+[repositório Subversion do Ruby pela web][2].
+
+Para mais informações sobre o Subversion, por favor consulte o
+[FAQ do Subversion][3] e o [livro do Subversion][4]. Alternativamente,
+você pode achar útil o livro introdutório
+[_Pragmatic Version Control with Subversion_][5].
+
+### Como usar o Git com o Repositório Principal do Ruby
+{: #git-ruby}
+
+Aqueles que preferem usar o [Git][6] ao invés do Subversion, podem encontrar
+as instruções no [_mirror_ no GitHub][7], tanto para
+[quem tem permissão de _commit_][8]
+quanto [todos os demais][9].
+
+### Melhorando o Ruby, *Patch* a *Patch*
+{: #patching-ruby}
+
+A equipe do _core_ mantém um [_issue tracker_][10] para submeter _patches_
+e reportar bugs para Matz e os demais. Essas informações também são enviadas
+para a [lista de e-mails do _core_ do Ruby][mailing-lists]
+para discussão, então você pode ter certeza de que o seu pedido não passará
+despercebido. Você também pode enviar os seus patches diretamente para
+a lista de e-mails. De qualquer forma, você é encorajado a participar na
+discussão que segue.
+
+Por favor dê uma olhada no [_Patch Writer’s Guide_][11] para ver algumas
+dicas, diretamente do Matz, sobre como fazer com que seus _patches_
+sejam considerados.
+
+Para resumir, os passos para criar um *patch* são:
+
+1.  Faça o _check out_ de uma cópia do código fonte do Ruby a partir do
+    Subversion. Geralmente os _patches_ para correções de bugs ou novas
+    funcionalidades devem ser enviados para o _trunk_ do código do Ruby.
+    Mesmo que você queira adicionar uma funcionalidade ao Ruby 1.9.3,
+    ele deve ser provado no _trunk_ primeiro.
+
+        $ svn co https://svn.ruby-lang.org/repos/ruby/trunk ruby
+
+    Se você estiver corrigindo um bug que é específico de um _branch_ de
+    manutenção, faça o _check out_ do respectivo _branch_, por exemplo
+    `{{ site.svn.previous.branch }}`.
+
+        $ svn co https://svn.ruby-lang.org/repos/ruby/branches/{{ site.svn.previous.branch }}
+
+2.  Faça as suas melhorias no código.
+
+3.  Crie um _patch_.
+
+        $ svn diff > ruby-changes.patch
+
+4.  Crie um _ticket_ no [_issue tracker_][10] ou envie seu _patch_ por
+    e-mail para a [lista de e-maisl do core do Ruby][mailing-lists]
+    com uma entrada no _ChangeLog_ descrevendo o _patch_.
+
+5.  Se não forem levantados quaisquer problemas sobre o _patch_,
+    quem fez o _commit_ receberá a permissão para aplicá-lo.
+
+**Nota:** os *patches* devem ser enviados como um [_unified diff_][12].
+Para saber mais sobre como os patches são fundidos, consulte o [manual do
+diffutils][13].
+
+A discussão do desenvolvimento do Ruby converge na
+[lista de e-mails Ruby-Core][mailing-lists]. Por isso, se está curioso
+se o seu *patch* vale a pena ou deseja animar uma discussão sobre o
+futuro do Ruby, não hesite e entre a bordo. Esteja avisado desde já
+que as conversas fora do contexto não são toleradas nesta lista. Os
+níveis de ruído deverão ser muito baixos, os tópicos deverão ser
+mencionados, bem concebidos e bem escritos. Já que nos dirigimos ao
+criador do Ruby, sejamos reverentes.
+
+Lembre-se de que os programadores do núcleo do Ruby vivem no Japão e,
+enquanto muitos falam muito bem o inglês, existe uma diferença
+significativa no fuso horário. Também existe um corpo inteiro de listas
+de e-mail em japonês que existem em paralelo às contrapartes em inglês.
+Seja paciente, e se o seu pedido não for atendido, seja persistente
+– tente outra vez alguns dias mais tarde.
+
+### Regras para os Programadores do _Core_
+{: #coding-standards}
+
+Em geral, os programadores de Ruby deverão estar familiarizados com o
+código fonte e o estilo de programação utilizado pela equipe. Para ficar
+mais claro, as seguintes diretrizes deverão ser respeitadas
+quando submeter código no repositório Subversion:
+
+* Todas as submissões deverão ser descritas no `ChangeLog`, seguindo as
+  [convenções GNU][14]. (Muitos programadores de Ruby usam o modo
+  `add-log` no Emacs, que poderá ser ativado como o commando `C-x 4 a`.)
+* Datas de submissão deverão ser dadas na Fuso Horário Japonês (UTC+9).
+* Os tópicos listados no seu ChangeLog também deverão ser colocados na
+  mensagem de submissão do Subversion. Esta mensagem será automaticamente
+  enviada para a lista Ruby-CVS depois da sua submissão.
+* Protótipos de funções são utilizadas por todo o código fonte Ruby
+  e em todos as suas extensões embutidas.
+* Por favor, não use comentários no estilo do C++ (`//`). Os
+  programadores do Ruby preferem os comentários de múltiplas linhas
+  do C (`/* .. */`).
+
+Veja também as informações no [_issue tracker_ do Ruby][10].
+
+
+
+[mailing-lists]: /pt_br/community/mailing-lists/
+[1]: http://subversion.apache.org/
+[2]: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/
+[3]: http://subversion.apache.org/faq.html
+[4]: http://svnbook.org
+[5]: http://www.pragmaticprogrammer.com/titles/svn/
+[6]: http://git-scm.com/
+[7]: https://github.com/ruby/ruby
+[8]: https://github.com/shyouhei/ruby/wiki/committerhowto
+[9]: https://github.com/shyouhei/ruby/wiki/noncommitterhowto
+[10]: https://bugs.ruby-lang.org/
+[11]: https://blade.ruby-lang.org/ruby-core/25139
+[12]: http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
+[13]: http://www.gnu.org/software/diffutils/manual/html_node/Merging-with-patch.html#Merging%20with%20patch
+[14]: http://www.gnu.org/prep/standards/standards.html#Change-Logs

--- a/pt_br/community/user-groups/index.md
+++ b/pt_br/community/user-groups/index.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: "Grupos de Usuários"
+lang: pt_br
+---
+
+Na comunidade de programadores, os grupos de usuários formam redes
+de suporte para as pessoas interessadas em determinados tópicos. São um
+lugar excelente para melhorar as suas habilidades e fazer um _networking_
+com outros programadores. Os Grupos de Usuários são informais e
+a sua estrutura varia de grupo para grupo. Qualquer pessoa poderá formar
+o seu próprio grupo e criar as suas próprias regras e agenda.
+{: .summary}
+
+### Grupos de Usuários de Ruby
+
+Se desejar juntar-se a outros programadores Ruby, um grupo local
+poderá ser o ideal. Os grupos de usuários são intereimente dedicados
+ao Ruby. Caracterizam-se por ter reuniões mensais, uma lista de e-mails, um
+website, e se você tiver sorte, sessões frequentes de *hacking* (reuniões
+dedicadas a dar a oportunidade aos membros de escrever código em Ruby).
+
+Informações sobre grupos de usuários de Ruby podem ser encontrados pelo
+menos em vários websites:
+
+[Ruby Meetup Groups][meetup]
+: Um número substancial de Grupos de Usuários de Ruby decidiram usar o
+  Meetup como o seu lar. O Meetup oferece um número de ferramentas
+  incluindo: fóruns privados, um local para colocar anúncios, lembretes
+  automáticos sobre reuniões e um bom sistema de RSVP.
+
+### Organizar o seu Próprio Grupo
+
+Se está interessado em formar o seu próprio grupo, assegure-se de
+descobrir se já existe um grupo na sua área. Encontros maiores
+normalmente são mais divertidos, portanto formar o seu próprio grupo pode
+não ser a melhor opção se já existir um por perto.
+
+
+
+[meetup]: https://www.meetup.com/topics/ruby/

--- a/pt_br/community/weblogs/index.md
+++ b/pt_br/community/weblogs/index.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: "Weblogs"
+lang: pt_br
+---
+
+Os blogs sobre Ruby explodiram durante o último ano. Com procura
+suficiente, poderá desenterrar centenas de blogs compartilhando trechos de
+código em Ruby, descrevendo novas técnicas ou especulando acerca do
+futuro do Ruby.
+{: .summary}
+
+### Blogs Notáveis
+
+Alguns blogs destacam-se pela frequência e rapidez das suas
+atualizações.
+
+* [**O’Reilly Ruby**][8] é um blog de um grupo com tutoriais e entrevistas
+  com pessoas interessantes da comunidade.
+* [**Riding Rails**][9] é o blog de grupo oficial da equipa do Ruby on
+  Rails. Se você estiver utilizando o Rails, este blog é essencial para
+  notificações de atualizações de segurança e uma visão geral da
+  grande comunidade do Rails.
+* [**Ruby Inside**][10] anuncia aplicações e bibliotecas interessantes de
+  todo o mundo, tanto sobre Ruby quanto Rails.
+* [**Matz’ Blog**][11] é um blog em japonês escrito pelos criador do
+  Ruby. Mesmo que você não consiga ler tudo, é bom saber que ele
+  está ali!
+
+### Divulgando a Palavra
+
+Você também poderá contatar os blogs
+acima, se você estiver cobrindo um tópico no qual eles possam se interessar.
+(Obviamente, se não é um blog relacionado a Rails, a equipe do *Riding Rails*
+pode não estar interessada – mas nunca se sabe.)
+
+O Ruby também é um tópico comum no [Slashdot][14], [reddit][15],
+e no [Hacker News][16], em suas respectivas notícias sobre programação.
+Se encontrar algum código brilhante, lembre-se de avisá-los!
+
+
+
+[8]: http://oreillynet.com/ruby/
+[9]: http://weblog.rubyonrails.org/
+[10]: http://www.rubyinside.com/
+[11]: http://www.rubyist.net/~matz/
+[14]: http://developers.slashdot.org/
+[15]: http://www.reddit.com/r/ruby
+[16]: http://news.ycombinator.com/

--- a/pt_br/documentation/index.md
+++ b/pt_br/documentation/index.md
@@ -1,0 +1,165 @@
+---
+layout: page
+title: "Documentação"
+lang: pt_br
+---
+
+Aqui você encontrará vários endereços para manuais, tutoriais e
+referências que serão úteis quando você sentir que gosta de programar
+em Ruby.
+{: .summary}
+
+### Instalando o Ruby
+
+A menos que você queira testar o Ruby no seu navegador (veja os links abaixo),
+você precisará ter o Ruby instalado no seu computador. Você pode verificar se
+o Ruby já está instalado abrindo o terminal e digitando
+
+{% highlight sh %}
+ruby -v
+{% endhighlight %}
+
+Isso deve imprimir algumas informações sobre a versão do Ruby instalada. Se não
+imprimir, consulte a [página de instalação](installation/) para conhecer as
+diversas maneiras de obter o Ruby.
+
+### Primeiros Passos
+
+[Try Ruby!][1]
+: Um tutorial interativo que permite que você teste o Ruby diretamente no
+  seu browser. Este tutorial de 15 minutos é destinado para iniciantes que
+  queiram ter uma ideia de como é a linguagem.
+
+[Ruby Koans][2]
+: Os Koans te conduzem pelo caminho da iluminação de modo a aprender Ruby.
+  O objetivo é aprender a linguagem, sintaxe, estrutura algumas funções e
+  bibliotecas comuns do Ruby. Também ensinamos cultura.
+
+[O Guia (Comovente) de Ruby do Why][5]
+: UM livro inconveniente, porém interessante, que te ensinará Ruby através
+  de histórias, humor e quadrinhos. Originalmente criado por *why the lucky
+  stiff*, esse guia permanece um clássico para os aprendizes de Ruby.
+
+[Ruby em Vinte Minutos](/pt_br/documentation/quickstart/)
+: Um bom tutorial que cobre o básico de Ruby. Desde o início ao fim, não
+  deverá levar mais de vinte minutos.
+
+[Ruby a Partir de Outras Linguagens](/pt_br/documentation/ruby-from-other-languages/)
+: Chegou ao Ruby por outra linguagem? Quer seja C, C++, Java, Perl,
+  PHP ou Python, este artigo é para você!
+
+[Ruby Essentials][7]
+: Ruby Essentials é um livro digital gratuito projetado para prover um
+  guia conciso e fácil de seguir para o aprendiz de Ruby.
+
+[Aprenda a Programar][8]
+: Pequeno e maravilhoso tutorial por Chris Pine para novatos em
+  programação. Se não sabe programar, comece aqui.
+
+[Learn Ruby the Hard Way][38]
+: Um ótimo conjunto de exercícios com explicações que o conduzem do básico
+  do Ruby por todo o caminho até a OOP e o desenvolvimento para a web.
+
+### Manuais
+
+[Programming Ruby][9]
+: Trabalho seminal de Ruby em inglês, a primeira edição do [Pragmatic
+  Programmers’ book][10] está disponível gratuitamente online.
+
+[The Ruby Programming Wikibook][12]
+: Manual online gratuito, com conteúdo para iniciantes e intermediário,
+  além de uma referência completa para a linguagem.
+
+### Documentação de Referência
+
+[Ruby Core Reference][13]
+: Vindo diretamente do código-fonte através de [RDoc][14], esta
+  referência documenta todas as classes e módulos do _core_ (como String,
+  Array, Symbol, etc…).
+
+[Ruby Standard Library Reference][15]
+: Também vindo do código-fonte através do RDoc, esta referência explora
+  documentos da biblioteca padrão.
+
+[RubyDoc.info][16]
+: O website essencial para documentação de referência sobre as Gems do Ruby e
+  projetos Ruby hospedados no GitHub.
+
+[APIdock][18]
+: Documentação do Ruby, Rails e RSpec com notas de usuários.
+
+### Editores e IDEs
+
+Para programar em Ruby, você pode usar o editor padrão do seu sistema
+operacional. A propósito, para programar mais eficazmente, pode valer
+a pena escolher um editor de código fonte com suporte básico a Ruby
+(por exemplo, que colore a sintaxe, lista os arquivos, etc.) ou um
+ambiente integrado de desenvolvimento com funcionalidades avançadas
+(como completar o código, refatorar, suporte a testes, etc.).
+
+Segue aqui uma lista das ferramentas populares utilizadas por
+programadores Ruby:
+
+* Ferramentas para Linux e outras plataformas:
+  * [Aptana Studio][19]
+  * [Emacs][20] com [Ruby mode][21] e [Rsense][22]
+  * [Geany][23]
+  * [gedit][24]
+  * [Vim][25] com o plugin [vim-ruby][26] e [Rsense][22]
+  * [RubyMine][27]
+  * [SciTe][28]
+  * [NetBeans][36]
+  * [Sublime Text][37]
+  * [Atom][atom]
+  * [Visual Studio Code][vscode]
+
+* No Windows:
+  * [Notepad++][29]
+
+* No macOS:
+  * [TextMate][32]
+  * [BBEdit][33]
+  * [Dash][39] (navegador de documentação)
+
+### Leitura Complementar
+
+[Ruby-Doc.org][34] mantém uma lista completa de fontes de documentação
+em inglês. Se você tiver
+perguntas sobre Ruby, a [lista de e-mails](/pt_br/community/mailing-lists/)
+é um ótimo lugar para começar.
+
+
+
+[1]: https://try.ruby-lang.org/
+[2]: https://rubykoans.com/
+[5]: http://why.carlosbrando.com/
+[7]: http://www.techotopia.com/index.php/Ruby_Essentials
+[8]: http://aprendaaprogramar.rubyonrails.com.br/
+[9]: https://web.archive.org/web/20250512022451/https://ruby-doc.com/docs/ProgrammingRuby/
+[10]: http://pragmaticprogrammer.com/titles/ruby/index.html
+[12]: http://en.wikibooks.org/wiki/Ruby_programming_language
+[13]: http://www.ruby-doc.org/core
+[14]: https://ruby.github.io/rdoc/
+[15]: http://www.ruby-doc.org/stdlib
+[16]: http://www.rubydoc.info/
+[18]: http://apidock.com/
+[19]: http://www.aptana.com/
+[20]: http://www.gnu.org/software/emacs/
+[21]: http://www.emacswiki.org/emacs/RubyMode
+[22]: http://rsense.github.io/
+[23]: http://www.geany.org/
+[24]: http://projects.gnome.org/gedit/screenshots.html
+[25]: http://www.vim.org/
+[26]: https://github.com/vim-ruby/vim-ruby
+[27]: http://www.jetbrains.com/ruby/
+[28]: http://www.scintilla.org/SciTE.html
+[29]: http://notepad-plus-plus.org/
+[32]: http://macromates.com/
+[33]: https://www.barebones.com/products/bbedit/
+[34]: http://ruby-doc.org
+[36]: https://netbeans.org/
+[37]: http://www.sublimetext.com/
+[38]: https://learncodethehardway.org/ruby/
+[39]: http://kapeli.com/dash
+[atom]: https://atom.io/
+[vscode]: https://code.visualstudio.com/

--- a/pt_br/documentation/installation/index.md
+++ b/pt_br/documentation/installation/index.md
@@ -1,0 +1,296 @@
+---
+layout: page
+title: "Instalando o Ruby"
+lang: pt_br
+---
+
+Você pode usar diversas ferramentas para instalar o Ruby.
+Esta página descreve como usar os principais sistemas de
+gerenciamento de pacotes ou ferramentas de terceiros para
+gerenciar e instalar o Ruby e como compilar o Ruby a
+partir do código fonte.
+{: .summary}
+
+
+## Escolha o seu Método de Instalação
+
+Existem diveras maneiras de instalar o Ruby:
+
+* Quando você está em um sistema operacional baseado em UNIX, utilizar o
+  **sistema de gerenciamento de pacotes** do seu sistema é a maneira mais fácil
+  de começar. No entanto, geralmente a versão do empacotada do Ruby não é a mais
+  recente.
+* **Instaladores** podem ser utilizados para instalar uma versão específica do
+  Ruby ou até mesmo várias delas. Também existe um instalador para o Windows.
+* **Gerenciadores** te ajudam a alternar entre múltiplas instalações do Ruby em
+  seu sistema.
+* E, por fim, você também pode **compilar o Ruby a partir do código fonte**.
+
+O resumo a seguir lista os métodos de instalação disponíveis
+para diferentes necessidades e plataformas:
+
+* [Sistemas de Gerenciamento de Pacotes](#package-management-systems)
+  * [Debian, Ubuntu](#apt)
+  * [CentOS, Fedora, RHEL](#yum)
+  * [Gentoo](#portage)
+  * [Arch Linux](#pacman)
+  * [macOS](#homebrew)
+  * [Solaris, OpenIndiana](#solaris)
+  * [Outras Distribuições](#other-systems)
+* [Instaladores](#installers)
+  * [ruby-build](#ruby-build)
+  * [ruby-install](#ruby-install)
+  * [RubyInstaller](#rubyinstaller) (Windows)
+  * [RailsInstaller e Ruby Stack](#railsinstaller)
+* [Gerenciadores](#managers)
+  * [chruby](#chruby)
+  * [rbenv](#rbenv)
+  * [RVM](#rvm)
+  * [uru](#uru)
+* [Compilando a partir do código fonte](#building-from-source)
+
+## Sistemas de Gerenciamento de Pacotes
+{: #package-management-systems}
+
+Se você não pode compilar o seu próprio Ruby e você não quer usar uma
+ferramenta de terceiros, você pode usar o gerenciador de pacotes do
+seu sistema para instalar o Ruby.
+
+Alguns membros da comunidade Ruby sugerem fortemente que você nunca
+deve usar um gerenciador de pacotes para instalar o Ruby e que você
+deve usar ferramentas ao invés disso. Embora a lista completa de
+prós e contras esteja fora do escopo desta página, o principal
+motivo é que os gerenciadores de pacotes têm versões mais antigas
+do Ruby em seus repositórios oficiais. Se você gostaria de usar
+um Ruby mais recente, assegure-se de usar o nome do pacote correto,
+ou de usar as ferramentas descritas acima ao invés disso.
+
+### apt (Debian ou Ubuntu)
+{: #apt}
+
+O Debian GNU/Linux e o Ubuntu usam o gerenciador de pacotes apt.
+Você pode utilizá-lo da seguinte forma:
+
+{% highlight sh %}
+$ sudo apt-get install ruby-full
+{% endhighlight %}
+
+No momento em que foi escrita esta página, o pacote `ruby-full` fornecia
+a versão 2.3.1 do Ruby, que é uma versão estável antiga, tanto no
+Debian quanto no Ubuntu.
+
+
+### yum (CentOS, Fedora ou RHEL)
+{: #yum}
+
+O CentOS, o Fedora e o RHEL usam o gerenciador de pacotes yum.
+Você pode utilizá-lo da seguinte maneira:
+
+{% highlight sh %}
+$ sudo yum install ruby
+{% endhighlight %}
+
+A versão instalada geralmente é a versão do Ruby mais recente disponível
+no momento do lançamento da versão específica da distribuição.
+
+
+### portage (Gentoo)
+{: #portage}
+
+O Gentoo usa o gerenciador de pacotes portage.
+
+{% highlight sh %}
+$ sudo emerge dev-lang/ruby
+{% endhighlight %}
+
+Por padrão, ele tentará instalar as versões 1.9 e 2.0, mas mais versões estão
+disponíveis. Para instalar uma versão específica, configure `RUBY_TARGETS`
+em seu `make.conf`. Consulte o [website do projeto Ruby do Gentoo][gentoo-ruby]
+para mais detalhes.
+
+
+### pacman (Arch Linux)
+{: #pacman}
+
+O Arch Linux utiliza um gerenciador de pacotes chamado pacman.
+Para obter o Ruby, apenas faça isso:
+
+{% highlight sh %}
+$ sudo pacman -S ruby
+{% endhighlight %}
+
+
+### Homebrew (macOS)
+{: #homebrew}
+
+No OS X Yosemite e Mavericks, o Ruby 2.0 já está incluso. O OS X Mountain Lion,
+Lion e Snow Leopard vêm com o Ruby 1.8.7.
+
+Muitas pessoas no macOS usam o [Homebrew][homebrew] como gerenciador de pacotes.
+É muito fácil de obter uma versão mais nova do Ruby usando o Homebrew:
+
+{% highlight sh %}
+$ brew install ruby
+{% endhighlight %}
+
+Este comando deve instalar a versão mais recente do Ruby.
+
+### Ruby no Solaris e OpenIndiana
+{: #solaris}
+
+O Ruby 1.8.7 está disponível do Solaris 8 até o Solaris 10 no
+[Sunfreeware][sunfreeware] e o Ruby 1.8.7 está disponível no
+Blastwave. O Ruby 1.9.2p0 também está disponível no
+[Sunfreeware][sunfreeware], mas está desatualizado.
+
+Para instalar o Ruby no [OpenIndiana][openindiana], por favor use o
+client do [Image Packaging System (IPS)][opensolaris-pkg]. Ele
+instalará os binários mais recentes do Ruby e do RubyGems diretamente
+a partir do repositório da rede OpenSolaris para o Ruby 1.9. É fácil:
+
+{% highlight sh %}
+$ pkg install runtime/ruby-18
+{% endhighlight %}
+
+Da mesma forma, as ferramentas de terceiros são uma excelente maneira
+de obter as versões mais recentes do Ruby.
+
+
+### Outras Distribuições
+{: #other-systems}
+
+Em outros sistemas, você pode pesquisar por Ruby no repositório de
+pacotes do gerenciador da sua distribuição de Linux, ou as
+ferramentas de terceiros podem ser a sua escolha certa.
+
+
+## Instaladores
+{: #installers}
+
+Se a versão do Ruby fornecida com o seu sistema ou gerenciador de pacotes estiver
+desatualizada, você pode instalar uma mais recentes através de um instalador de
+terceiros. Alguns deles também permitem que você instale múltiplas versões no
+mesmo sistema; os gerenciadores associados podem te ajudar a alternar entre
+diferentes Rubies. Se você planeja utilizar o [RVM](#rvm) como um gerenciador de
+versão, você não precisa de um instalador separado, ele vem com o seu próprio.
+
+
+### ruby-build
+{: #ruby-build}
+
+O [ruby-build][ruby-build] é um plugin para o [rbenv](#rbenv) que permite que
+você compile e instale diferentes versões do Ruby em diretórios arbitrários. O
+ruby-build também pode ser usado como um programa por si só, sem o rbenv. Ele
+está disponível para macOS, Linux e outros sistemas operacionais baseados em UNIX.
+
+
+### ruby-install
+{: #ruby-install}
+
+O [ruby-install][ruby-install] permite que você compile e instale diferentes
+versões do Ruby em diretórios arbitrários. Também tem um colega, que gerencia
+a alternância entre versões do Ruby. Ele está disponível para macOS, Linux e
+outros sistemas operacionais baseados em UNIX.
+
+
+### RubyInstaller
+{: #rubyinstaller}
+
+Se você está no Windows, existe um ótimo projeto para ajudá-lo
+a instalar o Ruby: [RubyInstaller][rubyinstaller]. Ele te dá
+tudo o que você precisa para configurar um ambiente de
+desenvolvimento em Ruby completo no Windows.
+
+Apenas baixe, rode e está pronto!
+
+
+### RailsInstaller e Ruby Stack
+{: #railsinstaller}
+
+Se você está instalando o Ruby para usar o Ruby on Rails,
+você pode usar os seguintes instaladores:
+
+* [RailsInstaller][railsinstaller],
+  que usa o RubyInstaller, mas te dá ferramentas adicionais
+  que ajudam no desenvolvimento com Rails. Suporta o OS X e o Windows.
+* [Bitnami Ruby Stack][rubystack],
+  que fornece um ambiente de desenvolvimento completo para Rails.
+  Suporta macOS, Linux, Windows, máquinas virtuais e imagens na nuvem.
+
+
+## Gerenciadores
+{: #managers}
+
+Muitos programadores Ruby utilizam gerenciadores para organizar múltiplas versões
+do Ruby. Eles conferem várias vantagens, mas não são suportados oficialmente. No
+entanto, suas comunidades são muito prestativas.
+
+
+### chruby
+{: #chruby}
+
+O [chruby][chruby] permite que você alterne entre múltiplos Rubies. O chruby
+pode gerenciar os Rubies instalados através do [ruby-install](#ruby-install) ou
+até mesmo compilados a partir do código fonte.
+
+
+### rbenv
+{: #rbenv}
+
+O [rbenv][rbenv] permite que você gerencie múltiplas instalações
+do Ruby. Ele não suporta a instalação do Ruby, mas existe um
+plugin popular chamado [ruby-build](#ruby-build) para isso. Ambas estas
+ferramentas estão disponíveis para macOS, Linux ou outros
+sistemas operacionais do tipo UNIX.
+
+
+### RVM ("Ruby Version Manager")
+{: #rvm}
+
+O [RVM][rvm] permite que você instale e gerencie múltiplas
+instalações do Ruby em seu sistema. Ele também permite
+gerenciar diferentes gemsets. Também está disponível para
+macOS, Linux ou outros sistemas operacionais do tipo UNIX.
+
+
+### uru
+{: #uru}
+
+O [Uru][uru] é uma ferramenta de linha de comando leve e multi-plataforma, que
+te ajuda a usar múltiplas versões do Ruby em sistemas macOS, Linux e Windows.
+
+
+## Compilando a Partir do Código Fonte
+{: #building-from-source}
+
+É claro, você pode instalar o Ruby a partir do código fonte.
+[Baixe](/en/downloads/) e descompacte o arquivo, e então apenas faça isso:
+
+{% highlight sh %}
+$ ./configure
+$ make
+$ sudo make install
+{% endhighlight %}
+
+Por padrão isso instalará o Ruby em `/usr/local`. Para alterar, informe
+a opção `--prefix=DIR` para o script `./configure`.
+
+No entanto, usar as ferramentas de terceiros ou os gerenciadores de pacotes
+pode ser uma ideia melhor, porque o Ruby instalado não será gerenciado
+por nenhuma ferramenta.
+
+
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv#readme
+[ruby-build]: https://github.com/rbenv/ruby-build#readme
+[ruby-install]: https://github.com/postmodern/ruby-install#readme
+[chruby]: https://github.com/postmodern/chruby#readme
+[uru]: https://bitbucket.org/jonforums/uru
+[rubyinstaller]: https://rubyinstaller.org/
+[railsinstaller]: http://railsinstaller.org/
+[rubystack]: http://bitnami.com/stack/ruby/installer
+[sunfreeware]: http://www.sunfreeware.com
+[openindiana]: http://openindiana.org/
+[opensolaris-pkg]: http://opensolaris.org/os/project/pkg/
+[gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/
+[homebrew]: http://brew.sh/

--- a/pt_br/documentation/quickstart/2/index.md
+++ b/pt_br/documentation/quickstart/2/index.md
@@ -1,0 +1,127 @@
+---
+layout: page
+title: "Ruby em Vinte Minutos"
+lang: pt_br
+
+header: |
+  <div class="multi-page">
+    <a href="../" title="Parte 1">1</a>
+    <span class="separator"> | </span>
+    <strong>2</strong>
+    <span class="separator"> | </span>
+    <a href="../3/" title="Parte 3">3</a>
+    <span class="separator"> | </span>
+    <a href="../4/" title="Parte 4">4</a>
+  </div>
+  <h1>Ruby em Vinte Minutos</h1>
+
+---
+
+E se quisermos dizer “Olá” várias vezes sem cansar os dedos? Temos que
+definir um método!
+
+{% highlight irb %}
+irb(main):010:0> def h
+irb(main):011:1> puts "Olá Mundo!"
+irb(main):012:1> end
+=> :h
+{% endhighlight %}
+
+O código `def h` começa a definição do método. Diz ao Ruby que estamos
+definindo um método, cujo nome é `h`. A linha seguinte é o corpo do
+método, a mesma linha que vimos antes: `puts "Olá Mundo"`. Finalmente, a
+última linha `end` diz ao Ruby que terminámos a definição do método.
+A reposta do Ruby `=> :h` nos diz que ele sabe que estamos definindo um
+método. Essa resposta poderia ser `=> nil` no Ruby 2.0 e versões anteriores.
+Mas isso não é importante agora, vamos seguir em frente.
+
+## As Breves e Repetitivas Vidas de um Método
+
+Agora vamos tentar rodar o método algumas vezes:
+
+{% highlight irb %}
+irb(main):013:0> h
+Olá Mundo!
+=> nil
+irb(main):014:0> h()
+Olá Mundo!
+=> nil
+{% endhighlight %}
+
+Bem, isso foi fácil. Chamar um método em Ruby é tão fácil como mencionar
+o seu nome ao Ruby. Se o método não tiver parâmetros isso é tudo de que
+precisamos. Podemos também colocar os parênteses vazios se desejarmos,
+porém eles não são necessários.
+
+E se o que queremos é dizer olá a uma pessoa só, e não ao mundo inteiro?
+Para isso basta redifinir `h` para que aceite um nome como parâmetro.
+
+{% highlight irb %}
+irb(main):015:0> def h(nome)
+irb(main):016:1> puts "Olá #{nome}!"
+irb(main):017:1> end
+=> :h
+irb(main):018:0> h("Matz")
+Ola Matz!
+=> nil
+{% endhighlight %}
+
+Parece funcionar… mas vamos parar um minuto para ver o que se passa
+aqui.
+
+## Reservando Espaços numa String
+
+O que significa a expressão `#{name}`? É a forma de inserir alguma coisa
+numa string. Aquilo que se encontra entre chaves transforma-se numa
+string (se já não o for) e é substituído naquele ponto da string.
+Podemos também usar isto para ter a certeza de que o nome de alguém se
+apresenta em letra maiúscula:
+
+{% highlight irb %}
+irb(main):019:0> def h(nome = "Mundo")
+irb(main):020:1> puts "Olá #{nome.capitalize}!"
+irb(main):021:1> end
+=> :h
+irb(main):022:0> h "chris"
+Olá Chris!
+=> nil
+irb(main):023:0> h
+Olá Mundo!
+=> nil
+{% endhighlight %}
+
+Podemos encontrar aqui um truque ou dois. Um deles é que estamos
+chamando novamente o método sem recorrer aos parênteses. Se aquilo que
+estamos fazendo for óbvio então os parênteses são opcionais. O outro
+truque é o parâmetro `Mundo` usado por omissão. O que isto quer dizer é
+que “Se o nome não for fornecido, então usamos o nome padrão
+`"Mundo"`.
+
+## Evoluindo para um Anfitrião
+
+E se quisermos criar um verdadeiro anfitrião, um que se lembre do
+nosso nome, nos dê as boas vindas e nos trate com o devido respeito?
+Podemos usar um objeto para isso. Então vamos criar a classe “Anfitrião”.
+
+{% highlight irb %}
+irb(main):024:0> class Anfitriao
+irb(main):025:1>   def initialize(nome = "Mundo")
+irb(main):026:2>     @nome = nome
+irb(main):027:2>   end
+irb(main):028:1>   def diz_ola
+irb(main):029:2>     puts "Olá #{@nome}!"
+irb(main):030:2>   end
+irb(main):031:1>   def diz_adeus
+irb(main):032:2>     puts "Adeus #{@nome}, volte sempre."
+irb(main):033:2>   end
+irb(main):034:1> end
+=> nil
+{% endhighlight %}
+
+A nova palavra-chave aqui é `class`. Ela define uma nova classe chamada
+Anfitrião e alguns métodos para essa classe. E o `@nome` ? É
+uma variável de instância e está disponível para todos os métodos da
+classe. Como podemos ver, ela é utilizada por `diz_ola` e `diz_adeus`.
+
+Então como é que fazemos a classe Anfitrião funcionar? [Criamos um
+objeto.](../3/)

--- a/pt_br/documentation/quickstart/3/index.md
+++ b/pt_br/documentation/quickstart/3/index.md
@@ -1,0 +1,235 @@
+---
+layout: page
+title: "Ruby em Vinte Minutos"
+lang: pt_br
+
+header: |
+  <div class="multi-page">
+    <a href="../" title="Parte 1">1</a>
+    <span class="separator"> | </span>
+    <a href="../2/" title="Parte 2">2</a>
+    <span class="separator"> | </span>
+    <strong>3</strong>
+    <span class="separator"> | </span>
+    <a href="../4/" title="Parte 4">4</a>
+  </div>
+  <h1>Ruby em Vinte Minutos</h1>
+
+---
+
+Agora vamos criar e usar um objeto Anfitrião:
+
+{% highlight irb %}
+irb(main):035:0> g = Anfitriao.new("João")
+=> #<Anfitriao:0x16cac @nome="João">
+irb(main):036:0> g.diz_ola
+Ola João
+=> nil
+irb(main):037:0> g.diz_adeus
+Adeus João, volte em breve.
+=> nil
+{% endhighlight %}
+
+Uma vez criado o objeto `g`, ele se lembra de que o nome é João. Mmm, e se
+quisermos acessar diretamente o nome?
+
+{% highlight irb %}
+irb(main):038:0> g.@nome
+SyntaxError: compile error
+(irb):52: syntax error
+        from (irb):52
+{% endhighlight %}
+
+Nope, não conseguimos.
+
+## Objeto por Baixo da Pele
+
+As variáveis de instância escondem-se dentro do objeto. Não estão assim
+tão bem escondidas, podem ser vistas quando se inspeciona o objeto e
+há outras formas de lhes acessar, mas o Ruby é fiel aos bons costumes da
+programação orientada a objetos mantendo os dados o mais privados
+possíveis.
+
+Então, que métodos estão disponíveis para os objetos Anfitrião?
+
+{% highlight irb %}
+irb(main):039:0> Anfitriao.instance_methods
+=> ["method", "send", "object_id", "singleton_methods",
+    "__send__", "equal?", "taint", "frozen?",
+    "instance_variable_get", "kind_of?", "to_a",
+    "instance_eval", "type", "protected_methods", "extend",
+    "eql?", "display", "instance_variable_set", "hash",
+    "is_a?", "to_s", "class", "tainted?", "private_methods",
+    "untaint", "diz_ola", "id", "inspect", "==", "===",
+    "clone", "public_methods", "respond_to?", "freeze",
+    "diz_adeus", "__id__", "=~", "methods", "nil?", "dup",
+    "instance_variables", "instance_of?"]
+{% endhighlight %}
+
+Uau. São muitos métodos. Nós só definimos dois métodos. O que é que
+aconteceu? Bem, estes são **todos** os métodos para os objetos
+Anfitrião, uma lista completa, incluindo os que estão definidos nas
+super-classes de Anfitrião. Se só quisermos listar os métodos
+definidos para a classe Anfitrião, podemos pedir-lhe que não inclua os
+métodos dos seus ancestrais passando-lhe o parâmetro `false`, que
+significa que não queremos os métodos definidos pelos seus ancestrais.
+
+{% highlight irb %}
+irb(main):040:0> Anfitriao.instance_methods(false)
+=> ["diz_adeus", "diz_ola""]
+{% endhighlight %}
+
+Há mais coisas a explorar. Vejamos a que métodos pode responder o nosso
+objeto Anfitrião:
+
+{% highlight irb %}
+irb(main):041:0> g.respond_to?("nome")
+=> false
+irb(main):042:0> g.respond_to?("diz_ola")
+=> true
+irb(main):043:0> g.respond_to?("to_s")
+=> true
+{% endhighlight %}
+
+Assim sabemos que responde a `diz_ola`, e `to_s` (que
+significa “converter algo em uma string”, um método que está definido por
+padrão para todos os objetos), mas que não reconhece `nome` como
+método.
+
+## Modificando Classes – Nunca é Tarde Demais
+
+E se quisermos ver ou alterar o nome? Ruby oferece uma forma fácil
+de fornecer acesso às variáveis de um objeto.
+
+{% highlight irb %}
+irb(main):044:0> class Anfitriao
+irb(main):045:1>   attr_accessor :nome
+irb(main):046:1> end
+=> [:nome, :nome=]
+{% endhighlight %}
+
+Em Ruby, podemos abrir uma classe novamente e alterá-la. As mudanças estarão
+presentes em quaisquer objetos criados e até mesmo nos objetos existentes
+dessa classe. Então vamos criar um novo objeto e vamos brincar com a sua
+propriedade `@nome`.
+
+{% highlight irb %}
+irb(main):047:0> g = Anfitriao.new("Pedro")
+=> #<Anfitriao:0x3c9b0 @nome="Pedro">
+irb(main):048:0> g.respond_to?("nome")
+=> true
+irb(main):049:0> g.respond_to?("nome=")
+=> true
+irb(main):050:0> g.diz_ola
+Ola Pedro
+=> nil
+irb(main):051:0> g.nome="Matilde"
+=> "Matilde"
+irb(main):052:0> g
+=> #<Anfitrion:0x3c9b0 @nome="Matilde">
+irb(main):053:0> g.nome
+=> "Matilde"
+irb(main):054:0> g.diz_ola
+Ola Matilde
+=> nil
+{% endhighlight %}
+
+O uso de `attr_accessor` definiu dois novos métodos para nós:
+`nome` para obter o valor e `nome=` para alterá-lo.
+
+## Saudando a Tudo e a Todos, MegaAnfitriao não Esquece Ninguém!
+
+De qualquer modo este Anfitrião não é assim tão interessante, ele só consegue
+trabalhar com uma pessoa de cada vez. E se tivéssemos uma classe MegaAnfitriao
+que pudesse saudar o mundo inteiro, uma pessoa ou uma lista inteira de pessoas?
+
+Vamos escrever isto num arquivo em vez de usar diretamente o interpretador
+interativo do Ruby (IRB).
+
+Para sair do IRB, digite “quit”, “exit” ou simplesmente pressione “Control+D”.
+
+{% highlight ruby %}
+#!/usr/bin/env ruby
+
+class MegaAnfitriao
+  attr_accessor :nomes
+
+  # Criar o objecto
+  def initialize(nomes = "Mundo")
+    @nomes = nomes
+  end
+
+  # Dizer ola a todos
+  def diz_ola
+    if @nomes.nil?
+      puts "..."
+    elsif @nomes.respond_to?("each")
+      # @nomes é uma lista de algum tipo,
+      # assim podemos iterar!
+      @nomes.each do |nome|
+        puts "Ola #{nome}"
+      end
+    else
+      puts "Ola #{@nomes}"
+    end
+  end
+
+  # Dizer adeus a todos
+  def diz_adeus
+    if @nomes.nil?
+      puts "..."
+    elsif @nomes.respond_to?("join")
+      # Juntar os elementos à lista
+      # usando a vírgula como separador
+      puts "Adeus #{@nomes.join(", ")}. Voltem em breve."
+    else
+      puts "Adeus #{@nomes}. Volta em breve."
+    end
+  end
+
+end
+
+
+if __FILE__ == $0
+  mg = MegaAnfitriao.new
+  mg.diz_ola
+  mg.diz_adeus
+
+  # Alterar o nome para "Diogo"
+  mg.nomes = "Diogo"
+  mg.diz_ola
+  mg.diz_adeus
+
+  # Alterar o nome para um vector de nomes
+  mg.nomes = ["Alberto", "Beatriz", "Carlos",
+    "David", "Ernesto"]
+  mg.diz_ola
+  mg.diz_adeus
+
+  # Alterar para nil
+  mg.nomes = nil
+  mg.diz_ola
+  mg.diz_adeus
+end
+{% endhighlight %}
+
+Salve este arquivo como “ri20min.rb”, e execute-o com o comando
+“ruby ri20min.rb”. O resultado deverá ser:
+
+    Ola Mundo
+    Adeus Mundo. Volta em breve.
+    Ola Diogo
+    Adeus Diogo. Volta em breve.
+    Ola Alberto
+    Ola Beatriz
+    Ola Carlos
+    Ola David
+    Ola Ernesto
+    Adeus Alberto, Beatriz, Carlos, David, Ernesto.
+    Voltem em breve.
+    ...
+    ...
+{: .code}
+
+Há uma série de coisas novas neste exemplo às quais podemos
+[observar mais profundamente](../4/)

--- a/pt_br/documentation/quickstart/4/index.md
+++ b/pt_br/documentation/quickstart/4/index.md
@@ -1,0 +1,153 @@
+---
+layout: page
+title: "Ruby em Vinte Minutos"
+lang: pt_br
+
+header: |
+  <div class="multi-page">
+    <a href="../" title="Parte 1">1</a>
+    <span class="separator"> | </span>
+    <a href="../2/" title="Parte 2">2</a>
+    <span class="separator"> | </span>
+    <a href="../3/" title="Parte 3">3</a>
+    <span class="separator"> | </span>
+    <strong>4</strong>
+  </div>
+  <h1>Ruby em Vinte Minutos</h1>
+
+---
+
+Vejamos então mais a fundo o nosso novo programa, perceba
+que as linhas iniciais começam com um sinal de cerquilha (#). Em Ruby,
+qualquer coisa após um sinal de cerquilha é considerado um comentário e
+é ignorado pelo interpretador. A primeira linha do arquivo é um caso especial,
+em um sistema operacional do tipo Unix, isto diz para o shell como executar
+o arquivo. O restante dos comentários só se encontra ali para clarificação.
+
+O nosso método `diz_ola` tornou-se um pouco mais complexo:
+
+{% highlight ruby %}
+# Dizer ola a todos
+def diz_ola
+  if @nomes.nil?
+    puts "..."
+  elsif @nomes.respond_to?("each")
+    # @nomes é uma lista de algum tipo, iterar!
+    @nomes.each do |nome|
+      puts "Ola #{nome}!"
+    end
+  else
+    puts "Ola #{@nomes}!"
+  end
+end
+{% endhighlight %}
+
+Agora ele verifica a variável de instância `@nomes` para tomar decisões.
+Se for nil, só imprime três pontos. Não há razão para cumprimentar ninguém,
+certo?
+
+## Ciclos e Loops – as Iterações
+
+Se o objeto `@nomes` responde a `each`, isto significa que é algo sobre
+o qual se pode iterar, assim, fazemos iterações sobre o mesmo e saudamos
+cada pessoa à sua vez. Finalmente, se `@nomes` é outra coisa qualquer,
+deixamos que se transforme numa string automaticamente e fazemos a
+saudação padrão.
+
+Vejamos o iterador com mais profundidade:
+
+{% highlight ruby %}
+@nomes.each do |nome|
+  puts "Ola #{nome}!"
+end
+{% endhighlight %}
+
+`each` é um método que aceita um bloco de código e que depois o executa
+para cada elemento numa lista, e o trecho entre `do` e `end` é
+exatamente um desses blocos. Um bloco é como uma função anônima ou
+`lambda`. A variável entre barras verticais é o parâmetro para este
+bloco.
+
+O que acontece aqui é que para cada entrada na lista, `nome` recebe
+esse elemento da lista e depois a expressão `puts "Ola #{nome}!"` é
+executada com esse nome.
+
+A maioria das outras linguagens varrem uma lista usando o loop `for`,
+que em C se assemelha a algo como:
+
+{% highlight c %}
+for (i=0; i<numero_de_elementos; i++)
+{
+  fazer_algo_com(elemento[i]);
+}
+{% endhighlight %}
+
+Isso funciona, mas não é muito elegante. Precisamos de uma variável
+descartável semelhante a `i`, temos que determinar previamente qual o
+tamanho da lista e temos que explicar como percorrer a lista. O modo de
+operar em Ruby é muito mais elegante, os pormenores ficam
+escondidos dentro do método `each`, tudo o que precisamos fazer é dizer-lhe
+o que fazer com cada elemento. Internamente, o método `each` irá
+essencialmente chamar `yield "Albert"`, depois `yield "Brenda"` e depois
+`yield "Charles"`, e assim sucessivamente.
+
+## Blocos, o Grande Brilho das Faces do Ruby
+
+O verdadeiro poder dos blocos é quando tratam de algo mais complexo do que
+listas. Além de tratar dos detalhes simples dos pormenores dentro do método,
+também pode tratar da instalação, da limpeza e dos erros – tudo
+de maneira escondida das preocupações do usuário.
+
+{% highlight ruby %}
+# Diz adeus a todo mundo
+def dizer_adeus
+  if @nomes.nil?
+    puts "..."
+  elsif @nomes.respond_to?("join")
+    # Juntar os elementos da lista com vírgulas
+    puts "Adeus #{@nomes.join(", ")}.  Voltem em breve!"
+  else
+    puts "Adeus #{@nomes}.  Volta em breve!"
+  end
+end
+{% endhighlight %}
+
+O método `diz_adeus` não usa o método `each`, em vez disso verifica se
+`@nomes` responde ao método `join` e se sim, usa-o. Caso contrário
+limita-se a imprimir a variável como string. Este método não se preocupa
+com o tipo da variável, só confiar em quais métodos suporta é conhecido como
+“Duck Typing”, no sentido de que “se anda como um pato, e faz quá quá como
+um pato então…”. A vantagem disto é não restringir desnecessariamente
+os tipos de variáveis suportados. Se alguém aparecer com um novo tipo
+de classe de lista, desde que essa lista implemente o método `join`
+com a mesma semântica que as outras listas, então tudo funcionará
+conforme o planejado.
+
+## Executando o Script
+
+Então, essa é a classe MegaAnfitrião, o resto do arquivo só
+chama os métodos nessa classe. Existe um último truque para
+verificarmos, que é a linha:
+
+{% highlight ruby %}
+if __FILE__ == $0
+{% endhighlight %}
+
+`__FILE__` é uma variável mágica que contém o nome do arquivo atual.
+`$0` é o nome do arquivo usado para iniciar o programa. Esta
+verificação diz: “Se este é o arquivo principal a ser usado, então…”,
+isto permite que um arquivo seja usado como biblioteca e nesse contexto
+não executar código, mas caso o arquivo seja usado como executável então
+executa esse código.
+
+## Considere-se Apresentado ao Ruby
+
+Pronto, essa foi uma visita rápida ao mundo do Ruby. Existe muito mais para
+explorar, as diferentes estruturas de controlo que o Ruby oferece; o uso
+de blocos e de `yield`; módulos como _mixins_; e muito mais. Espero que
+esta pequena amostra da linguagem Ruby tenha deixado o desejo de
+aprender mais.
+
+Se este for o caso, por favor visite a nossa seção de
+[Documentação](/pt_br/documentation/) , que reune links para manuais e tutoriais,
+todos disponíveis livremente online.

--- a/pt_br/documentation/quickstart/index.md
+++ b/pt_br/documentation/quickstart/index.md
@@ -1,0 +1,145 @@
+---
+layout: page
+title: "Ruby em Vinte Minutos"
+lang: pt_br
+
+header: |
+  <div class="multi-page">
+    <strong>1</strong>
+    <span class="separator"> | </span>
+    <a href="2/" title="Parte 2">2</a>
+    <span class="separator"> | </span>
+    <a href="3/" title="Parte 3">3</a>
+    <span class="separator"> | </span>
+    <a href="4/" title="Parte 4">4</a>
+  </div>
+  <h1>Ruby em Vinte Minutos</h1>
+
+---
+
+## Introdução
+
+Este é um pequeno tutorial de Ruby que não deverá demorar mais de 20
+minutos para completar. Ele presume que você já tem o Ruby instalado.
+(Se não tiver o Ruby no seu computador, faça o [download][installation]
+e instale-o antes de começar.)
+
+## Ruby Interativo
+
+O Ruby vem com um programa que mostrará os resultados de quaisquer
+instruções que você digitar. Brincar com código Ruby em sessões interativas
+como essa é um jeito formidável de aprender a linguagem.
+
+Abra o IRB (que significa _Interactive Ruby_).
+
+* Se estiver usando **macOS** abra o `Terminal`, escreva `irb`, e depois
+  pressione a tecla enter.
+* Se estiver usando **Linux**, abra um shell e escreva `irb`, seguido de
+  enter.
+* Se estiver usando **Windows**, abra `Interactive Ruby` a partir do atalho
+  para o Ruby no seu menu Iniciar.
+
+{% highlight irb %}
+irb(main):001:0>
+{% endhighlight %}
+
+Ok, ele abriu. E agora?
+
+Escreva isto: `"Ola Mundo"`
+
+{% highlight irb %}
+irb(main):001:0> "Ola Mundo"
+=> "Ola Mundo"
+{% endhighlight %}
+
+## O Ruby te Obedeceu!
+
+O que é que aconteceu? Será que acabamos de escrever o menor
+programa de “Olá mundo” do mundo? Não exatamente, a segunda linha é a forma do
+IRB nos dizer qual o resultado da última expressão que ele avaliou. Se
+desejarmos imprimir “Ola Mundo”, necessitamos de um pouco mais:
+
+{% highlight irb %}
+irb(main):002:0> puts "Ola Mundo"
+Ola Mundo
+=> nil
+{% endhighlight %}
+
+`puts` é o comando básico para imprimir algo em Ruby. Mas então o que é
+aquele `=> nil` ? É o resultado da expressão. `puts` sempre retorna nil,
+que em Ruby é o valor que representa o nada absoluto.
+
+## Sua Calculadora Gratuita está Aqui!
+
+Já temos neste momento conhecimento suficiente para utilizar o IRB como
+uma calculadora básica:
+
+{% highlight irb %}
+irb(main):003:0> 3+2
+=> 5
+{% endhighlight %}
+
+Três mais dois. Muito fácil. Mas e três *vezes* dois? Você pode
+escrevê-lo, é suficientemente curto, mas também podemos voltar atrás e
+mudar o que acabamos de inserir. Pressione **Seta para cima** no
+teclado e veja se ele o leva à linha com `3+2`. Se isso acontecer, use a
+tecla da seta para a esquerda para mover o cursor para a frente do sinal
+de `+` e depois use a tecla de backspace para mudar o sinal para `*`.
+
+{% highlight irb %}
+irb(main):004:0> 3*2
+=> 6
+{% endhighlight %}
+
+Em seguida vamos tentar três ao quadrado:
+
+{% highlight irb %}
+irb(main):005:0> 3**2
+=> 9
+{% endhighlight %}
+
+Em Ruby `**` é a forma de dizer “a potência de”. Mas o que acontece quando
+queremos saber o inverso disto, ou seja, a raiz quadrada de algo?
+
+{% highlight irb %}
+irb(main):006:0> Math.sqrt(9)
+=> 3.0
+{% endhighlight %}
+
+Muito bem, o que aconteceu aqui? Se você achou que ele “estava descobrindo
+a raiz quadrada de nove” então está correto. Mas vejamos as coisas com
+mais detalhes. Primeiramente, o que é `Math`?
+
+## Módulos Agrupam Código por Tópicos
+
+`Math` é um módulo nativo para funções matemáticas. Os módulos têm dois
+papeis em Ruby. Este é um desses papeis: agrupar métodos semelhantes sob
+um nome familiar. `Math` também contém métodos como `sin()` e `tan()`.
+
+Depois segue-se um ponto. O que faz o ponto? O ponto é como
+se identifica o receptor de uma mensagem. Qual é a mensagem? Neste caso
+é `sqrt(9)`, o que significa chamar o método `sqrt`, uma abreviatura em
+língua inglesa para “square root” (raiz quadrada) com o parâmetro `9`.
+
+O resultado desta chamada de método é o valor `3.0`. Se repararmos bem,
+o resultado não é apenas `3`. Mas isso deve-se ao fato de que a raiz quadrada
+de um número na maioria dos casos não é um inteiro e, assim sendo, o
+método retorna sempre um número de ponto flutuante.
+
+E se nós quisermos lembrar do resultado dessa matemática toda? Podemos
+atribuir o resultado a uma variável.
+
+{% highlight irb %}
+irb(main):007:0> a = 3 ** 2
+=> 9
+irb(main):008:0> b = 4 ** 2
+=> 16
+irb(main):009:0> Math.sqrt(a+b)
+=> 5.0
+{% endhighlight %}
+
+Como calculadora isto é muito bom, mas nós estamos nos afastando da
+mensagem tradicional de `Ola Mundo` em que os tutoriais para iniciantes
+normalmente focam… [portanto vamos voltar ao assunto.](2/)
+
+[installation]: /pt_br/documentation/installation/

--- a/pt_br/documentation/ruby-from-other-languages/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/index.md
@@ -1,0 +1,442 @@
+---
+layout: page
+title: "Ruby a Partir de Outras Linguagens"
+lang: pt_br
+---
+
+Quando olha pela primeira vez para um pedaço de código Ruby,
+lembrar-se-á, muito provavelmente, de outras linguagens de programação
+que já utilizou. Isto é de propósito. Muita da sintaxe é familiar a
+utilizadores de Perl, Python e Java (entre outras linguagens). Assim
+sendo, se já usou alguma delas, aprender Ruby será muito fácil.
+{: .summary}
+
+Este documento contém duas secções principais. A primeira, tenta ser um
+sumário introdutório daquilo que poderá esperar enquanto muda de uma
+linguagem *X* para Ruby. A segunda secção encarrega-se das
+características principais da linguagem e como elas se comparam com
+aquilo que já se encontra familiarizado.
+
+## O Que Esperar: *Linguagem X* para Ruby
+
+* [Para Ruby a partir de C e C++](to-ruby-from-c-and-cpp/)
+* [Para Ruby a partir de Java](to-ruby-from-java/)
+* [Para Ruby a partir de Perl](to-ruby-from-perl/)
+* [Para Ruby a partir de PHP](to-ruby-from-php/)
+* [Para Ruby a partir de Python](to-ruby-from-python/)
+
+## Características Importantes da Linguagem e Algumas Notas
+
+Aqui ficam alguns apontamentos e dicas das principais características
+que irá encontrar enquanto vai aprendendo Ruby.
+
+### Iterações
+
+Duas características do Ruby são um pouco diferentes daquilo que já
+alguma vez viu, e é necessário algum tempo para se habituar a elas:
+“blocos” e iteradores. Em vez de fazer um ciclo sobre um índice (como no
+C, C++, ou Java pre-1.5), ou sobre uma lista (como o `for (@a) {...}`
+do Perl ou `for i in Lista: ...` do Python, em Ruby irá frequentemente ver
+
+{% highlight ruby %}
+alguma_lista.each do |este_item|
+  # Estamos dentro do bloco.
+  # tratamos este_item.
+end
+{% endhighlight %}
+
+Para mais informação sobre o mé `each` (e `collect`, `find`, `inject`,
+`sort`, etc.), Ver `ri Enumerable`
+(e depois `ri Enumerable#nome_da_função`).
+
+### Tudo tem um valor
+
+Não existe diferença entre uma expressão e uma declaração. Tudo tem um
+valor, mesmo que seja **nil**. Isto é possível:
+
+{% highlight ruby %}
+x = 10
+y = 11
+z = if x < y
+      true
+    else
+      false
+    end
+z # => true
+{% endhighlight %}
+
+### Símbolos não são Strings
+
+Muitos principiantes de Ruby lutam por perceber o que são símbolos e
+para quê que podem ser utilizados.
+
+Símbolos podem ser descritos como identidades. Um símbolo é tudo sobre
+**quem** é, não sobre **o que** é. Arranque o `irb` e veja a diferença:
+
+{% highlight irb %}
+irb(main):001:0> :jorge.object_id == :jorge.object_id
+=> true
+irb(main):002:0> "jorge".object_id == "jorge".object_id
+=> false
+irb(main):003:0>
+{% endhighlight %}
+
+Os métodos *`object_id`* retornam a identidade de um Objecto. Se dois
+objectos têm o mesmo *`object_id`*, então são o mesmo (apontam para o
+mesmo objecto em memória).
+
+Como pode verificar quando utilizou pela primeira vez um símbolo,
+qualquer símbolo com os mesmos caracteres referencia o mesmo objecto em
+memória. Para quaisquer dois símbolos que representem os mesmos
+caracteres os *`object_id`* são os mesmos.
+
+Agora atente na *String*(“jorge”). Os *`object_id`* não são os mesmos.
+Isto significa que referenciam dois objectos diferentes em memória.
+Sempre que se utiliza uma nova String, o Ruby faz alocação de memória
+para esta.
+
+Se tiver dúvidas na utilização entre um símbolo e uma *String*,
+considere o que é mais importante: a identidade de um objecto (p.e.
+chave da tabela de Hashing), ou os conteúdos (no exemplo acima,
+“jorge”).
+
+### Tudo é um objecto
+
+“Tudo é um Objecto” não é só uma hipérbole. Mesmo as classes e os
+inteiros são objectos e poderá fazer o mesmo com eles o mesmo que faz
+com qualquer outro objecto:
+
+{% highlight ruby %}
+# Isto e' o mesmo que
+# class AMinhaClasse
+#   attr_accessor :variavel_de_instancia
+# end
+AMinhaClasse = Class.new do
+  attr_accessor :variavel_de_instancia
+end
+{% endhighlight %}
+
+### Constantes Variáveis
+
+As constantes não são verdadadeiramente constantes. Se modificar uma
+constante já inicializada, activar-se-á um aviso, mas o seu programa não
+terminará. No entanto, isto não quer dizer, que **deverá** redefinir
+constantes.
+
+### Convenções na Nomenclatura
+
+O Ruby obriga a algumas convenções na nomenclatura. Se um identificador
+começar com:
+
+* Letra Maiúscula, é uma *constante*;
+* `$`, é uma variável global;
+* `@`, é uma variável de instância;
+* `@@` é uma variável de classe.
+
+Apesar de tudo os nomes dos métodos permite-se que comecem com letras
+maiúsculas Isto poderá tornar-se confuso, como se pode ver o exemplo
+seguinte mostra:
+
+{% highlight ruby %}
+Constante = 10
+def Constante
+  11
+end
+{% endhighlight %}
+
+Agora `Constante` é 10, mas `Constante()` é 11.
+
+### Argumentos nomeados
+
+Como em Python, desde a versão Ruby 2.0, métodos podem ser definidos
+usando argumentos nomeados. Exemplo:
+
+{% highlight ruby %}
+def deliver(from: "A", to: nil, via: "mail")
+  "Enviando de #{from} para #{to} através de #{via}."
+end
+
+deliver(to: "B")
+# => "Enviando de A para B atavés de mail."
+deliver(via: "Pony Express", from: "B", to: "A")
+# => "Enviando de B para A através de Pony Express."
+{% endhighlight %}
+
+### A Propriedade Universal
+
+Tudo em Ruby, excepto **nil** e **false**, é considerado verdadeiro. Em
+C, Python e em muitas outras linguagens, 0 and possivelmente outros
+valores, tais como listas vazias, são consideradas falsas. Veja o
+seguinte código Python (o exemplo aplica-se a outras linguagens também):
+
+{% highlight python %}
+# em Python
+if 0:
+  print("0 e' verdadeiro")
+else:
+  print("0 e' falso")
+{% endhighlight %}
+
+Isto irá imprimir “0 e’ falso”. O equivalente em Ruby:
+
+{% highlight ruby %}
+# em Ruby
+if 0
+  puts "0 e' verdadeiro"
+else
+  puts "0 e' falso"
+end
+{% endhighlight %}
+
+imprime “0 e’ verdadeiro”.
+
+###  *Access modifiers* aplicam-se até ao fim do âmbito
+
+No seguinte código Ruby,
+
+{% highlight ruby %}
+class AMinhaClasse
+  private
+  def um_metodo; true; end
+  def outro_metodo; false; end
+end
+{% endhighlight %}
+
+Poderá pensar que `outro_metodo` seja público. Não é verdade. O
+`private` access modifier continua até ao fim do escopo, ou até que
+outro access modifier apareça, qualquer que apareça primeiro.
+
+Por omissão, os métodos são públicos:
+
+{% highlight ruby %}
+class MyClass
+  # Agora um_metodo é público
+  def um_metodo; true; end
+
+  private
+
+  # another_method is private
+  def outro_metodo; false; end
+end
+{% endhighlight %}
+
+`public`, `private` e `protected` são, na verdade, métodos, por isso podem levar parâmetros. Se passar um Symbol a um deles, a visibilidade desse método é alterada.
+
+### Acesso a métodos
+
+Em Java, `public` significa que um método é acessível por todos;
+`protected` significa que instâncias da classe, instâncias de classes
+descendentes e instâncias das classes no mesmo *package* podem aceder,
+mas mais nada pode; `private` significa que nada, para além das
+instâncias da classe podem aceder ao método.
+
+Em Ruby existem diferenças: `public` é, claro, público; `private`
+significa que os métodos são acessíveis somente quando chamados com um
+receptor específico. Só **self** pode ser o receptor dum método privado
+Only **self** is allowed to be the receiver of a private method call.
+
+`protected` é aquele que se deve ter mais cuidado. Um método protegido pode ser chamado de uma class ou classes descendentes, mas também com outra instância como receptor. Exemplo adaptado da [Ruby Language FAQ][faq]:
+
+{% highlight ruby %}
+class Test
+  # public por omissao
+  def identifier
+    99
+  end
+
+  def ==(other)
+    identifier == other.identifier
+  end
+end
+
+t1 = Test.new  # => #<Test:0x34ab50>
+t2 = Test.new  # => #<Test:0x342784>
+t1 == t2       # => true
+
+# seja `identifier' protected. ainda funciona
+# porque protected permite a outra referência
+
+class Test
+  protected :identifier
+end
+
+t1 == t2  # => true
+
+# seja `identifier' private
+
+class Test
+  private :identifier
+end
+
+t1 == t2
+# NoMethodError: private method `identifier' called for #<Test:0x342784>
+{% endhighlight %}
+
+### As Classes são abertas
+
+As classes em Ruby são abertas. Poderá abrir, adicionar e alterá-las a
+qualquer altura. Mesmo as classes do núcleo como por exemplo `Integer` ou
+mesmo a classe `Object`, a classe de topo. O Ruby on Rails define uma
+quantidade de métodos para lidar com as horas na classe `Integer`. Veja:
+
+{% highlight ruby %}
+class Integer
+  def horas
+    self * 3600 # nu'mero de segundos numa hora
+  end
+  alias hora horas
+end
+
+# 14 horas depois da meia noite de 1 de Janeiro
+# (também as horas a que costuma acordar nesse dia ;) )
+Time.mktime(2006, 01, 01) + 14.horas # => Sun Jan 01 14:00:00
+{% endhighlight %}
+
+### Nomes engraçados para métodos
+
+Em Ruby, os métodos podem terminar com pontos de interrogação e de
+exclamação. Por convenção, métodos que respondem a questões (p.e.
+`Array#empty?` devolve **true** se o receptor é vazio) terminam
+em ponto de interrogação. Métodos potencialmente “perigosos” (ie métodos
+que modificam **self** ou os argumentos, `exit!`, etc.) por convenção
+terminam em ponto de exclamação.
+
+No entanto, todos os métodos que alteram os seus argumentos não terminam
+com pontos de exclamação. `Array#replace` substitui os conteúdos
+de um array com os de um outro array. Não faz muito sentido ter um
+método como este que **não** modifique self.
+
+### Singleton methods
+
+Singleton Methods são métodos que só se encontram disponíveis no objecto
+em que foi definido.
+
+{% highlight ruby %}
+class Car
+  def inspect
+    "Carro barato"
+  end
+end
+
+porsche = Car.new
+porsche.inspect # => Carro barato
+def porsche.inspect
+  "Carro caro"
+end
+
+porsche.inspect # => Carro caro
+
+# Os outros objectos não são afectados
+other_car = Car.new
+other_car.inspect # => Carro barato
+{% endhighlight %}
+
+### Missing methods
+
+Ruby doesn’t give up if it can’t find a method that responds to a
+particular message. It calls the `method_missing` method with the name
+of the method it couldn’t find and the arguments. By default,
+`method_missing` raises a NameError exception, but you can redefine it to
+better fit your application, and many libraries do. Here is an example:
+
+{% highlight ruby %}
+# id is the name of the method called, the * syntax collects
+# all the arguments in an array named 'arguments'
+def method_missing(id, *arguments)
+  puts "Method #{id} was called, but not found. It has " +
+       "these arguments: #{arguments.join(", ")}"
+end
+
+__ :a, :b, 10
+# => Method __ was called, but not found. It has these
+# arguments: a, b, 10
+{% endhighlight %}
+
+The code above just prints the details of the call, but you are free to
+handle the message in any way that is appropriate.
+
+### Troca de mensagens. Chamadas a funções, não!
+
+A invocação de um método é na verdade uma **mensagem** para outro
+objecto:
+
+{% highlight ruby %}
+# Este
+1 + 2
+# E' o mesmo que este...
+1.+(2)
+# Que e' o mesmo que este:
+1.send "+", 2
+{% endhighlight %}
+
+### Blocos são Objectos, só que estes ainda não o sabem
+
+Blocos (fechos, na verdade) são extremamente usados na biblioteca
+*standard*. Para chamar um bloco, poderá usar `yield`, ou torná-lo num
+`Proc` adicionando um argumento especial à lista de argumentos, como:
+
+Blocks (closures, really) are heavily used by the standard library. To
+call a block, you can either use `yield`, or make it a `Proc` by
+appending a special argument to the argument list, like so:
+
+{% highlight ruby %}
+def block(&o_bloco)
+  # Aqui dentro, o_bloco é o bloco passado ao método o_bloco
+  o_bloco # devolve o bloco
+end
+somador = block { |a, b| a + b }
+# somador e' agora um objecto Proc
+adder.class # => Proc
+{% endhighlight %}
+
+Também, poderá criar blocos fora de chamadas a métodos: chamando
+`Proc.new` com um bloco; ou chamando o método `lambda`.
+
+Da mesma forma, métodos são também Objectos:
+
+Similarly, methods are also Objects in the making:
+
+{% highlight ruby %}
+method(:puts).call "puts e' um objecto!"
+# => puts e' um objecto!
+{% endhighlight %}
+
+### Operadores e Açúcar Sintáctico
+
+A maioria dos operadores em Ruby são somente açúcar sintático (com
+algumas regras de precedência) para chamadas a métodos. Poderá, por
+exemplo, redifinir o método + da classe Integer:
+
+{% highlight ruby %}
+class Integer
+  # Pode fazer, mas por favor não faça isto
+  def +(outro)
+    self - outro
+  end
+end
+{% endhighlight %}
+
+Não necessita do `operador+`, etc., do C++.
+
+Pode ainda ter um acesso no estilo de um array se definir os métodos
+`[]` e `[]=`. Para definir as operações unárias + e – (pense em +1 e
+-2), tem que definir os métodos `+@` e `-@`, respectivamente.
+
+Os operadores abaixo não são, no entanto, açúcar sintáctico.Não são
+métodos, e não podem ser redifinidos:
+
+{% highlight ruby %}
+=, .., ..., not, &&, and, ||, or, ::
+{% endhighlight %}
+
+Como `+=`, `*=` etc. são somente abreviações para `var = var + outra_var`,
+`var = var * outra_var`, etc. não podem ser redefinidos.
+
+## Mais informação
+
+Quando se sentir preparado para saber mais sobre Ruby, veja a nossa
+secção de [Documentação](/pt_br/documentation/).
+
+
+
+[faq]: http://ruby-doc.org/docs/ruby-doc-bundle/FAQ/FAQ.html

--- a/pt_br/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/to-ruby-from-c-and-cpp/index.md
@@ -1,0 +1,169 @@
+---
+layout: page
+title: "Para Ruby a partir de C e C++"
+lang: pt_br
+---
+
+É difícil escrever uma lista balizada demonstrando como o seu código
+será diferente em Ruby por comparação a C e C++ pois a diferença é
+tremenda. Uma das razões, é que o Ruby runtime faz muito do trabalho
+pelo programador.
+
+O Ruby parece estar tão longe quanto possível do principio de “sem
+mecanismos escondidos” do C — o objectivo principal do Ruby é
+tornar o trabalho humano mais fácil ás custas de entregar ao runtime um
+maior volume de trabalho. A menos que, ou até que, se dedique a
+optimizar o seu código, não terá de se preocupar minimamente em “manter
+o seu compilador feliz” quando usa o Ruby.
+
+Dito isto, e para começar, deverá esperar que o seu código Ruby seja
+executado muito mais lentamente do que código “equivalente” em C ou C++.
+Ao mesmo tempo, ficará espantado com a rapidez com a qual poderá pôr um
+programa em Ruby a correr, bem como com a quantidade diminuta de linhas
+de código necessárias para o escrever. O Ruby é muito, muito mais
+simples que o C++—irá estraga-lo com mimos!
+
+O Ruby é tipado dinamicamente e não estaticamente—o runtime faz tanto
+trabalho quanto possível em tempo de execução. Por exemplo, o
+programador não precisará de saber a que módulos o seu programa em Ruby
+irá “ligar-se” (isto é, carregar e usar) ou saber de antemão que métodos
+irá chamar.
+
+Felizmente, acontece que o Ruby e o C mantêm uma saudável relação
+simbiótica. O Ruby suporta os chamados “módulos de expansão”. Estes são
+um tipo de módulo que se pode usar a partir da sua aplicação em Ruby (e
+que, vistos do exterior parecem ser e agem como qualquer outro módulo de
+Ruby), mas que no entanto são escritos em C. Deste modo, poderá dividir
+as partes do seu projecto em Ruby e utilizar C puro onde a performance é
+mais critica.
+
+E, claro, o Ruby em si é escrito em C.
+
+### Semelhanças com o C
+
+Como em C, no Ruby…
+
+* Poderá programar processualmente (no entanto o código será orientado a
+  objectos por detrás de cena)
+* Os operadores são, na sua maioria, os mesmos (inclusive os operadores
+  de atribuição composta (exe.: a \*= b + c) e também os operadores de
+  lógica binária). No entanto o Ruby não tem os operadores `++` e `--`.
+* Tem o `__FILE__` e o `__LINE__`.
+* Pode usar constantes, no entanto não existe a palavra reservada
+  `const`. A “constância” é garantida por uma convenção de nomenclatura
+  – todos os nomes começados com letra maiúscula são reservados para
+  constantes.
+* As strings (cadeias de caracteres em C) são delimitadas por aspas.
+* As strings são mutáveis.
+* Tal como as man pages, poderá ler a maioria da documentação no
+  terminal – usando para isso o comando `ri`
+* Tem o mesmo tipo de depuradores em linha de comandos.
+
+### Semelhanças com o C++
+
+Como com o C++, em Ruby…
+
+* A maioria dos operadores são os mesmos (inclusive o `::`). É comum
+  utilizar `<<` para acrescentar elementos a uma lista. No entanto
+  atenção: em Ruby nunca se usa `->`—é sempre `.`.
+* As palavras reservadas `public`, `private` e `protected` têm
+  comportamentos semelhantes.
+* A sintaxe de herança é ainda apenas um caracter, mas é o `<` em vez de
+  `:` .
+* Pode colocar o seu código em “módulos”, semelhantes ao modo como o
+  `namespace` é usado em C++.
+* As excepções têm um funcionamento semelhante, no entanto a
+  nomenclatura das palavras reservadas foi mudada para proteger os
+  inocentes!
+
+### Diferenças do C
+
+Ao contrario do C, em Ruby…
+
+* Os objectos são fortemente tipados (e as próprias variáveis não têm
+  qualquer tipo).
+* Não existem macros ou pre-processador. Não existem casts. Não existem
+  ponteiros (nem aritmética de ponteiros). Não existem typedefs, sizeof
+  ou enums.
+* Não existem ficheiros header. Basta definir funções (normalmente
+  chamados de “métodos”) e classes nos ficheiros de código fonte.
+* Não se usa `#define`. Ao invés usam-se constantes.
+* A partir da versão 1.8 de Ruby, o código é interpretado em tempo de
+  execução em vês de ser compilado para qualquer tipo de código maquina
+  ou binário.
+* As variaveis residem em memoria. Mais ainda, não precisam de se
+  preocupar em liberta-las—o `garbage collector` encarrega-se disso por
+  si.
+* Os argumentos são passados aos métodos (por exemplo: funções) por
+  referência, não por valor.
+* Usa-se `require 'foo'` em vez de `#include <foo>` ou `#include "foo"`.
+* Não se pode baixar ao assembly.
+* As linhas não acabam com ponto e virgula.
+* Nas construções lógicas `if` e `while` não se usam parênteses.
+* A utilização de parênteses na chamada a metodos (por exemplo: funções)
+  é normalmente opcional.
+* Normalmente não se usa chavetas – basta usar a palavra reservada end
+  para terminar um bloco de código expandido por múltiplas linhas(por
+  exemplo um ciclo `while`).
+* A palavra reservada `do` é utilizada nos chamados “blocos”. Não existe
+  a construção `do` como em C.
+* O termo “bloco” é usado para algo completamente diferente. Usa-se para
+  bloco de código que se associa a uma chamada de método para que o
+  corpo do método possa fazer chamadas ao bloco enquanto é executado.
+* Não existem declarações de variáveis. Simplesmente atribuem-se valores
+  assim que surja a necessidade.
+* Num teste lógico, apenas false e nil são avaliados como falso. Tudo o
+  resto é verdadeiro (incluindo `0`, `0.0`, e `"0"`).
+* Não existe o `char`—é apenas uma string de apenas uma letra.
+* As strings não acabam com um byte nulo.
+* Os arrays literais são colocados dentro de parênteses rectos em vez de
+  chavetas.
+* Os arrays crescem automaticamente quando se lhes acrescente elementos.
+* Se somar dois arrays obterá um array novo e maior (alojado em memoria,
+  é claro) em vez de fazer aritmética de ponteiros.
+* Frequentemente tudo será considerado uma expressão (o que quer dizer
+  que coisas como ciclos `while` serão avaliados com um `rvalue`).
+
+### Diferenças do C++
+
+Ao contrario do C++, no Ruby,...
+
+* Não existem referências explícitas. O que quer dizer que em Ruby cada
+  variável e apenas um nome automaticamente desreferenciado para algum
+  objecto.
+* Os objectos são fortemente mas dinamicamente tipados. O runtime
+  descobre em tempo de execução se a chamada a método realmente
+  funciona.
+* O “construtor” é chamado `initialize` em vez de um nome de uma classe.
+* Todos os métodos são sempre virtuais.
+* Nomes de variáveis de classe (estáticas) começam sempre por
+  `@` (por exemplo `@valor_total`).
+* Não se pode aceder directamente a variáveis de membros todo o acesso a
+  variáveis públicas de membros (chamadas em Ruby de atributos) é feito
+  através de métodos.
+* Usa-se `self` em vez de `this`.
+* Alguns nomes de métodos terminam em ’?’ ou ’!’. E a terminação faz
+  realmente parte do nome.
+* Não existe múltipla herança por si só. Embora em Ruby possa haver
+  “mixins” (por exe.: pode-se herdar todas as instancias de métodos de
+  um modulo).
+* Nas chamadas a métodos, os parênteses são opcionais.
+* Pode-se reabrir uma classe a qualquer momento e adicionar novos
+  métodos.
+* Não há a necessidade de utilização de templates de C++ (uma vez que se
+  pode atribuir qualquer tipo de objecto a qualquer variável e os tipos
+  são descobertos em tempo de execução de qualquer modo). Também não
+  existe casting.
+* A iteração é feita de uma maneira algo diferente. Em Ruby não
+  utilizará um objecto iterador separado (como por exemplo
+  `vector<T>:const_iterator iter`) mas ao invés os objectos criados
+  podem misturar o modulo `enumerator` e fazer uma chamada a um método
+  como por exemplo `meu_obj.each`.
+* Existem apenas dois tipos contentores: `Array` e `Hash`.
+* Não existe conversão de tipo. No entanto provavelmente aperceber-se-á
+  que tal não é necessário.
+* As capacidades multithreading são nativas, mas a partir do Ruby 1.8,
+  elas são “threads ecológicas” (implementadas apenas dentro do
+  interpretador) por oposição a threads nativas.
+* O Ruby vem complementado com uma biblioteca standard de testes
+  unitários.

--- a/pt_br/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/to-ruby-from-java/index.md
@@ -1,0 +1,58 @@
+---
+layout: page
+title: "Para Ruby a partir de Java"
+lang: pt_br
+---
+
+Java é maduro. Está testado. E é rápido (contrariamente ao que todos os grupos anti-java possam dizer). Também é bastante palavroso. Ao passares de Java para Ruby, o programador poderá esperar que o tamanho do seu código diminua consideravelmente. Também poderá esperar demorar menos tempo a criar um prototipo aplicacional.
+
+### Semelhanças
+
+Tal como em Java, em Ruby…
+
+* A memoria é gerida automaticamente através de um garbage collector.
+* Os Objectos são fortemente tipados.
+* Existem métodos públicos, privados e protegidos.
+* Existem ferramentas de documentação embebidas (a de Ruby chama-se
+  RDoc). A documentação gerada pelo RDoc tem um aspecto muito parecido
+  aquela gerada pelo Javadoc.
+
+### Diferenças
+
+Ao contrário de Java, em Ruby…
+
+* Não precisará de compilar código-fonte, pois este é executado
+  directamente.
+* Existem vários conjuntos de ferramentas de desenvolvimento com
+  interface gráfica (GUI). Os utilizadores de Ruby podem experimentar
+  [WxRuby][1], [FXRuby][2], [Ruby-GNOME2][3], [Qt][4],
+  ou o biblioteca nativa Ruby Tk, por exemplo.
+* Utiliza-se a palavra-chave `end` para terminar a definição de uma
+  classe em vez de se colocar parentesis á volta de blocos de código.
+* Utiliza-se o `require` em vez de `import`.
+* Todas as variáveis de instância são privadas. Podem, no entanto, ser
+  acedidas externamente através de métodos.
+* Os parêntesis nas chamadas aos métodos são normalmente opcionais e
+  muitas vezes omitidas.
+* Tudo é um objecto, incluído numeros como 2 ou o 3.14159.
+* Não existe validação estática de tipos de dados.
+* Os nomes de variáveis são apenas etiquetas. Não têm qualquer tipo de
+  dado associado a elas.
+* Não existe declaração de tipo de dados, estes são associados a novos
+  nomes de variáveis conforme se necessite (por exemplo `a = [1,2,3]` em
+  vez de `int[] a = {1,2,3};`).
+* Não existe transformação de tipos de dados (casting). Basta chamar os
+  métodos. Os seus testes unitários deverão avisa-lo se existe uma
+  excepção antes da execução do código.
+* Escreve-se `foo = Foo.new("ola")` em vez de `Foo foo = new Foo("ola")`.
+* O construtor é sempre chamado “initialize” em vez do nome da classe.
+* Temos “mixins” em vez de interfaces.
+* O uso de YAML é favorecido em relação ao XML.
+* Utiliza-se `nil` em vez de `null`.
+
+
+
+[1]: https://github.com/eumario/wxruby
+[2]: https://github.com/larskanis/fxruby
+[3]: https://ruby-gnome2.osdn.jp/
+[4]: https://github.com/ryanmelt/qtbindings/

--- a/pt_br/documentation/ruby-from-other-languages/to-ruby-from-perl/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/to-ruby-from-perl/index.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Para Ruby a partir de Perl"
+lang: pt_br
+---
+
+O Perl é espectacular. A documentação do Perl é espetaculares. A Comunidade de Perl é...
+incrível.
+
+### Semelhanças
+
+Tal como em Perl, em Ruby...
+
+- Existe um sistema de gestão de pacotes, semelhante ao CPAN (chamado
+  [RubyGems][1])
+- O Tratamento de Expressões Regulares (Regexes) está embutido na
+  linguagem. Bon appétit!
+- Existe um número bastante razoável de funcionalidades nativas de uso
+  frequente.
+- Os parênteses são frequentemente opcionais.
+- As strings funcionam essencialmente da mesma forma.
+- Existe uma sitaxe de delimitação de strings e expressões regulares
+  geralmente utilizada semelhante a do Perl. Ele parece `%q{isto}` (single-quoted), or
+  `%Q{isto}` (double-quoted) e `%w{esta é uma lista de palavras single-quoted}`.
+  Você `%Q|pode|` `%Q(usar)` `%Q^outros^` delimitadores que você prefere.
+- Em Ruby existe interpolação de váriaveis entre aspas, `"aplica-se #{desta} forma"` (o código ruby é colocado entre `#{}`).
+- A execução de comandos de sistema através da Shell faz-se com
+  `` `backticks` ``.
+- O Ruby possui ferramenta de documentação embutida (Em Ruby é
+  chamado RDoc).
+
+### Diferenças
+
+Ao contrario do Perl, no Ruby…
+
+- Não existem as regras dependentes do contexto como no Perl.
+- Uma variável não é o mesmo que o objeto ao qual se refere. Em vez
+  disso é sempre um referencia para um objeto.
+- Apesar de `$` e `@` serem utilizados por vezes como os
+  primeiros caracteres nos nomes das variaveis, em vez de indicar o
+  tipo, indicam o escopo `$` para variáveis globais, `@` para
+  instâncias de objetos, e `@@` para atributos de classe).
+- Os elementos de um Array são colocados entre colchetes em vez
+  de parênteses.
+- Criar listas de listas não as reduz a uma grande lista, em vez disso
+  obtem-se um array de arrays.
+- Utiliza-se `def` em vez de `sub`.
+- Não são necessários ponto e vírgula (;) no final de cada linha. As
+  definições de funções, classes e estruturas `case` terminam com a
+  palavra `end`.
+- Os objetos têm tipagem forte. É necessário invocar manualmente os
+  métodos `foo.to_i`, `foo.to_s`, etc., se for necessário converter
+  entre tipos.
+- Não existem `eq`, `ne`, `lt`, `gt`, `ge`, nem `le`.
+- Não existe ‘diamond operator’ (`<>`). Usualmente utiliza-se
+  `IO.alguma_funçao`.
+- O simbolo `=>` é utilizado somente para os elementos de uma tabelas
+  de hash.
+- Não existe `undef`. Em Ruby utiliza-se a expressão `nil`. `nil` é um
+  objeto (tal como tudo o resto em Ruby). Não é o mesmo que uma
+  variável indefinida. Toma sempre o valor `false` se for tratada como
+  um booleano.
+- Quando é feito um teste booleano, somente `false` e `nil` devolvem um
+  valor falso. Tudo o resto é verdadeiro (incluindo `0`, `0.0` e
+  `"0"`).
+- Não há um [PerlMonks][2]. Embora a mailing list do ruby-talk seja um
+  site muito amigável.
+
+[1]: http://guides.rubygems.org
+[2]: http://www.perlmonks.org/

--- a/pt_br/documentation/ruby-from-other-languages/to-ruby-from-php/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/to-ruby-from-php/index.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: "Para Ruby a partir de PHP"
+lang: pt_br
+---
+
+O uso do PHP está generalizado para o desenvolvimento de aplicações web,
+mas se desejar utilizar Ruby on Rails ou simplesmente desejar uma
+linguagem talhada para um uso mais generalizado, vale a pena dar uma
+vista de olhos ao Ruby.
+
+### Semelhanças
+
+Tal como no PHP, em Ruby …
+
+* O Ruby é tipado dinamicamente, tal como o PHP, não é necessário
+  declarar variavéis.
+* Existem classes e é possível controlar o acesso a elas tal como em PHP
+  5 (`public`, `protected` and `private`)
+* Algumas variáveis começam com $, tal como o PHP (mas não todas)
+* Também existe `eval`
+* Pode ser utilizada a interpolação de strings. Em vez de `"$foo é um $bar"`,
+  podemos escrever `"#{foo} é um #{bar}"`—tal como em PHP, isto
+  não se aplica para strings entre ‘plicas’
+* Existem heredocs
+* Ruby tem excepções, tal como o PHP 5
+* Existe uma biblioteca Standard bastante completa
+* Os arrays e as tabelas de hash funcionam da forma esperada, se alterar
+  `array()` por `{` e `}`\: `array('a' => 'b')` fica `{'a' => 'b'}`.
+* `true` e `false` comportam-se tal como no PHP, mas `null` é chamado
+  `nil` em ruby
+
+### Diferenças
+
+Diferente do PHP, em Ruby …
+
+* Existe uma tipagem forte. Deverá utilizar os métodos `to_s`, `to_i`
+  etc. para converter entre strings, inteiros e demais tipos, em vez de
+  confiar na linguagem para o fazer.
+* Strings, números, arrays, hashes, etc. são objectos. Em vez de
+  invocarmos `abs(-1)` é `-1.abs`
+* Os parêntesis são opcionais nas invocações dos métodos, excepto para
+  clarificar que parâmetros são passados para que método.
+* Em vez de convenções de nomes, tal como o uso de underscore (`_`), a
+  biblioteca standard e as extensões estão organizadas em módulos e
+  classes.
+* A Reflexão é uma capacidade inerente dos objectos, não é necessário
+  utilizar Classes `Reflection` tal como no PHP 5
+* As variáveis são referências.
+* Não existe uma classe `abstract` ou `interface`s
+* Hashes e arrays são diferentes não se podem fazer passar uma pelo
+  outro.
+* Somente `false` e `nil` são falsos: `0`, `array()` e `""` são todos
+  verdade em expressões condicionais.
+* Quase tudo é uma invocação de um método, até `raise` (`throw` no PHP).

--- a/pt_br/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
+++ b/pt_br/documentation/ruby-from-other-languages/to-ruby-from-python/index.md
@@ -1,0 +1,68 @@
+---
+layout: page
+title: "Para Ruby a partir de Python"
+lang: pt_br
+---
+
+Python é uma outra boa linguagem de programação. Ir de Python para ruby,
+irá verificar que há um pouco mais de sintaxe a aprender do que em
+Python.
+
+### Similaridades
+
+Assim com em Python, em Ruby…
+
+* Há um prompt interactivo (chamado `irb`).
+* Pode ler documentos na linha de comandos (com o comando `ri` em vez do
+  `pydoc`).
+* Não há terminadores de linha especiais (excepto a usual nova linha).
+* Texto escrito literalmente pode ocupar várias linhas assim como o
+  texto com triplas aspas em Python.
+* Parênteses rectos são para as listas, e parênteses são para
+  dicionários (que, em Ruby, são chamados “hashes”)
+* Arrays funcionam da mesma maneira (adicionando-os entre sí, faz um
+  array maior, mas compondo-os desta forma `a3 = [ a1, a2]` dá-nos um
+  array de arrays).
+* Os objectos são fortemente e dinâmicamente tipados.
+* Tudo é um objecto, e variáveis são apenas referências a objectos.
+* Contudo as palavras chave são um pouco diferentes, as excepções
+  trabalham da mesma forma.
+* Tem ainda ferramentas de documentação embebida (é chamado rdoc em
+  Ruby).
+
+### Diferenças
+
+Em oposição ao Pyhton, no Ruby,...
+
+* As strings são mutáveis.
+* Pode criar constantes (variáveis as quais o valor não pretende mudar).
+* Há algumas “case-conversions” forçadas (ex. nomes de classes começam
+  com uma maiúsculas, variáveis começam com uma letra minúscula).
+* Há apenas um tipo de “list container” (um Array), e é mutável.
+* Texto em aspas permitem sequências de escape (tipo `\t`) e sintaxe
+  especial “expressões de substituição” (as quais permitem inserir o
+  resultado das expressões em Ruby directamente numa outra string sem
+  ter de adicionar `"add " + "strings " + "together"`). Texto em pelicas
+  são como `r"raw strings"` em Python.
+* Não há algo como classes de “novo estilo” e “antigo estilo”. Só um
+  tipo.
+* Nunca há acessos directos aos atributos. Com Ruby, são tudo chamadas a
+  métodos.
+* Os parênteses são opcionais para as chamadas a métodos.
+* Há o `public`, `private`, e `protected` para forçar o acesso, ao invés
+  do Python `_voluntary_` underscore `__convention__`.
+* “mixins” são utilizados ao invés das múltiplas heranças.
+* Pode re-abrir classes em qualquer momento e adicionar mais métodos.
+* Tem o `true` `false` em vez de `True` e `False` (e `nil` em vez de
+  `None`).
+* Assim que testado para verdadeiro, só o `false` e o `nil` avaliam para
+  um valor falso. Tudo o resto é verdadeiro (incluindo `0`, `0.0`, `""`,
+  e `[]`),
+* É `elsif` em vez de `elif`.
+* É `require` instead of `import`. Embora outras vezes, a sua utilização
+  seja a mesma.
+* O estilo comum de comentários nas linhas *acima* das coisas (ao invés
+  de docstrings abaixo delas) são usadas para gerar documentos.
+* Há um número de atalhos que, embora dão mais trabalho a lembrar, irá
+  rapidamente aprender. Eles pretende fazer o Ruby divertido e muito
+  produtivo

--- a/pt_br/documentation/success-stories/index.md
+++ b/pt_br/documentation/success-stories/index.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: "Histórias de Sucesso"
+lang: pt_br
+---
+
+Ruby é utilizado por muitas pessoas de forma profissional ou como hobby.
+Aqui você encontrará uma pequena amostra do uso de Ruby no mundo real.
+{: .summary}
+
+#### Simulações
+
+* [NASA Langley Research Center][1] usa Ruby para realizar simulações.
+
+* Um grupo de pesquisa na [Motorola][2] usa Ruby para fazer scripts para
+  um simulador, tanto para gerar cenários como para processar esses mesmos
+  dados depois.
+
+#### Modelagem 3D
+
+* O [Google SketchUp][3] é uma aplicação de modelagem 3D que utiliza o Ruby
+  para sua macro-API de scripting.
+
+#### Negócios
+
+* [Toronto Rehab][4] usa um programa baseado no RubyWebDialogs para
+  gerir e acompanhar o suporte via telefone e pessoal das equipes de
+  help desk de TI e operações de TI.
+
+#### Robótica
+
+* No projeto MORPHA, Ruby foi usado para implementar a parte do
+  controle reativo do robô de serviços da Siemens.
+
+#### Telefonia
+
+* Ruby está sendo utilizado na Lucent num produto de telefonia
+  3G wireless.
+
+#### Administração de Sistemas
+
+* Ruby foi usado para escrever o componente de coleta de dados do
+  sistema de Capacidade unix e Planejamento da [Level 3 Communications][8],
+  que recolhe estatísticas de performance de cerca de 1700 servidores Unix
+  (Solaris e Linux) espalhados pelo mundo.
+
+#### Aplicações Web
+
+* [Basecamp][9], uma aplicação de gestão de projetos online
+  desenvolvida pela [37signals][10] é programada inteiramente em
+  Ruby.
+
+* [A List Apart][11], uma revista para pessoas interessadas na criação
+  de websites que existe desde 1997, foi recentemente renovada e usa uma
+  aplicação personalizada construída em Ruby on Rails.
+
+#### Segurança
+
+* O [Metasploit Framework][metasploit], um projeto open source da comunidade
+  gerenciado pela [Rapid7][rapid7], é uma plataforma gratuita de teste de
+  penetração que permite que profissionais de TI avaliem a segurança
+  de suas redes e aplicações. O projeto Metasploit consiste de mais de
+  700.000 linhas de código e foi baixado mais de um milhão de vezes
+  em 2010.
+  As versões comerciais desenvolvidas pela Rapid7 também são baseadas em Ruby.
+
+
+
+[1]: http://www.larc.nasa.gov/
+[2]: http://www.motorola.com
+[3]: http://www.sketchup.com/
+[4]: https://www.uhn.ca/TorontoRehab
+[8]: http://www.level3.com/
+[9]: http://www.basecamphq.com
+[10]: http://www.37signals.com
+[11]: http://www.alistapart.com
+[metasploit]: http://www.metasploit.com
+[rapid7]: http://www.rapid7.com

--- a/pt_br/downloads/index.md
+++ b/pt_br/downloads/index.md
@@ -1,0 +1,76 @@
+---
+layout: page
+title: "Baixar o Ruby"
+lang: pt_br
+---
+
+Aqui você poderá obter as distribuições mais recentes de Ruby em seus sabores
+preferidos. A versão estável atual é a {{ site.data.downloads.stable[0] }}.
+Por favor certifique-se de ter lido a [Licença do Ruby][license].
+{: .summary}
+
+### Formas de instalar o Ruby
+
+Existem diversas ferramentas para instalar o Ruby em cada grande plataforma:
+
+* No Linux/UNIX, você pode usar o sistema de gerenciamento de pacotes da
+  sua distribuição ou ferramentas de terceiros ([rbenv][rbenv] e [RVM][rvm]).
+* Em máquinas com macOS, você pode usar ferramentas de terceiros ([rbenv][rbenv] e [RVM][rvm]).
+* Em máquinas com Windows, você pode usar o [RubyInstaller][rubyinstaller] ou o pik.
+
+Consulte a página [Instalação][installation] para mais detalhes sobre
+como usar sistemas de gerenciamento de pacotes ou ferramentas de terceiros.
+
+É claro, você também pode instalar Ruby a partir do código fonte em todas
+as principais plataformas.
+
+### Compilando Ruby — Código Fonte
+
+Instalar a partir do código-fonte é uma grande solução para quando você
+estiver confortável o suficiente com a sua plataforma e talvez precise
+de configurações específicas para o seu ambiente. Também é uma boa solução
+quando não houver outros pacotes pré-criados para a sua plataforma.
+
+Consulte a página [Instalação][installation] para detalhes sobre
+como compilar Ruby a partir dos fontes. Se você tiver algum problema
+compilando Ruby, considere utilizar uma das ferramentas de terceiros
+mencionadas acima. Elas podem te ajudar.
+
+* **Versões estáveis:**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+
+{% if site.data.downloads.security_maintenance %}
+* **Com suporte a atualizações de segurança (EOL em breve!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+{% endif %}
+
+{% if site.data.downloads.eol %}
+* **Sem suporte a atualizações (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+{% endif %}
+
+* **Snapshots:**
+  * [Snapshot Estável]({{ site.data.downloads.stable_snapshots[0].url.gz }}):
+    Este é um arquivo compactado com o snapshot mais recente do branch estável.
+  * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
+    Este é um arquivo compactado do que está no Git, criado todas as noites.
+    Ele pode conter bugs ou outros problemas, use por sua própria conta e risco!
+
+Para mais informações sobre os repositórios Subversion e Git do Ruby, consulte
+a nossa página [Núcleo do Ruby](/pt_br/community/ruby-core/).
+
+O código fonte do Ruby está disponível a partir de um conjunto de
+[Sites de _Mirror_][mirrors] pelo mundo afora. Por favor tente
+usar um _mirror_ que está próximo de você.
+
+
+
+[license]: {{ site.license.url }}
+[installation]: /pt_br/documentation/installation/
+[mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/pt_br/examples/cities.md
+++ b/pt_br/examples/cities.md
@@ -1,0 +1,21 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# O Ruby sabe o que você
+# quer dizer, mesmo que isso
+# seja fazer contas em
+# um Array completo
+cidades   = %w[ Londres
+                Oslo
+                Paris
+                Amsterdão
+                Berlim ]
+visitadas = %w[Berlim Oslo]
+
+puts "Ainda me falta " +
+     "visitar " +
+     "as cidades:",
+     cidades - visitadas
+{% endhighlight %}

--- a/pt_br/examples/greeter.md
+++ b/pt_br/examples/greeter.md
@@ -1,0 +1,22 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# A classe Saudação
+class Saudacao
+  def initialize(name)
+    @name = name.capitalize
+  end
+
+  def sauda
+    puts "Olá #{@name}!"
+  end
+end
+
+# Criar um novo objecto
+ola = Saudacao.new("mundo")
+
+# Saída: "Olá Mundo!"
+ola.sauda
+{% endhighlight %}

--- a/pt_br/examples/hello_world.md
+++ b/pt_br/examples/hello_world.md
@@ -1,0 +1,18 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# O famoso programa
+# "Olá Mundo" é trivial
+# em Ruby. Não necessita de:
+#
+# * um método "main"
+# * caracteres escape
+#   de linha
+# * ponto e virgulas
+#
+# Aqui está o código:
+
+puts "Olá Mundo!"
+{% endhighlight %}

--- a/pt_br/examples/i_love_ruby.md
+++ b/pt_br/examples/i_love_ruby.md
@@ -1,0 +1,17 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# Output "Eu gosto de ruby"
+diz = "Eu gosto de Ruby"
+puts diz
+
+# Saída "EU *GOSTO* DE RUBY"
+diz = diz.sub("gosto", "*gosto*")
+puts diz.upcase
+
+# Output: "Eu *gosto*
+# de Ruby" 5 vezes
+5.times { puts diz }
+{% endhighlight %}

--- a/pt_br/feeds/news.rss
+++ b/pt_br/feeds/news.rss
@@ -1,0 +1,4 @@
+---
+layout: news_feed
+lang: pt_br
+---

--- a/pt_br/index.html
+++ b/pt_br/index.html
@@ -1,0 +1,15 @@
+---
+layout: homepage
+title: "Linguagem de Programação Ruby"
+lang: pt_br
+---
+
+{% include home/hero.html %}
+
+
+{% include home/why_ruby.html %}
+
+
+{% include home/community.html %}
+
+{% include home/news_security.html %}

--- a/pt_br/libraries/index.md
+++ b/pt_br/libraries/index.md
@@ -1,0 +1,134 @@
+---
+layout: page
+title: "Bibliotecas"
+lang: pt_br
+---
+
+Como na maioria das linguagens de programação, Ruby utiliza um grande
+conjunto de bibliotecas de terceiros.
+{: .summary}
+
+A maioria delas são disponibilizadas na forma de uma **gem**.
+[**RubyGems**][1] é um sistema de pacotes Ruby que facilita a
+criação, compartilhamento e instalação de bibliotecas (pode-se dizer
+que é um sistema de distribuição de pacotes similar, por exemplo,
+ao `apt-get`, porém voltado a software em Ruby). A partir da versão
+1.9, o Ruby vem com o RubyGems instalado por padrão, enquanto nas
+versões anteriores é necessário [instalá-lo manualmente][2].
+
+Algumas outras bibliotecas são disponibilizadas como diretórios compactados
+de **código fonte** (.zip ou .tar.gz). O processo de instalação pode variar,
+geralmente há um arquivo `README` ou `INSTALL` com instruções sobre isso.
+
+Vamos dar uma olhada em como você pode encontrar e instalar bibliotecas.
+
+### Encontrando Bibliotecas
+
+O principal lugar onde as bibliotecas estão hospedadas é o
+[**RubyGems.org**][1], disponibilizando bibliotecas Ruby como gems.
+Você pode acessar o website diretamente ou usar o comando `gem`.
+
+Através do comando `gem search -r`, você pode inspecionar o repositório
+do RubyGems. Por exemplo, `gem search -r rails` retornará uma lista de
+gems relacionadas ao Rails. Com a opção `--local` (`-l`), você
+executa uma busca local através das gems já instaladas. Para instalar
+uma gem, use `gem install [gem]`. Para navegar através das gems
+instaladas, use o comando `gem list`. Para mais informações sobre
+o comando `gem`, leia abaixo ou acesse [a documentação do RubyGems][3].
+
+No entanto, eixstem outras fontes de bibliotecas. O [RubyForge][4]
+costumava ser um local popular para biblitoecas Ruby, mas nos últimos
+anos vimos a ascenção do [**GitHub**][5] como um dos principais
+repositórios de conteúdo relacionado a Ruby. Na maior parte dos casos,
+o código-fonte de uma gem será hospedado no GitHub enquanto é publicado
+como uma gem completa no RubyGems.org.
+
+O [**The Ruby Toolbox**][6] é um projeto que facilita descobrir projetos Ruby
+open source. Possui categorias para várias tarefas comuns do desenvolvimento,
+reúne várias informações sobre os projetos tais como a data de lançamento
+e a atividade de commits ou dependências, e dá uma nota para os projetos
+baseada em sua popularidade no RubyGems.org e no GitHub. A busca torna
+fácil descobrir o que você está procurando.
+
+### Mais algumas palavras sobre RubyGems
+
+Segue aqui um review rápido do comando `gem` para uso diário. Está disponível
+uma [documentação mais detalhada][7], cobrindo todos os aspectos deste
+sistema de pacotes.
+
+#### Procurando por Gems
+
+O comando de **search** pode ser usado para encontrar gems, baseado em uma
+string. As gems cujo nome começa com a string especificada serão listadas.
+Por exemplo, para pesquisar por gems relacionadas a “html”:
+
+{% highlight sh %}
+$ gem search -r html
+
+*** REMOTE GEMS ***
+
+html-sample (1.0, 1.1)
+{% endhighlight %}
+
+A flag `--remote` / `-r` indica que queremos pesquisar no repositório
+oficial do RubyGems.org (comportamento padrão). Com a flag `--local` / `-l`
+você pode pesquisar localmente nas gems instaladas.
+
+#### Instalando uma Gem
+
+Uma vez encontrada a gem que você deseja **instalar**, por exemplo o Rails:
+
+{% highlight sh %}
+$ gem install rails
+{% endhighlight %}
+
+Poderá também instalar uma determinada versão da biblioteca utilizando a
+flag `--version` / `-v`.
+
+{% highlight sh %}
+$ gem install rails --version 5.0
+{% endhighlight %}
+
+#### Listando Todas as Gems
+
+Para obter uma **lista** de todas as gems instaladas:
+
+{% highlight sh %}
+$ gem list
+{% endhighlight %}
+
+Para obter uma lista (muito longa) de todas as gems disponíveis
+no RubyGems.org:
+
+{% highlight sh %}
+$ gem list -r
+{% endhighlight %}
+
+#### Ajuda!
+
+A documentação está disponível diretamente no seu terminal:
+
+{% highlight sh %}
+$ gem help
+{% endhighlight %}
+
+Por exemplo, `gem help commands` é útil para listar todos os comandos
+de `gem`.
+
+#### Criando suas próprias gems
+
+O RubyGems.org tem [vários guias][3] sobre esse assunto. Você também pode
+querer investigar o [Bundler][9], uma ferramenta genérica que ajuda a
+gerenciar as dependências de uma aplicação e que pode ser utilizada
+junto com o RubyGems.
+
+
+
+[1]: https://rubygems.org/
+[2]: https://rubygems.org/pages/download/
+[3]: http://guides.rubygems.org/
+[4]: http://rubyforge.org/
+[5]: https://github.com/
+[6]: https://www.ruby-toolbox.com/
+[7]: http://guides.rubygems.org/command-reference/
+[9]: http://bundler.io/

--- a/pt_br/news/_posts/2001-01-18-stable-snapshot-is-available.md
+++ b/pt_br/news/_posts/2001-01-18-stable-snapshot-is-available.md
@@ -1,0 +1,13 @@
+---
+layout: news_post
+title: "Snapshot estável está disponível"
+author: "Matz"
+translator: "jcserracampos"
+lang: pt_br
+---
+
+[Snapshot estável][1] está disponível. Este é um arquivo compactado (tar e zip) da
+última **CVS** estável. Esta versão deve estar melhor do que a última.
+
+
+[1]: https://cache.ruby-lang.org/pub/ruby/stable-snapshot.tar.gz

--- a/pt_br/news/_posts/2001-04-19-ruby-pocket-reference.md
+++ b/pt_br/news/_posts/2001-04-19-ruby-pocket-reference.md
@@ -1,0 +1,13 @@
+---
+layout: news_post
+title: "Ruby Pocket Reference"
+author: "Matz"
+translator: "jcserracampos"
+lang: pt_br
+---
+
+O’Reilly finalmente decidiu publicar traduções de **Ruby Pocket Reference**.
+Será um [livro entitulado “Ruby in a Nutshell”][1].
+
+
+[1]: http://www.ora.com/catalog/ruby

--- a/pt_br/news/_posts/2001-06-20-ruby-garden.md
+++ b/pt_br/news/_posts/2001-06-20-ruby-garden.md
@@ -1,0 +1,13 @@
+---
+layout: news_post
+title: "Ruby Garden"
+author: "Matz"
+translator: "jcserracampos"
+lang: pt_br
+---
+
+[Ruby Garden][1] – Portal de notícias para Ruby.
+
+
+
+[1]: http://www.rubygarden.org/

--- a/pt_br/news/_posts/2001-07-10-removed-language-comparison-page.md
+++ b/pt_br/news/_posts/2001-07-10-removed-language-comparison-page.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "Removida a página de comparação de linguagens"
+author: "NaHi"
+translator: "jcserracampos"
+lang: pt_br
+---
+
+Matz decidiu remover esta página.
+
+
+
+
+    "Eu removi o link para a página de comparação de linguagens
+    porque existem muitas pessoas que levam isto muito a sério.
+    Era para ser divertido."

--- a/pt_br/news/_posts/2001-07-13-ruby-introduction-presentation.md
+++ b/pt_br/news/_posts/2001-07-13-ruby-introduction-presentation.md
@@ -1,0 +1,14 @@
+---
+layout: news_post
+title: "Apresentação introdutória de Ruby"
+author: "Matz"
+translator: "jcserracampos"
+lang: pt_br
+---
+
+[Apresentação introdutória de Ruby no New York City CTO club][1] por Jim
+Menard em 10 de julho de 2001.
+
+
+
+[1]: http://www.io.com/~jimm/downloads/rubytalk/

--- a/pt_br/news/_posts/2008-06-25-vulnerabilidades-de-seguranca-no-ruby.md
+++ b/pt_br/news/_posts/2008-06-25-vulnerabilidades-de-seguranca-no-ruby.md
@@ -1,0 +1,78 @@
+---
+layout: news_post
+title: "Vulnerabilidades de segurança no Ruby"
+author: "Unknown Author"
+lang: pt_br
+---
+
+Algumas vulnerabilidades de segurança no Ruby permitem ataques \"denial
+of service (DoS)\" ou execução arbitrária de código.
+
+## Impacto
+
+As seguintes vulnerabilidades permitem ataques de DoS ou execução
+arbitrária de código.
+
+* [CVE-2008-2662][1]
+* [CVE-2008-2663][2]
+* [CVE-2008-2725][3]
+* [CVE-2008-2726][4]
+* [CVE-2008-2664][5]
+
+## Versões vulneráveis
+
+1.8
+: * 1\.8.4 e todas as anteriores
+  * 1\.8.5-p230 e todas as anteriores
+  * 1\.8.6-p229 e todas as anteriores
+  * 1\.8.7-p21 e todas as anteriores
+
+1.9
+: * 1\.9.0-1 e todas as anteriores
+
+## Solução
+
+1.8
+: Actualizar para a versão 1.8.5-p231, ou 1.8.6-p230, ou 1.8.7-p22.
+
+  * [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p231.tar.gz&gt;][6]
+    (md5sum: e900cf225d55414bffe878f00a85807c)
+  * [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p230.tar.gz&gt;][7]
+    (md5sum: 5e8247e39be2dc3c1a755579c340857f)
+  * [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p22.tar.gz&gt;][8]
+    (md5sum: fc3ede83a98f48d8cb6de2145f680ef2)
+
+1.9
+: Actualizar para a versão 1.9.0-2.
+
+  * [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-2.tar.gz&gt;][9]
+    (md5sum: 2a848b81ed1d6393b88eec8aa6173b75)
+
+Estas versões também corrigem a vulnerabilidade no WEBrick
+([CVE-2008-1891][10]).
+
+Note que um pacote binário que corrige este problema poderá já estar
+disponível a partir do seu software de gestão de aplicações.
+
+## Créditos
+
+Os créditos vão para Drew Yao da Segurança de Produtos da Apple por dar
+a conhecer o problema à equipa de segurança do Ruby
+
+## Alterações
+
+* 2008-06-21 00:29 +09:00 removidos os CVE IDs incorrectos
+  (CVE-2008-2727, CVE-2008-2728).
+
+
+
+[1]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-2662
+[2]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-2663
+[3]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-2725
+[4]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-2726
+[5]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-2664
+[6]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p231.tar.gz
+[7]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p230.tar.gz
+[8]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p22.tar.gz
+[9]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-2.tar.gz
+[10]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-1891

--- a/pt_br/news/_posts/2008-09-05-vulnerabilidade-dos-na-biblioteca-rexml.md
+++ b/pt_br/news/_posts/2008-09-05-vulnerabilidade-dos-na-biblioteca-rexml.md
@@ -1,0 +1,97 @@
+---
+layout: news_post
+title: "Vulnerabilidade DoS na biblioteca REXML"
+author: "Unknown Author"
+lang: pt_br
+---
+
+Existe uma vulnerabilidade DoS na biblioteca REXML incluída na
+biblioteca standard do Ruby. Uma técnica de ataque conhecida como “XML
+entity explosion” poderá ser utilizada para terminar remotamente
+qualquer aplicação que faça parse de XML com a biblioteca REXML.
+
+A maioria das aplicações rails estarão vulneráveis, uma vez que o Rails
+faz parse de XML com REXML, por omissão.
+
+## Impacto
+
+Um ataque deste tipo pode ser repetido pedindo uma análise de um
+documento XML contendo entidades aninhadas recursivas pela biblioteca
+REXML. Veja-se o exemplo:
+
+{% highlight xml %}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE member [
+  <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+  <!ENTITY c "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+  <!ENTITY d "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+  <!ENTITY e "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+  <!ENTITY f "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+  <!ENTITY g "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+]>
+<member>
+&a;
+</member>
+{% endhighlight %}
+
+## Versões vulneráveis
+
+### Versões 1.8
+
+* 1\.8.6-p287 e todas as anteriores
+* 1\.8.7-p72 e todas as anteriores
+
+### Versões 1.9
+
+* Todas
+
+## Solução
+
+Faça download do seguinte *patch* para corrigir o problema.
+
+* [https://www.ruby-lang.org/security/20080823rexml/rexml-expansion-fix.rb][1]
+
+Depois adicione a linha na aplicação para carregar
+rexml-expansion-fix.rb antes de utilizar REXML.
+
+{% highlight ruby %}
+require "rexml-expansion-fix"
+...
+doc = REXML::Document.new(str)
+...
+{% endhighlight %}
+
+para aplicações em Rails, copie o ficheiro rexml-expansion-fix.rb para a directoria RAILS\_ROOT/lib/, por exemplo, e adicione a linha seguinte no ficheiro config/environment.rb.
+
+{% highlight ruby %}
+require "rexml-expansion-fix"
+{% endhighlight %}
+
+Se a sua aplicação utiliza Rails 2.1 ou posterior, basta copiar o
+ficheiro rexml-expansion-fix.rb para a directoria
+RAILS\_ROOT/config/initializers para que este seja automaticamente
+inicializado.
+
+Por omissão, a expansão de entidades XML é de 10000. Poderá alterar este
+valor mudando REXML::Document.entity\_expansion\_limit.
+
+{% highlight ruby %}
+REXML::Document.entity_expansion_limit = 1000
+{% endhighlight %}
+
+Esta correcção estará disponível também como uma gema e utilizada por
+versões futuras de Rails, mas aconselham-se medidas de correcção
+imediatas.
+
+## Créditos
+
+Créditos para Luka Treiber and Mitja Kolsek da ACROS Security por
+informar as Equipas de Segurança de Ruby e Ruby on Rails.
+
+Créditos para Michael Koziarski da Rails Core Team por criar a correcção
+para a vulnerabilidade
+
+
+
+[1]: {{ site.url }}/security/20080823rexml/rexml-expansion-fix.rb

--- a/pt_br/news/_posts/2009-03-04-ruby-1-9-1-disponvel-para-download.md
+++ b/pt_br/news/_posts/2009-03-04-ruby-1-9-1-disponvel-para-download.md
@@ -1,0 +1,64 @@
+---
+layout: news_post
+title: "Ruby 1.9.1 disponível para download"
+author: "Emanuel Mota"
+lang: pt_br
+---
+
+Lançamento do Ruby 1.9.1. Esta é a primeira release estável da série
+Ruby 1.9.
+
+O Ruby 1.9 é uma nova série da linguagem Ruby. É moderno, mais rápido,
+com uma sintaxe mais clara, suporte multilingue. É uma versão muito
+melhorada do Ruby.
+
+A série Ruby 1.8 é utilizada desde 2003 e foi utilizada para criar
+muitos e grandes produtos.
+
+Hoje, a série Ruby 1.9 começa a sua história tal como a 1.8 o fez no
+passado.
+
+Apesar do lançamento da nova série, o Ruby 1.8 ainda se mantém. A versão
+1.8.8 será lançada ainda este ano.
+
+Pode ler sobre as principais alterações desde a versão 1.8.7 [aqui][1]
+(em inglês)
+
+Foram corrigidos [7 bugs][2] desde a versão 1.9.1 RC2.
+
+Se encontrar qualquer bug ou problema, por favor reporte utilizando o
+[sistema de tracking de bugs oficial][3].
+
+O Download está disponível em:
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2][4]
+  SIZE: 7190271 bytes
+
+  MD5: 0278610ec3f895ece688de703d99143e
+
+  SHA256: de7d33aeabdba123404c21230142299ac1de88c944c9f3215b816e824dd33321
+^
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz][5]
+  SIZE: 9025004 bytes
+
+  MD5: 50e4f381ce68c6de72bace6d75f0135b
+
+  SHA256: a5485951823c8c22ddf6100fc9e10c7bfc85fb5a4483844033cee0fad9e292cc
+^
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip][6]
+  SIZE: 10273609 bytes
+
+  MD5: 3377d43b041877cda108e243c6b7f436
+
+  SHA256: 00562fce4108e5c6024c4152f943eaa7dcc8cf97d5c449ac102673a0d5c1943b
+
+
+
+[1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS
+[2]: https://bugs.ruby-lang.org/projects/ruby-19/issues?query_id=11
+[3]: https://bugs.ruby-lang.org
+[4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2
+[5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz
+[6]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.zip

--- a/pt_br/news/_posts/2009-05-15-ruby-1-8-7-p160-e-1-8-6-p368-disponvel-para-download.md
+++ b/pt_br/news/_posts/2009-05-15-ruby-1-8-7-p160-e-1-8-6-p368-disponvel-para-download.md
@@ -1,0 +1,64 @@
+---
+layout: news_post
+title: "Ruby 1.8.7-p160 e 1.8.6-p368 disponível para download"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+Actualização para as versões de Ruby 1.8.7 e 1.8.6 já está disponível
+para download.
+
+Foram corrigidos dezenas de bugs, incluindo resoluções temporárias para
+os problemas descritos em CVE-2007-1558 e CVE-2008-1447. Resolvidos
+muitos problemas com segmentation faults. Para uma lista completa ler os
+ChangeLogs inclusos nos ficheiros para download ou aqui:
+
+* [https://svn.ruby-lang.org/repos/ruby/tags/v1\_8\_6\_368/ChangeLog][1]
+* [https://svn.ruby-lang.org/repos/ruby/tags/v1\_8\_7\_160/ChangeLog][2]
+
+O download está disponível em:
+
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.gz][3]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.bz2][4]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.zip][5]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.gz][6]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.bz2][7]
+* [https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.zip][8]
+
+Checksums:
+
+
+    MD5(ruby-1.8.6-p368.tar.gz)= 508bf1911173ac43e4e6c31d9dc36b8f
+    SHA256(ruby-1.8.6-p368.tar.gz)= cc8cad3edd02d8c2de3c63a7d8a5cb85af39766dd47360a9c0f26339b101e2a0
+    SIZE(ruby-1.8.6-p368.tar.gz)= 4602095
+
+    MD5(ruby-1.8.6-p368.tar.bz2)= 623447c6d8c973193aae565a5538ccfc
+    SHA256(ruby-1.8.6-p368.tar.bz2)= 1bd398a125040261f8e9e74289277c82063aae174ada9f300d2bea0a42ccdcc1
+    SIZE(ruby-1.8.6-p368.tar.bz2)= 3967709
+
+    MD5(ruby-1.8.6-p368.zip)= 3d301a4b1aded1922570585bbece2c29
+    SHA256(ruby-1.8.6-p368.zip)= 8ba4bfd14d2914bfe2c18ffa9da084234be978fd0eee654f7a5c732a1beb0246
+    SIZE(ruby-1.8.6-p368.zip)= 5619494
+
+    MD5(ruby-1.8.7-p160.tar.gz)= 945398f97e2de6dd8ab6df68d10bb1a1
+    SHA256(ruby-1.8.7-p160.tar.gz)= 47c3d1ae6b3dbda230d04f258304516fc1da571fa757d5e1d8d0104b49045530
+    SIZE(ruby-1.8.7-p160.tar.gz)= 4818817
+
+    MD5(ruby-1.8.7-p160.tar.bz2)= f8ddb886b8a81cf005f53e9a9541091d
+    SHA256(ruby-1.8.7-p160.tar.bz2)= e524a086212d2142c03eb6b82cd602adcac9dcf8bf60049e89aa4ca69864984d
+    SIZE(ruby-1.8.7-p160.tar.bz2)= 4137518
+
+    MD5(ruby-1.8.7-p160.zip)= 06319bafa225df47fe26dfb52bc174a7
+    SHA256(ruby-1.8.7-p160.zip)= c56fefbb9e7e186bf9feeb864793ad2a53062ce871b47ab0170316e38f738995
+    SIZE(ruby-1.8.7-p160.zip)= 5876269
+
+
+
+[1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_6_368/ChangeLog
+[2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_8_7_160/ChangeLog
+[3]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.gz
+[4]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.bz2
+[5]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.zip
+[6]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.gz
+[7]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.bz2
+[8]: https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.zip

--- a/pt_br/news/_posts/2009-05-15-ruby-1-9-1-p129-j-disponvel-para-download.md
+++ b/pt_br/news/_posts/2009-05-15-ruby-1-9-1-p129-j-disponvel-para-download.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Ruby 1.9.1-p129 já disponível para download"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+Ruby 1.9.1-p129 já está disponível para download.
+
+Esta é uma versão de manutenção para o Ruby 1.9.1. Corrige diversos bugs
+e duas vulnerabilidades de seguranla. Uma vez que é uma versão que
+contém uma correcção de segurança aconselha-se que todos os utilizadores
+façam esta actualização.
+
+#### Disponível a partir de
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2&gt;][1]
+
+      SIZE:   7183891 bytes
+      MD5:    6fa62b20f72da471195830dec4eb2013
+      SHA256: cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz&gt;][2]
+
+      SIZE:   9034947 bytes
+      MD5:    c71f413514ee6341c627be2957023a5c
+      SHA256: 27b7a8ace1d17cec237020ae9355230b53f8c3875f8d942de903e7d58d14253b
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip&gt;][3]
+
+      SIZE:   10299369 bytes
+      MD5:    156305e9633758eb60b419fabc33b6e4
+      SHA256: 6cbf0eda4ba0afedd8f0bd320e6a14f826149ef517d8bb967149af0558b0743b
+
+#### Vulnerabilidades de Segurança
+
+* DL::Function#call could pass tainted arguments to a C function even if
+
+$SAFE &gt; 0.
+
+* DL::dlopen could open a library with tainted library name even if
+
+$SAFE &gt; 0
+
+
+
+[1]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.gz
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.zip

--- a/pt_br/news/_posts/2011-07-18-ruby-1-9-2-p290-disponvel-para-download.md
+++ b/pt_br/news/_posts/2011-07-18-ruby-1-9-2-p290-disponvel-para-download.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Ruby 1.9.2-p290 disponível para download"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+Ruby 1.9.2-p290 está disponível.
+
+Esta versão não inclui a correcção de nenhuma vulnerabilidade de
+segurança, no entanto foram corrigidos muitos bugs.
+
+Ver [ChangeLog][1] (em Inglês).
+
+### Downloads
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2&gt;][2]
+  TAMANHO
+  : 8811237 bytes
+
+  MD5
+  : 096758c3e853b839dc980b183227b182
+
+  SHA256
+  : 403b3093fbe8a08dc69c269753b8c6e7bd8f87fb79a7dd7d676913efe7642487
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz&gt;][3]
+  TAMANHO
+  : 11182217 bytes
+
+  MD5
+  : 604da71839a6ae02b5b5b5e1b792d5eb
+
+  SHA256
+  : 1cc817575c4944d3d78959024320ed1d5b7c2b4931a855772dacad7c3f6ebd7e
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.zip&gt;][4]
+  TAMANHO
+  : 12600100 bytes
+
+  MD5
+  : 6060b410aa15d09ac13b93033b8b5c66
+
+  SHA256
+  : bce3d1c8c78fbafb6a0d67df2b8dec5322301f7b4b0f7594656ad689e9cb461d
+
+
+
+[1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_2_290/ChangeLog
+[2]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz
+[4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.zip

--- a/pt_br/news/_posts/2011-08-02-lancado-o-ruby-1-9-3-preview1.md
+++ b/pt_br/news/_posts/2011-08-02-lancado-o-ruby-1-9-3-preview1.md
@@ -1,0 +1,58 @@
+---
+layout: news_post
+title: "Lançado o Ruby 1.9.3 preview1"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+O Ruby 1.9.3 preview1 foi lançado. Esta é a primeira pre-release da
+próxima versão e ainda existem alguns problemas conhecidos, que serão
+resolvidos na proxima release, Ruby 1.9.3-p0
+
+Ver [ChangeLogs][1] e [NEWS][2] para descrições.
+
+### Descargas
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2&gt;][3]
+  SIZE: 9507455 bytes
+  MD5: 7d93dc773c5824f05c6e6630d8c4bf9b
+  SHA256: a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz&gt;][4]
+  SIZE: 12186410 bytes
+  MD5: 0f0220be4cc7c51a82c1bd8f6a0969f3
+  SHA256: 75c2dd57cabd67d8078a61db4ae86b22dc6f262b84460e5b95a0d8a327b36642
+
+* [&lt;URL:https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.zip&gt;][5]
+  SIZE: 13696708 bytes
+  MD5: 960e08b2dc866c9987f17d0480de63a1
+  SHA256: 249483f88156b4ae65cd45742c6f6316660f793b78739657596c63b86f76aaeb
+
+### Diferenças da versão anterior
+
+As versões anteriores do Ruby encontravam-se sob a licença \"GPLv2\" e
+\"Ruby\". No entanto, nesta versão foi substituida pela licença
+\"2-clause BSDL\"(AKA Simplified BSD License) e \"Ruby\".
+
+### Encoding
+
+SJIS changed to alias for Windows-31J, instead of Shift\_JIS.
+
+### Standard Libraries
+
+* io/console: Add capabilities to IO instances.
+* openssl
+* test/unit: supports parallel test
+
+### Other changes
+
+* pathname and date are re-implemented on current preview.
+* A purpose of VM locking is changed.
+
+
+
+[1]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_preview1/ChangeLog
+[2]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_preview1/NEWS
+[3]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2
+[4]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz
+[5]: https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.zip

--- a/pt_br/news/_posts/2012-03-30-matz-recebe-o-fsfs-2011-free-software-award.md
+++ b/pt_br/news/_posts/2012-03-30-matz-recebe-o-fsfs-2011-free-software-award.md
@@ -1,0 +1,23 @@
+---
+layout: news_post
+title: "Matz recebe o FSF's 2011 Free Software Award"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+O Prémio para o Avanço do Software Livre é dado, anualmente, a alguém
+que tenha contribuído para o progresso e desenvolvimento do software
+livre, realizando actividades que estejam de acordo com o espírito do
+software livre.
+
+Este ano, o prémio foi para Yukihiro Matsumoto (ou Matz), o criador da
+linguagem de programação Ruby. Matz trabalhou no GNU, Ruby e outros
+projectos de software livre nos os últimos 20 anos. Ele aceitou o prémio
+em pessoa e falou na conferência acerca das suas primeiras experiências
+com software livre, especialmente da influência do GNU Emacs no Ruby.
+
+[Ler artigo completo.][1] (em Inglês)
+
+
+
+[1]: https://www.fsf.org/news/2011-free-software-awards-announced

--- a/pt_br/news/_posts/2012-10-20-lanado-o-ruby-1-9-3-p286.md
+++ b/pt_br/news/_posts/2012-10-20-lanado-o-ruby-1-9-3-p286.md
@@ -1,0 +1,26 @@
+---
+layout: news_post
+title: "Lançado o Ruby 1.9.3-p286"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+Foi lançado o Ruby 1.9.3-p286.
+
+Esta versão inclui a correcção de algumas falhas de segurança e de
+muitos bugs.
+
+* [$SAFE escaping vulnerability about Exception#to\_s / NameError#to\_s
+  (CVE-2012-4464, CVE-2012-4466)][1]
+* [Unintentional file creation caused by inserting an illegal NUL
+  character][2]
+* correcção de muitos outros bugs.
+
+Ver [tickets][3] e [ChangeLog][4] para mais detalhes.
+
+
+
+[1]: {{ site.url }}/en/news/2012/10/12/cve-2012-4464-cve-2012-4466/
+[2]: {{ site.url }}/en/news/2012/10/12/poisoned-NUL-byte-vulnerability/
+[3]: https://bugs.ruby-lang.org/projects/ruby-193/issues?set_filter=1&amp;status_id=5
+[4]: https://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_286/ChangeLog

--- a/pt_br/news/_posts/2012-10-22-rupy-2012-muito-em-breve.md
+++ b/pt_br/news/_posts/2012-10-22-rupy-2012-muito-em-breve.md
@@ -1,0 +1,18 @@
+---
+layout: news_post
+title: "RuPy 2012 muito em breve"
+author: "Filipe Rocha"
+lang: pt_br
+---
+
+[RuPy 2012][1] – a 5ª edição da conferência de Ruby, Python e JavaScript
+para hackers dos dois hemisférios. **16-18 Novembro 2012** em [Brno][2],
+**8-9 Dezembro** em [São José][3].
+
+A não perder!
+
+
+
+[1]: http://rupy.eu/
+[2]: http://rupy.eu/#city-carousel
+[3]: http://rupy.com.br/#city-carousel

--- a/pt_br/news/_posts/2013-12-21-ruby-version-policy-changes-with-2-1-0.md
+++ b/pt_br/news/_posts/2013-12-21-ruby-version-policy-changes-with-2-1-0.md
@@ -1,0 +1,66 @@
+---
+layout: news_post
+title: "Versionamento Semântico após o Ruby 2.1.0"
+author: "zzak"
+translator: "diogoandre"
+date: 2013-12-21 2:00:00 +0000
+lang: pt_br
+---
+
+Decidimos mover para uma política de [Versionamento Semântico](http://semver.org/)
+após a liberação do Ruby 2.1.0.
+
+Para prover um esquema de versionamento melhor definido e propriamente utilizado
+para o Ruby, nós decidimos por gradualmente mudar para as seguintes políticas.
+
+## Mudanças de Política
+
+Esta política é baseada em uma proposta do administrador de sistemas de ruby-lang.org
+Hiroshi Shibata ([@hsbt](https://twitter.com/hsbt)).
+
+### Esquema de Versionamento
+
+* `MAJOR`: acrescido quando mudanças com incompatibilidade que não pode ser lançada em MINOR
+  * Reservado para eventos especiais
+* `MINOR`: acrecido a cada natal, pode ser incompatível a API
+* `TEENY`: correção de segurança ou bug que mantém compatibilidade a API
+  * Pode ser acrescido em mais de 10 (como `2.1.11`), e será lançado a cada 2-3 meses.
+* `PATCH`: número de commits desde a última versão `MINOR` (será reiniciado para 0 quando lançado uma `MINOR`)
+
+### Esquema de ramificações
+
+Manteremos as seguintes ramificações(branches):
+
+* trunk
+* `ruby_{MAJOR}_{MINOR}`
+
+O branch `ruby_{MAJOR}_{MINOR}` será mantido através de lançamentos `TEENY`.
+Nós usaremos tags para cada lançamento.
+
+### Compatibilidade de API
+
+As seguintes peculiaridades podem ser marcadas como uma mudança incompatível, requerendo um
+acréscimo na versão `MINOR`:
+
+* Remoção de recursos da api no nível C
+* Mudanças ou adições incompatíveis com versões anteriores
+
+### Compatibilidade de ABI
+
+ABI será compatível com o seguinte esquema: `{MAJOR}.{MINOR}.0`
+
+Faremos nosso melhor para manter compatibilidade de ABI dentro da mesma versão
+de nível `MINOR`, então `TEENY` será corrigida em 0.
+
+## Referências
+
+Para ler mais sobre esta proposta por favor siga os links abaixo:
+
+* [Introducing a semantic versioning scheme and branching policy](https://bugs.ruby-lang.org/issues/8835)
+* [Proposta aceita em Inglês](https://gist.github.com/sorah/7803201)
+* [Proposta aceita em Japonês](https://gist.github.com/hsbt/7719305)
+
+## Obrigado!
+
+Eu gostaria de pessoalmente agradecer a todos que contribuiram com essa discussão. Cada
+passo que tomamos nos deixa mais perto de um Ruby mais estável e efetivo.

--- a/pt_br/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
+++ b/pt_br/news/_posts/2013-12-25-ruby-2-1-0-is-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Lançado o Ruby 2.1.0"
+author: "nurse"
+translator: "diogoandre"
+date: 2013-12-25 16:00:00 +0000
+lang: pt_br
+---
+
+Nós temos o prazer de anunciar a liberação do Ruby 2.1.0.
+
+O Ruby 2.1 tem muitas melhorias, incluindo rapidez sem incompatibilidades severas.
+
+Experimente!
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2)
+  * SIZE:   12007442 bytes
+  * MD5:    1546eeb763ac7754365664be763a1e8f
+  * SHA256: 1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz)
+  * SIZE:   15076389 bytes
+  * MD5:    9e6386d53f5200a3e7069107405b93f7
+  * SHA256: 3538ec1f6af96ed9deb04e0965274528162726cc9ba3625dcf23648df872d09d
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.zip)
+  * SIZE:   16603067 bytes
+  * MD5:    2fc3a80b56da81b906a9bb6fc7ca8399
+  * SHA256: d40d7bfb39ca2e462dea61dcbbcf33426b60e6e553335c3afb39b4d827a6891c
+
+## Mudanças desde 2.0
+
+As mudanças mais importantes são:
+
+* VM (cache de métodos)
+* RGenGC (Veja as apresentações de ko1 em [RubyKaigi](http://rubykaigi.org/2013/talk/S73) e [RubyConf 2013](http://www.atdot.net/~ko1/activities/rubyconf2013-ko1_pub.pdf))
+* refinamentos [#8481](https://bugs.ruby-lang.org/issues/8481) [#8571](https://bugs.ruby-lang.org/issues/8571)
+* mudanças de sintaxe
+  * Literal Racional/Complexo [#8430](https://bugs.ruby-lang.org/issues/8430)
+  * Valor de retorno de def [#3753](https://bugs.ruby-lang.org/issues/3753)
+* Bignum
+  * uso de GMP [#8796](https://bugs.ruby-lang.org/issues/8796)
+* String#scrub [#8414](https://bugs.ruby-lang.org/issues/8414)
+* Socket.getifaddrs [#8368](https://bugs.ruby-lang.org/issues/8368)
+* RDoc 4.1.0 e RubyGems 2.2.0
+* "literal".freeze agora está otimizado [#9042](https://bugs.ruby-lang.org/issues/9042)
+* adicionado Exception#cause [#8257](https://bugs.ruby-lang.org/issues/8257)
+* atualização de bibliotecas como BigDecimal, JSON, NKF, Rake, RubyGems, and RDoc
+* remoção de Curses [#8584](https://bugs.ruby-lang.org/issues/8584)
+
+Veja mais detalhes das mudanças em: [NEWS in Ruby repository](https://github.com/ruby/ruby/blob/v2_1_0/NEWS).

--- a/pt_br/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
+++ b/pt_br/news/_posts/2014-01-10-ruby-1-9-3-will-end-on-2015.md
@@ -1,0 +1,19 @@
+---
+layout: news_post
+title: "Suporte para Ruby versão 1.9.3 acabará em 23 de Fevereiro de 2015"
+author: "hsbt"
+translator: "esampaio"
+date: 2014-01-10 00:00:00 +0000
+lang: pt_br
+---
+
+Hoje anunciamos nossos planos para o futuro do Ruby versão 1.9.3.
+
+Atualmente este branch está em modo de manutenção e permanecerá assim até
+23 de Fevereiro de 2014.
+
+Após 23 de Fevereiro de 2014, nós proveremos apenas correções de segurança
+para 1.9.3 até 23 de Fevereiro de 2015, quando o suporte para 1.9.3 acabará.
+
+Nós recomendamos que você atualize para Ruby 2.1 ou 2.0.0 o mais rápido
+possível.

--- a/pt_br/news/_posts/2014-01-20-abril-pro-ruby-2014.md
+++ b/pt_br/news/_posts/2014-01-20-abril-pro-ruby-2014.md
@@ -1,0 +1,24 @@
+---
+layout: news_post
+title: "Abril Pro Ruby 2014, a Conferência Tropical de Ruby"
+author: "lailsonbm"
+translator: "lailsonbm"
+date: 2014-01-20 11:22:14 +0000
+lang: pt_br
+---
+
+O [Abril Pro Ruby 2014](http://abrilproruby.com/pt_br/), a terceira edição da
+Conferência Tropical de Ruby, acontecerá em **26 de abril de 2014**, na praia
+de **Porto de Galinhas**. Venha e junte-se a Rubistas de alto nível para
+trocar experiências curtindo as belezas naturais deste paraíso no nordeste
+brasileiro.
+
+As [atividades oficiais da conferência](http://abrilproruby.com/pt_br/conference/)
+incluem mergulho, passeio de jangada e catamarã, que acontecerão um dia antes
+e um dia depois do evento.
+
+**Jim Weirich** (criador do Rake), **Rafael França** (do Rails Core Team) e
+**Nell Shamrell** (a guru de Expressões Regulares) estão confirmados e a
+**Chamada para Palestrantes** está aberta. Se você deseja palestrar no evento,
+[envie sua proposta](http://cfp.abrilproruby.com/) até o fim deste mês
+(**31 de janeiro**).

--- a/pt_br/news/_posts/2014-02-12-the-2014-ruby-hero-awards.md
+++ b/pt_br/news/_posts/2014-02-12-the-2014-ruby-hero-awards.md
@@ -1,0 +1,20 @@
+---
+layout: news_post
+title: "Indicados para o Ruby Hero Award 2014"
+author: "Gregg Pollack"
+translator: "esampaio"
+date: 2014-02-12 14:02:03 +0000
+lang: pt_br
+---
+
+Alguém da comunidade Ruby o ajudou neste último ano? Talvez ensinando algo,
+escrevendo uma gem ou lhe oferecendo suporte técnico? Se você lembrou de
+alguém, por favor a [indique](http://rubyheroes.com/) para um Ruby Hero Award.
+
+Nos últimos 6 anos, nós entregamos 38 troféus para aqueles em nossa comunidade
+que não recebem o reconhecimento devido. Em três semanas, os Ruby Heroes dos
+últimos anos vão avaliar os indicados e decidir quem deve receber os prêmios
+(dessa forma não se torna um concurso de popularidade). Contudo, suas
+indicações importam muito, então pegue um minuto de seu tempo e distribua sua
+gratidão.
+[Vote hoje!](http://rubyheroes.com/)

--- a/pt_br/news/_posts/2014-02-24-ruby-1-9-3-p545-is-released.md
+++ b/pt_br/news/_posts/2014-02-24-ruby-1-9-3-p545-is-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Ruby 1.9.3-p545 is released"
+author: "usa"
+translator: "diogoandre"
+date: 2014-02-24 05:00:00 +0000
+lang: pt_br
+---
+
+Feliz aniversário, Ruby!
+Hoje, 24 de Fevereiro, é o 21º aniversário do Ruby.
+Em comemoração a isso o Ruby 1.9.3-p545 é lançado.
+
+Este é a última versão ordinal do Ruby 1.9.3. Isso quer dizer que o
+Ruby 1.9.3 entra em um estado de fase de manutenção de segurança, e não será
+mais atualizado a não ser que uma regressão crítica ou problema de segurança
+seja encontrado.
+Esta fase está planejada para ser mantida durante 1 ano.
+Então, a manutenção do Ruby 1.9.3 será encerrada em 24 de Fevereiro de 2015.
+
+Esta versão inclui muitas correções de bugs.
+Veja [tickets](https://bugs.ruby-lang.org/projects/ruby-193/issues?set_filter=1&amp;status_id=5)
+e [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_545/ChangeLog)
+para detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2](https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2)
+
+      SIZE:   10038164 bytes
+      MD5:    4743c1dc48491070bae8fc8b423bc1a7
+      SHA256: 2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz](https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz)
+
+      SIZE:   12582277 bytes
+      MD5:    8e8f6e4d7d0bb54e0edf8d9c4120f40c
+      SHA256: 05fb00ebd374ef800475eb40b71ebc42cc18c1f61f4885c11737f310d3d23111
+
+* [https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.zip](https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.zip)
+
+      SIZE:   13970747 bytes
+      MD5:    d056aefa64237737fedb127257b502d2
+      SHA256: 2d0d17840da0dfbea8ace8a77050a7710d2ef3c9e05dd88f2731464532aea31e
+
+## Comentários do Lançamento
+
+Eu sou agradecido a todos que suportam o Ruby.
+Obrigado.
+
+Esta versão é dedicada à memória do nosso melhor camarada, Jim Weirich.
+Obrigado, Jim. Descanse em paz.

--- a/pt_br/news/_posts/2014-02-24-ruby-2-0-0-p451-is-released.md
+++ b/pt_br/news/_posts/2014-02-24-ruby-2-0-0-p451-is-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 2.0.0-p451 is released"
+author: "nagachika"
+translator: "diogoandre"
+date: 2014-02-24 12:00:00 +0000
+lang: pt_br
+---
+
+Hoje, 24 de Fevereiro, é o 21º aniversário do Ruby,
+e com felicidade anunciamos uma nova versão patch, Ruby 2.0.0-p451.
+
+Esta versão inclui muitas correções de bugs.
+Veja [tickets](https://bugs.ruby-lang.org/projects/ruby-200/issues?set_filter=1&amp;status_id=5)
+e [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_0_0_451/ChangeLog)
+para detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2)
+
+      SIZE:   10725438 bytes
+      MD5:    908e4d1dbfe7362b15892f16af05adf8
+      SHA256: 5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5
+
+* [https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz)
+
+      SIZE:   13587580 bytes
+      MD5:    9227787a9636551f1749ee8394b5ffe5
+      SHA256: e6d6900eb4084053058349cfdbf63ad1414b6a8d75d58b47ed81010a9947e73b
+
+* [https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.zip](https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.zip)
+
+      SIZE:   15097530 bytes
+      MD5:    e90cb32e9cf534d180754d7492988748
+      SHA256: 8999133f35ad5ddc9a6174860c795c5022e3868ff3b6587448b86af81ea2d5ec
+
+## Comentários do Lançamento
+
+Muitos commiters, desenvolvedores e usuários que enviaram relatórios
+de bug me ajudaram a fazer este lançamento.
+Agradeço por suas contribuições.

--- a/pt_br/news/_posts/2014-02-24-ruby-2-1-1-is-released.md
+++ b/pt_br/news/_posts/2014-02-24-ruby-2-1-1-is-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 2.1.1 is released"
+author: "naruse"
+translator: "diogoandre"
+date: 2014-02-24 05:00:00 +0000
+lang: pt_br
+---
+
+Hoje, 24 de Fevereiro, é o 21º aniversário do Ruby,
+e com felicidade anunciamos uma nova versão patch do Ruby 2.1, Ruby 2.1.1.
+
+Ruby 2.1 tem muitas melhorias, incluindo mais rapidez sem incompatibilidades
+severas. Você pode usá-lo com Rails e algumas outras aplicações, e ter uma
+experiência mais confortável.
+
+Esta versão inclui muitas correções de bugs.
+Veja [tickets](https://bugs.ruby-lang.org/projects/ruby-21/issues?set_filter=1&amp;status_id=5)
+e [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_1_1/ChangeLog)
+para detalhes.
+
+Como no anúncio anterior que altera a
+[política de versionamento no Ruby 2.1](https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/),
+esta versão é chamada simplesmente de "2.1.1".
+
+**Atualização:** Nós percebemos uma regressão em `Hash#reject`. Para mais detalhes, veja:
+[Regressão em Hash#reject no Ruby 2.1.1](https://www.ruby-lang.org/pt_br/news/2014/03/10/regression-of-hash-reject-in-ruby-2-1-1/).
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2>
+  * SIZE:   11990697 bytes
+  * MD5:    53edc33b2f590ecdd9f6a344b9d92d0d
+  * SHA256: 96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc
+* <https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz>
+  * SIZE:   15092388 bytes
+  * MD5:    e57fdbb8ed56e70c43f39c79da1654b2
+  * SHA256: c843df31ae88ed49f5393142b02b9a9f5a6557453805fd489a76fbafeae88941
+* <https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.zip>
+  * SIZE:   16618363 bytes
+  * MD5:    02c1dbff9c550d2d808444c8fef483bc
+  * SHA256: 6c226d3f3a4bd1a9356077473d1915968f45af6775660bb8ec5e245a337e3b14

--- a/pt_br/news/_posts/2014-03-10-regression-of-hash-reject-in-ruby-2-1-1.md
+++ b/pt_br/news/_posts/2014-03-10-regression-of-hash-reject-in-ruby-2-1-1.md
@@ -1,0 +1,46 @@
+---
+layout: news_post
+title: "Regressão em Hash#reject no Ruby 2.1.1"
+author: "sorah"
+translator: "diogoandre"
+date: 2014-03-10 14:00:00 +0000
+lang: pt_br
+---
+
+No Ruby 2.1.0 ou anterior, o método `reject` em qualquer classe que herda
+`Hash` retorna um objeto de sua própria classe.
+Mas no Ruby 2.1.1, esse comportamento mudou acidentalmente para sempre retornar
+um objeto Hash simples, não da classe herdada.
+
+{% highlight ruby %}
+class SubHash < Hash
+end
+
+p Hash.new.reject { }.class
+#=> 2.1.0: Hash, 2.1.1: Hash
+p SubHash.new.reject { }.class
+#=> 2.1.0: SubHash, 2.1.1: Hash
+{% endhighlight %}
+
+(Para ser preciso, estados extra como variáveis de instância, etc. também
+não são copiadas.)
+
+Ruby 2.1.1 não deveria incluir tais mudanças de comportamento, porque com o
+lançamento do Ruby 2.1.0 nós [mudamos a política de versionamento](https://www.ruby-lang.org/pt_br/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/),
+então o Ruby 2.1.1 é um lançamento do nível patch e não deveria quebrar a
+compatibilidade retroativa.
+
+Essa regressão poderia potencialmente afetar muitas bibliotecas, dois desses
+casos são o `HashWithIndifferentAccess` e `OrderedHash` no Rails.
+Eles estão quebrados: [Rails' issue #14188](https://github.com/rails/rails/issues/14188).
+
+Esse comportamento será revertido para o comportamento da 2.1.0 no Ruby 2.1.2,
+mas esse será o comportamento esperado no Ruby 2.2.0:
+[Funcionalidade #9223](https://bugs.ruby-lang.org/issues/9223).
+Então recomendamos que corrija o seu código para esperar essa mudança de
+comportamento.
+
+Esse acidente foi causado por um commit de backport perdido.
+Para mais detalhes, veja [http://blog.sorah.jp/2014/03/10/hash-reject-regression-in-ruby211](http://blog.sorah.jp/2014/03/10/hash-reject-regression-in-ruby211).
+
+Desculpe por qualquer inconveniencia, e obrigado pelo seu suporte.

--- a/pt_br/news/_posts/2014-03-14-rubyconf-taiwan-2014.md
+++ b/pt_br/news/_posts/2014-03-14-rubyconf-taiwan-2014.md
@@ -1,0 +1,16 @@
+---
+layout: news_post
+title: "Inscrições para a RubyConf Taiwan 2014 Abertas"
+author: "Juanito Fatas"
+translator: "diogoandre"
+date: 2014-03-14 05:58:31 +0000
+lang: pt_br
+---
+
+RubyConf Taiwan 2014 vai acontecer em Taipei, Taiwan em 25-26 Abril de 2014.
+
+Para detalhes sobre palestrantes e agenda por favor visite o [site da conferência](http://rubyconf.tw/2014/) e o [press release da RubyConf Taiwan](http://rubytaiwan.tumblr.com/post/79134654151/rubyconftaiwan2014-press-release-en).
+
+Tíquetes estão disponíveis até 31 de Março de 2014.
+
+[Reserve Seu Tíquete!](http://rubytaiwan.kktix.cc/events/rubyconftw2014?locale=en)

--- a/pt_br/news/_posts/2014-03-15-eurucamp-2014.md
+++ b/pt_br/news/_posts/2014-03-15-eurucamp-2014.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "eurucamp 2014 datas e CFP"
+author: "Florian Gilcher"
+translator: "esampaio"
+date: 2014-03-15 14:00:00 +0000
+lang: pt_br
+---
+
+[eurucamp 2014][1] acontecerá em Berlin entre 1 e 3 de Agosto.
+eurucamp é uma cria da EuRuKo 2011 e tem acontecido desde então.
+
+O [Call for Proposals][2] está aberto até 1º de Maio.
+Nosso CFP é anônimo e justo e todos as entradas serão preenchidas por ele, além
+disso, a eurocamp possui um [programa de mentoria incondicional][3].
+
+Nós estamos aceitando propostas tanto para palestras quanto para workshops
+sobre Ruby e a comunidade. Apresentadores novos ou veteranos são igualmente
+bem-vindos a experimentar novos assuntos.
+Maiores informações podem ser encontradas em nosso [guia CFP][4].
+
+eurucamp é uma conferência que ocorre no verão e possui bastante tempo livre
+para socialização além de muitas oportunidades para desenvolver suas idéias.
+Veja nosso [vídeo de 2012][5] em nossa [página no Vimeo][6] para ter uma idéia.
+Também veja nosso [aplicativo de atividades][7] como uma amostra do que
+acontece na eurucamp e envolta dela.
+
+eurucamp possui um [Código de Conduta][8] estrito. Nós aceitamos famílias e
+oferecemos creche, além de recebermos pessoas com dificuldades de acessibilidade.
+
+Somos uma conferência internacional e já recebemos pessoas de todo o mundo.
+
+A venda de ingressos estará disponível em breve.
+
+[1]: http://2014.eurucamp.org
+[2]: http://cfp.eurucamp.org
+[3]: http://cfp.eurucamp.org/mentorship
+[4]: http://cfp.eurucamp.org/guide
+[5]: https://vimeo.com/51200145
+[6]: https://vimeo.com/eurucamp
+[7]: http://activities.eurucamp.org
+[8]: http://cfp.eurucamp.org/coc

--- a/pt_br/news/_posts/2016-02-24-support-plan-of-ruby-2-0-0-and-2-1.md
+++ b/pt_br/news/_posts/2016-02-24-support-plan-of-ruby-2-0-0-and-2-1.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Planos de suporte para Ruby 2.0.0 e Ruby 2.1"
+author: "usa"
+translator: "fpgentil"
+date: 2016-02-24 09:00:00 +0000
+lang: pt_br
+---
+
+Anunciamos os futuros planos de suporte para Ruby 2.0.0 e Ruby 2.1.
+
+## Sobre Ruby 2.0.0
+
+Como anunciado anteriormente, todo o suporte para Ruby 2.0.0 se encerra hoje.
+*Bugs* e correções de seguranças de versões mais recentes de Ruby não serão mais
+portadas à versão 2.0.0 e nenhum *patch release* da versão 2.0.0 será lançado.
+
+Recomendamos fortemente que você faça o upgrade para Ruby 2.3 ou 2.2 o mais
+rápido possível.
+
+Por favor entre em contato conosco através da lista de email ruby-core caso
+queira continuar mantendo um branch da versão 2.0.0 com motivos pelos quais você
+não pode fazer o upgrade.
+
+## Ruby 2.1
+
+Estamos planejando em lançar uma versão de Ruby 2.1.9 até o final de março.
+Isso significa que após o lançamento da versão 2.1.9 nós não iremos mais portar
+nenhuma correção de *bugs* para a versão 2.1, com exceção das correções de
+segurança.
+
+Nós recomendamos que você comece a planejar o *upgrade* para Ruby 2.3 ou 2.2.
+
+A propósito, nós estamos também planejando em lançar a versão 2.1.10 logo após
+a *release* 2.1.9. Isso não é uma correção de *bugs* e nem de segurança. Nós
+nunca tivemos antes uma versão de Ruby com dois dígitos. Portanto, nós
+consideramos que é importante testar essa versão sem nenhuma correção crítica
+de segurança.
+
+Ruby 2.1.10 não irá incluir nenhuma mudança da 2.1.9 com exceção do número da
+versão. Você não deve usá-la em produção, mas sim testá-la antes do lançamento
+da 2.1.11 que irá provavelmente incluir correções de segurança.

--- a/pt_br/news/_posts/2016-03-30-ruby-2-1-9-released.md
+++ b/pt_br/news/_posts/2016-03-30-ruby-2-1-9-released.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Ruby 2.1.9 lançado"
+author: "usa"
+translator: "fpgentil"
+date: 2016-03-30 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.1.9 foi lançado.
+
+Esta versão inclui várias correções de *bugs*.
+Consulte o [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_1_9/ChangeLog)
+para detalhes.
+
+[Como anunciado anteriormente](https://www.ruby-lang.org/pt_br/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/),
+esta é a última *release* normal para a série Ruby 2.1. Depois disso, nós nunca
+mais iremos portar nenhuma correção de *bug* para 2.1 com exceção de correções
+de segurança. Nós recomandamos que você comece a planejar o *upgrade* para Ruby
+2.3 ou 2.2.
+
+A propósito, nós estamos planejando lançar o Ruby 2.1.10 em alguns dias.
+Ruby 2.1.10 não incluirá nenhuma alteração da versão 2.1.9, com exceção do
+número da versão. Você não deve utilizá-la em produção, mas deve testá-la pois
+é um número de versão com dois dígitos.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2)
+
+      SIZE:   12016421 bytes
+      SHA1:   39524185b580a3390a3b5019819c8b28d3249766
+      SHA256: 4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e
+      SHA512: a86422132e4c64007a84a91696f4557bdcbc8716fbfe1962f1eef3754ee7f994f4de0b5b7e7231c25057515767040d5c4af33339750b6db15744662e9bd24f38
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz)
+
+      SIZE:   15166126 bytes
+      SHA1:   dd68afc652fe542f83a9a709a74f4da2662054bf
+      SHA256: 034cb9c50676d2c09b3b6cf5c8003585acea05008d9a29fa737c54d52c1eb70c
+      SHA512: 1e03aa720e932f019c4651c355e8ef35b87fdf69b054c9d39a319467d2a8e5bfe4995cbacd9add36b832c77761a47c9d1040f00e856ad5888d69ec7221455e35
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.xz)
+
+      SIZE:   9395648 bytes
+      SHA1:   5e89efa5189c3def8ee8de18ce750a7e4a20ac32
+      SHA256: 39f203f7498aed2456fb500147fada5adcbf102d89d4f6aca773ebcadd8ea82a
+      SHA512: 1f331a8910fd7a9ab9c41bf56aef12041dd413ad49c696f6df2c9a7ec3a3d5cdf383f2a3d30949ea37b8ecb39f50355e526412b36ed4e07b60733d9db4d2bd14
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.zip)
+
+      SIZE:   16696728 bytes
+      SHA1:   4aa288b65fbf12692ac53577adc561c9a0f6a6ca
+      SHA256: 8610fdb1836d493c19600cfed4828083f85197096c0aea3f73fa1ed532cbb5a7
+      SHA512: a212b6a58637f6bf4f456d7ecc7bbd8ceaa0c3f16cb844b872eb62eaf261b5874fdb79705241d05a356fcdc1d3fdd8a94fcd8e6ca62190e9f544c8f45a9f41af
+
+## Comentário da *release*
+
+Obrigado a todos que ajudaram nessa *release*.
+
+A manutenção do Ruby 2.1, incluindo essa *release*, baseia-se no "Agreement for
+the Ruby stable version" da [Ruby Association](http://www.ruby.or.jp/).

--- a/pt_br/news/_posts/2016-04-01-ruby-2-1-10-released.md
+++ b/pt_br/news/_posts/2016-04-01-ruby-2-1-10-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Ruby 2.1.10 lançado"
+author: "usa"
+translator: "fpgentil"
+date: 2016-04-01 02:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.1.10 foi lançado.
+Essa *release* não é destinada para uso em produção, mas sim testes de
+compatibilidade com as versões de dois dígitos.
+Você não precisa substituir o Ruby 2.1.9 por 2.1.10 em uso regular.
+
+Como anunciado em [2.1.9 release post](https://www.ruby-lang.org/pt_br/news/2016/03/30/ruby-2-1-9-released/),
+Ruby 2.1.10 não inclui nenhuma mudança da versão 2.1.9, com exceção de seu número
+(e uma pequena alteração relacionada com a suíte de testes). Por favor teste sua
+aplicação e/ou bibliotecas para compatibilidade com versões de dois dígitos.
+
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2)
+
+      SIZE:   12015299 bytes
+      SHA1:   22dcd759d8cbb14c8735988fbc7ee5c35f9d4720
+      SHA256: a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1
+      SHA512: 4b7213695416876e4de3cbce912f61ac89db052c74f0daa8424477991cfc49b07300e960177ff576b634a97ee8afef3c5aded5d5806329dbd01d0ce7b42b9b63
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz)
+
+      SIZE:   15165837 bytes
+      SHA1:   2a5194b1fd42a3f1f23f1e0844ae78332a9efd5d
+      SHA256: fb2e454d7a5e5a39eb54db0ec666f53eeb6edc593d1d2b970ae4d150b831dd20
+      SHA512: 5f9c0cc3d10b4e04c63f001b4add782c34b9f260368f48b443b397cea57680d328f7c28cbb2a9be4c2f5acd114bac07dacb100d57018fa4d2a1792fc03083418
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.xz)
+
+      SIZE:   9362868 bytes
+      SHA1:   adcc9e10b8f7add0e19f8c70afc134c069a862ca
+      SHA256: 5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
+      SHA512: 72406ac133af7f057d4633d2a300e49e133881f6b36ff4cdf6c72b4ff4325de332fc5a45c96ea407140a8bf09cdc307e13107c539196902e5b67b7d24cd72dc9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip](https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.zip)
+
+      SIZE:   16706304 bytes
+      SHA1:   402158192b7673cb4e7a67f48f6d93945bc9fd13
+      SHA256: 21cf83156ec782d17827fb9c8a945626dfd68cf0d9eb5ca7a78b12eb91c6f1fb
+      SHA512: 5490fc4726a1efaea8c7c541ca3102013b00a0af2903d15009307265c93b218bb13aab0007d279823c740a9b173d957ca79f2d8f25932f04763ec1aa18d164e8
+
+## Comentários da *release*
+
+Obrigado a todos que contribuíram para essa *release*.

--- a/pt_br/news/_posts/2016-04-26-ruby-2-2-5-released.md
+++ b/pt_br/news/_posts/2016-04-26-ruby-2-2-5-released.md
@@ -1,0 +1,55 @@
+---
+layout: news_post
+title: "Ruby 2.2.5 lançado"
+author: "usa"
+translator: "fpgentil"
+date: 2016-04-26 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.2.5 foi lançado.
+
+Essa *release* inclui várias correções de *bugs*.
+Consulte o [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_2_5/ChangeLog)
+para mais detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2)
+
+      SIZE:   13350551 bytes
+      SHA1:   f78473fe60a632b778599374ae64612592c2c9c1
+      SHA256: 22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700
+      SHA512: d3224814361c297bc36646c2e40f63c461ccf5a77fea5a3acdcb2c7ad1705bb229ac6abbd7ad1ae61cbe0fefd7a008c6102568d11366ad3107179302cd3e734e
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz)
+
+      SIZE:   16654395 bytes
+      SHA1:   457707459827bd527347a5cee7b4dc509b486713
+      SHA256: 30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3
+      SHA512: 3dd8688c64b8b143bdd6b0f123b7c2ecdd1b93c7c9ee51b2774a3b0b864897789932c7ad406293a6ab12c9eb9db9cfb2940fc14e2afc4f79718994f7668cbd5f
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.xz)
+
+      SIZE:   10457620 bytes
+      SHA1:   58484284dd613e139e8f7023b1168e9034a8766d
+      SHA256: f86feaa0a578e8da0924ced3ec68b25b50d69fc9a72cc8d919bc3c73f85f87d7
+      SHA512: 6da4bdb0a43d56c7a8e4dddbcacf237e998ebb54706c8f835b53713dbdf924e40d5f89f63017515e1d66904ca01f28058cf296567104e06540c57f036dcdd0fe
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.zip)
+
+      SIZE:   18493821 bytes
+      SHA1:   e4f497e5b79768ae93dd73ac26da4ff5dd722bfe
+      SHA256: d5094d7cc50266772a8352c68b7fcd865889fd174c09e2f11bb003696cd04bb3
+      SHA512: b3789063252e361aa4598ecd9170fc360f0d5685497975ce09442fe5815c438b67b95fc67e56b99ab4044a49715ed1a8b1fb089f757c7c0d1a777536e06de8cf
+
+## Comentários da *release*
+
+Obrigado a todos que contribuíram para essa *release*.
+
+Com essa *release*, a manutenção do Ruby 2.2 mudou do nagachika-san para o usa.
+Cerca de dois terços das mudanças incluídas nessa *release* foram feitas pelo
+nagachika-san. Obrigado pela sua grande contribuícão.
+
+A manutenção do Ruby 2.2, incluindo essa *release*, baseia-se no "Agreement for
+the Ruby stable version" da [Ruby Association](http://www.ruby.or.jp/).

--- a/pt_br/news/_posts/2016-04-26-ruby-2-3-1-released.md
+++ b/pt_br/news/_posts/2016-04-26-ruby-2-3-1-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Ruby 2.3.1 Released"
+author: "nagachika"
+translator: "fpgentil"
+date: 2016-04-26 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.3.1 foi lançado.
+
+Essa é a primeira versão minúscula (*TEENY*) estável da série 2.3.
+
+Essa versão inclui várias correções de *bugs*.
+Consulte o [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_3_1/ChangeLog)
+para detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2)
+
+      SIZE:   14432088 bytes
+      SHA1:   4ee76c7c1b12d5c5b0245fc71595c5635d2217c9
+      SHA256: 4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d
+      SHA512: a8659b96a3a481a3dbdbb6997eb18ff1f8cd926a9707a90d071e937315c21d372c89252f0d44732ae5007d2678fda8c8fbceafa4e4b4ff500d236fb796284d8d
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz)
+
+      SIZE:   17797997 bytes
+      SHA1:   c39b4001f7acb4e334cb60a0f4df72d434bef711
+      SHA256: b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd
+      SHA512: 7399d59b54764e02760ed6cac525a43c5e7212aebbbff8a04234dc45adbc0cd9fe1ff9a9328eefd38f02d3b6c5b2e3ca843808784755ff4e66ded624f55c150a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.xz)
+
+      SIZE:   11407048 bytes
+      SHA1:   83499c14c674cf2d88e495031434a94c06330879
+      SHA256: 6725b5534d5a3a21ec4f14d6d7b9921a0d00d08acb88fd04cd50b47b70496338
+      SHA512: e9d89aeefb1b1e72cee9d3d414b27c793cf09ff3ed5e0ea5277a2b6ae1cae9fdbf6b404a84b42c0c6835754eb04674fc4f1470fbfedabeee3f57e518f13db633
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.zip)
+
+      SIZE:   19842037 bytes
+      SHA1:   ab9dec602b11ee4cfc295d6aa87ebe712372d123
+      SHA256: 4c8ae431b33f78d64cabb31911e0890e9a3ac380b4f22b11738f9baeeda51763
+      SHA512: a26d3ab5983c6f3ea454e3e75554137305525479e4c15c0ae424689e870e2c5a9f0fe194975cf362cc5528ce601e31a0a15b87c7af200fd0d1da17459435b953
+
+## Comentários da *release*
+
+Vários *committers*, desenvolvedores e usuários que reportaram *bugs* nos ajudaram
+a lançar essa versão. Obrigado pelas suas contribuições.

--- a/pt_br/news/_posts/2016-05-16-confoo-cfp.md
+++ b/pt_br/news/_posts/2016-05-16-confoo-cfp.md
@@ -1,0 +1,19 @@
+---
+layout: news_post
+title: "ConFoo Vancouver 2016 está procurando por palestrantes em Ruby"
+author: "afilina"
+translator: "jcserracampos"
+date: 2016-05-16 20:06:00 +0000
+lang: pt_br
+---
+
+ConFoo está mais uma vez procurando por palestrantes apaixonador para sua próxima conferência.
+
+![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yvr2016/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}ConFoo está feliz por [receber artigos][1]  para a edição Vancouver 2016! Se você é interessado em falar sobre Ruby ou outros tópicos sobre desenvolvimento web, por favor submeta até dia 6 e junho. Nós vamos custear viagem e hotel para os palestrantes que requerirem.
+
+ConFoo Vancouver acontecerá entra 5 e 7 de dezembro de 2016. Para aqueles que são acostumados com ConFoo Montreal, esta conferência ainda ocorrerá anualmente em adição a de Vancouver. [Visite nosso site][2] para aprender mais.
+
+Palestras são 35 minutos do tópico e 10 minutos para perguntas e respostas, totalizando 45 minutos. Estamos ansiosamento esperando por sua proposta!
+
+[1]: https://confoo.ca/en/yvr2016/call-for-papers
+[2]: https://confoo.ca/en/yvr2016

--- a/pt_br/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
+++ b/pt_br/news/_posts/2016-06-20-ruby-2-4-0-preview1-released.md
@@ -1,0 +1,116 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.0-preview1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2016-06-20 09:00:00 +0000
+lang: pt_br
+---
+
+Estamos satisfeitos em anunciar o lançamento do Ruby 2.4.0-preview1.
+
+Ruby 2.4.0-preview1 é o primeiro *preview* do Ruby 2.4.0.
+Este preview1 está sendo lançado antes do usual porque ele inclui várias
+funcionalidades novas e melhorias.
+Sinta-se a vontade para
+[enviar comentários](https://github.com/ruby/ruby/wiki/How-To-Report)
+já que você ainda pode mudar as funcionalidades.
+
+
+## [Unificação de Fixnum e Bignum em Integer](https://bugs.ruby-lang.org/issues/12005)
+
+Embora a [ISO/IEC 30170:2012](http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=59579)
+não especifique detalhes da classe Integer,
+CRuby tem duas classes visíveis de Integer: Fixnum e Bignum.
+Ruby 2.4 as unifica em Integer.
+
+## [String suporta mapeamento de caixa Unicode](https://bugs.ruby-lang.org/issues/10085)
+
+`String/Symbol#upcase/downcase/swapcase/capitalize(!)` agora lida
+com mapeamento de caixa Unicode ao invés de apenas mapeamento de caixa ASCII.
+
+## Melhorias de perfomance
+
+Ruby 2.4 também contém as seguintes melhorias de performance incluindo
+mudanças na linguagem:
+
+### [Array#max, Array#min](https://bugs.ruby-lang.org/issues/12172)
+
+`[x, y].max` e `[x, y].min` estão otimizadas para não criarem um *array* temporário
+dentro de certas condições.
+
+### [Regexp#match?](https://bugs.ruby-lang.org/issues/8110)
+
+Adicionada `Regexp#match?`, que executa uma combinação de expressão regular sem criar
+um objeto de referência de volta e mudando '$~' para reduzir a alocação de objeto.
+
+### Outras melhorias de perfomance
+
+* [acelerada o acesso a variável de instância](https://bugs.ruby-lang.org/issues/12274)
+
+## Debugando
+
+### [Thread#report_on_exception e Thread.report_on_exception](https://bugs.ruby-lang.org/issues/6647)
+
+Ruby ignora exceções em *threads* a não ser que outra *thread* se junte explicitamente a ela.
+Com `report_on_exception = true`,
+você pode notar se uma *thread* morreu devido a uma exceção não processada.
+
+Envie-nos comentários sobre qual deve ser o padrão para `report_on_exception`
+e sobre *report-on-GC*.
+
+### [Detecção de *thread deadlock* agora mostra *threads* com seu histórico e dependências](https://bugs.ruby-lang.org/issues/8214)
+
+Ruby tem deteção de *deadlock* para *threads* em espera, mas seu relatório não
+inclue informações suficientes para debugar.
+A detecção de *deadlock* no Ruby 2.4 mostrar *threads* com seu histórico e
+*threads* dependentes.
+
+Experimente e aproveite programando com Ruby 2.4.0-preview1, e
+[nos envie comentários](https://github.com/ruby/ruby/wiki/How-To-Report)!
+
+## Mudanças notáveis desde 2.3
+
+Veja [NOTÍCIAS](https://github.com/ruby/ruby/blob/v2_4_0_preview1/NEWS)
+e [ChangeLog](https://github.com/ruby/ruby/blob/v2_4_0_preview1/ChangeLog)
+para detalhes.
+
+Com essas mudanças,
+[1140 arquivos mudaram, 33126 inserções(+), 50993 remoções(-)](https://github.com/ruby/ruby/compare/v2_3_0...v2_4_0_preview1)
+desde Ruby 2.3.0!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2>
+
+  * SIZE:   14108114 bytes
+  * SHA1:   7dcc42548d0724d83b6589ab98f34282845d7bcd
+  * SHA256: 17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649
+  * SHA512: c9873e8686eb54dbde61d6e23cd5197beebccd6cb31fd12c82763ebe1fde17095d7514d9d93c2c82b238032c98691df5479dc2d666a8a590e0fc54450ec29cb5
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.gz>
+
+  * SIZE:   17605452 bytes
+  * SHA1:   1003a1e57547d81f4bb979c0f40f242afc284cd5
+  * SHA256: 80d02f49f40e7ce07b70bee7efda751b0595a349a017306e9fe8caad5da13e64
+  * SHA512: 4b603ab4ff9ea7e8bb8053aa4b638839d534241466d7f0e4d5bca3f2ea416694c2ea391790f1ffdc07fa538918d27707621741eb0ddc7bd00eb9d7628622787a
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.xz>
+
+  * SIZE:   11155800 bytes
+  * SHA1:   bc33085277266f5a09a143bf6817affcb77f8e7f
+  * SHA256: 62942c7300727469fe3d2b43e5a5c772d4836cf624a1d644bdece2afaca472c8
+  * SHA512: dfc2c6642d49fa95383817a6dc82c416b3218ddfdaf882d6d2e5a7da22d0a5ac142e516a57aa96214070f3c7551d275044233ac052c82d67189b01c39847aad4
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.zip>
+
+  * SIZE:   19904781 bytes
+  * SHA1:   25c16ee91bbcb0224f80e20d938f5c08832973f7
+  * SHA256: fd588aea1558b1171f87a3dd342ee207b8995a2c0a8241d7aa15bcfa16036854
+  * SHA512: f2fff35ff9157a4b31177b3d6b91bdaad04c22b3c626c3a5e5ec9a31b103f9607b31c909ef27880065cfdbcfa5d6901a6db89d22e0c645666d069c5b6dd1818b
+
+## Comentário de lançamento
+
+Veja também o calendário de lançamento e outras informações:
+
+[ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-master/wiki/ReleaseEngineering24)

--- a/pt_br/news/_posts/2016-07-25-ruby-prize-2016.md
+++ b/pt_br/news/_posts/2016-07-25-ruby-prize-2016.md
@@ -1,0 +1,31 @@
+---
+layout: news_post
+title: "Nomeações para Ruby Prize 2016 estão abertas"
+author: "Ruby Association"
+translator: "jcserracampos"
+date: 2016-07-25 12:00:00 +0000
+lang: pt_br
+---
+
+Nomeações para a Ruby Prize 2016 estão sendo aceitas para novos e excepcionais
+membros da comunidade Ruby.
+
+O Ruby Prize é dado para reconhecer os esforços de atividades memoráveis e
+conquistas na comunidade Ruby. O prêmio será entregue pelo comitê
+executivo composto por três organizações, a Ruby Association, Nihon Ruby no Kai
+e Matsue City.
+
+O ganhador e indicado finalista (1-2 pessoas) receberão uma premiação na
+RubyWorld Conference 2016, que ocorrerá em Matsue, Japão em 3 e 4 de novembro.
+
+Em adição, o ganhador do Ruby Prize também ganhará 1 milhão de ienes
+(aproximadamente 9.683 dólares no câmbio de 12 de julho de 2016)
+
+Indicados serão selecionados por:
+
+* Recomendações vindas do comitê executivo "Prize Member"
+* Recomendações vindas do público geral (você)
+
+Por favor, veja abaixo para mais detalhes
+
+[Ruby Association: Now accepting nominations for the Ruby Prize Award 2016](http://www.ruby.or.jp/en/news/20160725.html)

--- a/pt_br/news/_posts/2016-08-26-confoo-cfp.md
+++ b/pt_br/news/_posts/2016-08-26-confoo-cfp.md
@@ -1,0 +1,20 @@
+---
+layout: news_post
+title: "ConFoo Montreal 2017 está procurando palestrantes em Ruby"
+author: "afilina"
+translator: "jcserracampos"
+date: 2016-08-26 16:00:00 +0000
+lang: pt_br
+---
+
+Quer levar suas ideias de desenvolvimento web para frente de uma plateia ao vivo? A [chamada para artigos][1] para a conferência ConFoo Montreal 2017 está aberta! Se você tem um desejo ardente para falar em público sobre Ruby, bancos de dados, JavaScript, ou qualquer outro tópico de desenvolvimento web, ConFoo quer ver as suas propostas.
+
+![ConFoo - Developer Conference](https://confoo.ca/images/propaganda/yul2017/en/like.png){: style="border:0; float:right; margin-left:20px;" width="180" height="130"}
+O período é de 21 de agosto até 20 de setembro de 2016, então corra. Um benefício adicional: Se sua proposta for selecionado e você mora fora da região de Montreal,, ConFoo cobrirá sua viagem e hospedagem.
+
+Você terá 45 minutos para impressionar a plateia, com 35 minutos para seu tópico e 10 minutos para perguntas e respostas. ConFoo não pode esperar para ver suas propostas. Impressione-nos.
+
+ConFoo Montreal ocorrerá entre 8-10 de março de 2017. Para quem já sabe sobre nossa conferência, fique alerta que nossa tradição anual ainda ocorrerá em adição a ConFoo Vancouver. Visite [site da ConFoo][2] para aprender mais sobre os dois eventos.
+
+[1]: https://confoo.ca/en/yul2017/call-for-papers
+[2]: https://confoo.ca/en

--- a/pt_br/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
+++ b/pt_br/news/_posts/2016-09-08-ruby-2-4-0-preview2-released.md
@@ -1,0 +1,121 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.0-preview2"
+author: "naruse"
+translator: "jcserracampos"
+date: 2016-09-08 09:00:00 +0000
+lang: pt_br
+---
+
+Estamos satisfeitos em anunciar o lançamento do Ruby 2.4.0-preview2.
+
+Ruby 2.4.0-preview2 é o segundo *preview* do Ruby 2.4.0.
+Este preview2 está sendo lançado para receber comentários da comunidade.
+Sinta-se a vontade para
+[enviar comentários](https://github.com/ruby/ruby/wiki/How-To-Report)
+sendo que você ainda pode mudar as funcionalidades.
+
+## [Unificação de Fixnum e Bignum em Integer](https://bugs.ruby-lang.org/issues/12005)
+
+Embora a [ISO/IEC 30170:2012](http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=59579)
+não especifique detalhes da classe Integer,
+CRuby tem duas classes visíveis de Integer: Fixnum e Bignum.
+Ruby 2.4 as unifica em Integer.
+Todas as extensões em C que envolvem as classes Fixnum ou Bignum precisam ser corrigidas.
+
+Veja também [o ticket](https://bugs.ruby-lang.org/issues/12005) e [slides do akr](http://www.a-k-r.org/pub/2016-09-08-rubykaigi-unified-integer.pdf).
+
+## [String suporta mapeamento de código Unicode](https://bugs.ruby-lang.org/issues/10085)
+
+`String/Symbol#upcase/downcase/swapcase/capitalize(!)` agora lida
+com mapeamento de código Unicode ao invés de apenas mapeamento de código ASCII.
+
+## Aperfeiçoamento de perfomance
+
+Ruby 2.4 também contém os seguintes aprimoramentos de performance incluindo
+mudanças na linguagem
+
+### [Array#max, Array#min](https://bugs.ruby-lang.org/issues/12172)
+
+`[x, y].max` e `[x, y].min` estão otimizadas para não criarem um *array* temporário
+dentro de certas condições.
+
+### [Regexp#match?](https://bugs.ruby-lang.org/issues/8110)
+
+Adicionada `Regexp#match?`, que executa uma combinação de expressão regular sem criar
+um objeto de referência de volta e mudando '$~' para reduzir a alocação de objeto.
+
+### Outras melhorias de perfomance
+
+* [acelerado o acesso a variável de instância](https://bugs.ruby-lang.org/issues/12274)
+
+## Debugging
+
+### [Thread#report_on_exception e Thread.report_on_exception](https://bugs.ruby-lang.org/issues/6647)
+
+Ruby ignora exceções em *threads* a não ser que outra *thread* se junte explicitamente a ela.
+Com `report_on_exception = true`,
+você pode notar se uma *thread* morreu devido a uma exceção não processada.
+
+Envie-nos comentários sobre qual deve ser o padrão para `report_on_exception`
+e sobre report-on-GC, o qual mostrar um relatório quando uma *thread* é
+coletada como lixo sem se juntar.
+
+### [Detecção de *thread deadlock* agora mostra *threads* com seu histórico e dependências](https://bugs.ruby-lang.org/issues/8214)
+
+Ruby tem deteção de *deadlock* para *threads* em espera, mas seu relatório não
+inclue informações suficientes para debugar.
+A detecção de *deadlock* no Ruby 2.4 mostrar *threads* com seu histórico e
+*threads* dependentes.
+
+Experimente e aproveite programando com Ruby 2.4.0-preview2, e
+[nos envie comentários](https://github.com/ruby/ruby/wiki/How-To-Report)!
+
+## Mudanças notáveis desde de 2.3
+
+* Suporte a OpenSSL 1.1.0
+* ext/tk foi removido de stdlib [Feature #1490]
+
+Veja [NOTÍCIAS](https://github.com/ruby/ruby/blob/v2_4_0_preview1/NEWS)
+e [ChangeLog](https://github.com/ruby/ruby/blob/v2_4_0_preview1/ChangeLog)
+para detalhes.
+
+With those changes,
+[2353 arquvidos alterados, 289057 inserções(+), 73847 remoções(-)](https://github.com/ruby/ruby/compare/v2_3_0...v2_4_0_preview2)
+desde Ruby 2.3.0!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2>
+
+  * SIZE:   12463225 bytes
+  * SHA1:   95a501624f1cf4bb0785d3e17afd0ad099f66385
+  * SHA256: 2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d
+  * SHA512: 0c9a59a2f57a99c4ee8539a30f41da1de7547566203f89d856e1be9dbb44365754e6c470145dc9336eb324e0feb2f53d9fef18a1564968ac21f9ee528905949f
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.gz>
+
+  * SIZE:   15586514 bytes
+  * SHA1:   492a13c4ddc1c0c218433acb00dcf7ddeef96fe0
+  * SHA256: fec544836428aada2dc593a8cc42ce330798a805e49ecb807a0e21b386fd0b14
+  * SHA512: 5a3de852a7611e79f38219ed7bb13772aaabb25538ca843d38743180a0cc939a4e34c008b61d578da785285196b6b8882270bddc17cbed481237db8afa4c54e4
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.xz>
+
+  * SIZE:   9886832 bytes
+  * SHA1:   95d5fd7d54d86497194f69ec433755a517dcde8f
+  * SHA256: 6c2d25bedc50c2f19b0e349f0ffd9b9a83000d9cb6a677bf5372fb493d33e16a
+  * SHA512: b9bd898d17583103ee61b4764ac86eb62c9661fca1f41ff0d06a15965a0a1ba581491d4b8a342e527d63e102b6ddcb2acebdabe5b246409ce9711e13f9428d5b
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.zip>
+
+  * SIZE:   17401564 bytes
+  * SHA1:   5f3a5b2fd03f70d49e74ec36be3e0c110f6c17cc
+  * SHA256: 4d0e466148283ad52208b1e1b70b018aefb7fa95b490fc862d5ea4ca284ecdd2
+  * SHA512: 0ef2098d995238580245a4bcee843641199c1194189be13614611e2ffec329278072319a799d409eaf13b1cff45f05a0eae02d9ea8ccc69058fa49e03eca0130
+
+## Comentário de Lançamento
+
+Veja também o cronograma de lançamento e outras informações:
+
+[ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-master/wiki/ReleaseEngineering24)

--- a/pt_br/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
+++ b/pt_br/news/_posts/2016-10-20-fukuoka-ruby-award-2017.md
@@ -1,0 +1,65 @@
+---
+layout: news_post
+title: "2017 Fukuoka Ruby Award Competition - Inscrições serão avaliadas por Matz"
+author: "Fukuoka Ruby"
+translator: jcserracampos
+date: 2016-10-20 00:00:00 +0000
+lang: pt_br
+---
+
+Prezados Entusiastas do Ruby,
+
+O Governo de Fukuoka, Japão, juntamente com "Matz" Matsumoto gostaria de lhe
+convidar para se inscrever na seguinte competição Ruby. Se você já desenvolveu um
+programa Ruby interessante, por favor sinta-se encorajado a participar.
+
+2017 Fukuoka Ruby Award Competition - Grande Prêmio - 1 Milhão de ienes!
+
+Prazo de inscrição: 27 de dezembro de 2016
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz e um grupo de palestrantes selecionarão os vencedores da _Fukuoka Competition_.
+O grande prêmio para a Fukuoka Competition é um milhão de ienes.
+Ganhadores do grande prêmio anteriores incluem Rhomobile (EUA) e APEC Climate Center (Coreia).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Programas inscritos na competição não precisam ser escritos inteiramente em Ruby
+mas devem aproveitar-se das características únicas do Ruby.
+
+Projetos devem ter sido desenvolvidos ou concluídos dentro dos 12 meses passados
+para serem elegíveis. Por favor, visite os seguintes sites da Fukuoka para informações
+adicionais ou para se inscrever
+
+[http://www.digitalfukuoka.jp/events/114](http://www.digitalfukuoka.jp/events/114)
+ou
+[http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2017-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/305/RubyAward_ApplicationForm_2017.doc)
+
+Por favor, envie o formulário de inscrição para award@f-ruby.com.
+
+Neste ano, nós temos os seguintes prêmios especiais:
+
+O vencedor do AWS Prize receberá:
+
+* Amazon Fire Tablet (sujeito a alteração)
+* Consultoria técnica de arquiteto da AWS
+
+O vencedor do GMO Pepavo Prize receberá:
+
+* Uma cesta de presentes cheia de comidas locais e petiscos (no valor de 30.000 ienes)
+* Um certificado de 50.000 ienes para serviços de domínio
+
+O vencedor do IIJ GIO Prize receberá:
+* Um cupom gratuito no valor de 500.000 ienes do IIJ GIO (até 6 meses)
+
+O vencedor do Salesforce Prize receberá:
+
+* Novidades da salesforce.com
+
+"Matz testará e revisará completamente seu código fonte, então
+é muito significativo participar! A competição é gratuita para se inscrever."
+
+Obrigado!

--- a/pt_br/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
+++ b/pt_br/news/_posts/2016-11-09-ruby-2-4-0-preview3-released.md
@@ -1,0 +1,131 @@
+---
+layout: news_post
+title: "Lançado o Ruby 2.4.0-preview3"
+author: "naruse"
+translator: "Filipe Rocha"
+date: 2016-11-09 09:00:00 +0000
+lang: pt_br
+---
+
+Temos o gosto de anunciar a versão 2.4.0-preview3 do Ruby.
+
+A versão 2.4.0-preview3 do Ruby é a terceira *preview* do Ruby 2.4.0,
+lançada com o fim de obter *feedback* da comunidade.
+
+Poderão
+[enviar *feedback*](https://github.com/ruby/ruby/wiki/How-To-Report)
+uma vez que ainda podem influenciar das funcionalidades.
+
+## [Introdução de melhorias nas hash tables por Vladimir Makarov](https://bugs.ruby-lang.org/issues/12142)
+
+Melhorar a estrutura interna da hash table (st_table) introduzindo o *open addressing*
+e introdução de um *array* com a ordem de inclusão.
+
+## Binding#irb: Iniciar uma sessão REPL como `binding.pry`
+
+Enquanto está a fazer o *debug*, poderá utilizar `p` para listar o valor das variáveis.
+Com o [pry](https://github.com/pry/pry) e incluindo `binding.pry` na sua aplicação,
+será lançado este REPL para correr qualquer código ruby.
+[r56624](https://github.com/ruby/ruby/commit/493e48897421d176a8faf0f0820323d79ecdf94a) introduz `binding.irb` com o mesmo comportamento para o irb.
+
+## [Unificar as classes Fixnum e Bignum na classe Integer](https://bugs.ruby-lang.org/issues/12005)
+
+Apesar do [ISO/IEC 30170:2012](http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=59579)
+não especificar os detalhes da classe Integer,
+o Ruby teve duas classes Integer visíveis: Fixnum and Bignum.
+O Ruby 2.4 unifica-as na classe Integer.
+Todas as extensões C que utilizam a classe Fixnum ou Bignum necessitam de ser corrigidas.
+
+Consultar também [o ticket](https://bugs.ruby-lang.org/issues/12005) e os [slides do akr](http://www.a-k-r.org/pub/2016-09-08-rubykaigi-unified-integer.pdf).
+
+## [String suporta Unicode case mappings](https://bugs.ruby-lang.org/issues/10085)
+
+`String/Symbol#upcase/downcase/swapcase/capitalize(!)` manipula, agora,
+maiúsculas e minúsculas em Unicode em vez de o fazer somente em ASCII.
+
+## Melhorias de desempenho
+
+O Ruby 2.4 contém, também, as seguintes melhorias na performance incluindo melhorias na linguagem:
+
+### [Array#max, Array#min](https://bugs.ruby-lang.org/issues/12172)
+
+`[x, y].max` e `[x, y].min` estão optimizados para evitar a criação de um array temporário em certas condições.
+
+### [Regexp#match?](https://bugs.ruby-lang.org/issues/8110)
+
+Adicionado `Regexp#match?`, que executa um *regexp match* sem a criação
+de um objecto de referência e alterando `$~` para reduzir a alocação de objectos.
+
+### Outras melhorias de desempenho
+
+* [acelerar o acesso às variáveis de instância](https://bugs.ruby-lang.org/issues/12274)
+
+## Depuração
+
+### [Thread#report_on_exception and Thread.report_on_exception](https://bugs.ruby-lang.org/issues/6647)
+
+O Ruby ignora exceções nas *threads*, a não ser que outra *thread* se junte a elas.
+Utilizando `report_on_exception = true`,
+poderá verificar se uma *thread* terminou devido a uma exceção não tratada.
+
+Enviem-nos *feedback* sobre qual deverá ser o valor pré-definido para `report_on_exception`
+e sobre report-on-GC, que mostra um relatório quando uma *thread* é *garbage collected* sem se juntar.
+
+### [Deteção de *deadlocks* em *threads* mostra todas as *threads* com o seu *backtrace* e dependencias](https://bugs.ruby-lang.org/issues/8214)
+
+O Ruby tem deteção de *deadlocks* de *threads* em espera, mas relatório não
+inclui informação suficiente para depuração.
+A deteção de *deadlocks* no Ruby 2.4 mostra *threads* com o seu *backtrace* e *threads* dependentes.
+
+Experimente e desfrute a programação com o Ruby 2.4.0-preview3 e
+[envie-nos o seu *feedback*](https://github.com/ruby/ruby/wiki/How-To-Report)!
+
+## Outras alterações importantes desde a versão 2.3
+
+* Suporta OpenSSL 1.1.0
+* ext/tk foi removido de stdlib [Feature #8539](https://bugs.ruby-lang.org/issues/8539)
+* XMLRPC foi removido de stdlib [Feature #12160](https://bugs.ruby-lang.org/issues/12160)
+
+Consultar as [Notícias](https://github.com/ruby/ruby/blob/v2_4_0_preview3/NEWS)
+e o [ChangeLog](https://github.com/ruby/ruby/blob/v2_4_0_preview3/ChangeLog)
+para detalhes.
+
+Com todas as alterações,
+[2470 ficheiros alterados, 283051 inserções(+), 64902 eliminações(-)](https://github.com/ruby/ruby/compare/v2_3_0...v2_4_0_preview3)
+desde o Ruby 2.3.0!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2>
+
+      SIZE:   12615328 bytes
+      SHA1:   fefe49f6a7d5b642936c324f3b05aaac827355db
+      SHA256: 305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52
+      SHA512: 6602c65a7b1e3bc680acc48217108f4335e84fdd74a9cf06f2e2f9ad00a2fccacf9fa035a912bc9d5cc3f0c7a5e21475971dfac37b0364311ef3645f25c7ddf9
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.gz>
+
+      SIZE:   15758023 bytes
+      SHA1:   f6a6ec9f7fedad0bf4efee2e42801cc963f60dca
+      SHA256: c35fe752ccfabf69bf48e6aab5111c25a05938b428936f780638e2111934c9dd
+      SHA512: 68556d5252b6813b4c8eeba32733e940207f80694b5c5d20e69bf01eb52929ed2466496b05a895a5ad4831d430695e17624eb35b728b2d4d7cf02df756ac48b4
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.xz>
+
+      SIZE:   9957596 bytes
+      SHA1:   66592b1a52f985638d639e7c3dd6bdda4e0569d0
+      SHA256: b14be2b5c80bff0d6894ae2b37afdb17a968413e70236ec860f3e2d670b4c317
+      SHA512: 5be20f0b2609745790c2b22f2228e69a840f63c34a117a1f95fd5436af211f0a6db2758d513d3e095a2d97c53c80793579cb2a1e00e70cf72c487a88c4a40d33
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.zip>
+
+      SIZE:   17579012 bytes
+      SHA1:   15d08cff952da3844ae54887b7f74b12d47c9ee2
+      SHA256: b95a8f67fb7d6e852db77c5660c8878c14d68eb72c5501dac164a7e640ecb06e
+      SHA512: fa15e1b7ab0cab56c9a580e1b1e2fee250ee0b9c59546079675a1931a36e37131bd37d64033c75e05d8e9d9fcc33ce7850254d3acaca2136cf3bd08b070244f0
+
+## Comentários de Lançamento
+
+Consulte também o calendário de lançamentos e outras informações:
+
+[ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-master/wiki/ReleaseEngineering24)

--- a/pt_br/news/_posts/2016-11-15-ruby-2-2-6-released.md
+++ b/pt_br/news/_posts/2016-11-15-ruby-2-2-6-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Lançado o Ruby 2.2.6"
+author: "usa"
+translator: "Filipe Rocha"
+date: 2016-11-15 12:00:00 +0000
+lang: pt_br
+---
+
+Foi lançado o Ruby 2.2.6.
+
+Esta versão inclui os novos certificados SSL para o RubyGems, e ainda a correção de 80 *bugs* desde a última versão.
+Consulte o [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_2_6/ChangeLog)
+para mais detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2)
+
+      SIZE:   13378616 bytes
+      SHA1:   67b15fcc394bb1ffb5a7e926dcd6222d8e988188
+      SHA256: e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7
+      SHA512: 7a93f72d236521ac28c8a0bc0c73cf805797a8813d22e02f42c5fc05dd39f6e422817272e0db6a24c245f6f97ad4b2b412a9a47ac50156ab186df596918a5f34
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.gz)
+
+      SIZE:   16663387 bytes
+      SHA1:   a5aaf19694470e543c8216e3f1189e48b6dbb0da
+      SHA256: de8e192791cb157d610c48a9a9ff6e7f19d67ce86052feae62b82e3682cc675f
+      SHA512: 221ea2d18ff23e65539ee184e09ef78643e46266a0ca18ccd2cb251970a6c057b843363f7c97541b2a6e68e1c3c41a36e2ae5c8218da888e0429473504abf66d
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.xz)
+
+      SIZE:   10487776 bytes
+      SHA1:   6248eb97cbb5533009ef91c100d42e72af283f16
+      SHA256: 9414ecc0d09cf71c9a24e8dc82fcc87919ac7359fb08db2791d6c32bfd157339
+      SHA512: a2cfde1c6df4df6b996f8d86c52b255fd43b469f8b9f0d7a81ce5f4de949a67025d8bead4ce61f03263eb6a8378b156b843f97b429208afaa1d3bfd0a7af4ef4
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.zip)
+
+      SIZE:   18506149 bytes
+      SHA1:   6e207a91f13e301379d4fd37b7af847808185e41
+      SHA256: 71bafc98c0b6f7b70cd79473952060e9b9fc36c8d57ee21c6b775451a16e6f9a
+      SHA512: dfce7a0e1c3e3d64490dfad101897e8aaacb6f1c0b193a97a38a4288532ec65464796de898685497ba35f199ed6d8eeaf9bb84d31cab0ea4cfd762466597a840
+
+## Comentários de Lançamento
+
+Obrigado a todos os que nos ajudaram neste lançamento.
+
+A manutenção do Ruby 2.2, incluindo esta versão,
+é baseada no *"Agreement for the Ruby stable version"* da
+[Ruby Association](http://www.ruby.or.jp/).

--- a/pt_br/news/_posts/2016-11-15-ruby-2-3-2-released.md
+++ b/pt_br/news/_posts/2016-11-15-ruby-2-3-2-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Lançado o Ruby 2.3.2"
+author: "nagachika"
+translator: "Filipe Rocha"
+date: 2016-11-15 12:00:00 +0000
+lang: pt_br
+---
+
+Foi lançado o Ruby 2.3.2.
+
+Esta é uma versão *TEENY* da série 2.3 stable.
+
+Esta versão inclui uma atualização do RubyGems 2.5.2 e dos certificados ssl incluídos.
+
+Inclui, também, muitas correções de erros.
+Consulte o [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_2/ChangeLog)
+para detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2)
+
+      SIZE:   14428572 bytes
+      SHA1:   7adc23d308d335486a03f0099dad2b2f44b8a4a8
+      SHA256: e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0
+      SHA512: 78699bae5b0a2382a58f9d51f7d891341f00ad3a90d9ca06b68b1b245cf5acebc3a82133e39bf6a412ac999a5c0f778a0dab177c2569ffbee085ffff6f6ec38e
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.gz)
+
+      SIZE:   17814200 bytes
+      SHA1:   baef56b27941bfbfac6e2cd005b686d320c7f124
+      SHA256: 8d7f6ca0f16d77e3d242b24da38985b7539f58dc0da177ec633a83d0c8f5b197
+      SHA512: 833e76555c72fd142d89701715e6c6d838121347c4c7aa857478ba1e8f7596aa7c4fd1950046322747e46db041288747e4c1943cf9b13e064c6e85ee60d6515a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.xz)
+
+      SIZE:   11420276 bytes
+      SHA1:   b7c780dbfc34b5baea116504ae700f68c92379a0
+      SHA256: 5c78f311045ce48160092160444dec2744941a5e37d7865032978bd5bf392f0c
+      SHA512: f2e602281cbcfad81b8197b9555bf637a1ef34f51dbc7548e5e0c5996ab1b7db5bd9eeb902128d37eed90f39b559c569aa75f2b29fe5f65085be65a63206fd72
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.zip)
+
+      SIZE:   19861601 bytes
+      SHA1:   1ac64ad7cb1ed9004101812f5b707c151570dd84
+      SHA256: b8ad5b47fad22610476a4abc1c32b8e558265f9b20a5865a12836709028cbd76
+      SHA512: 8a794c8eed53380b026b150b0ce176af2a6ba278d5f7a5067e27615940ae85b6af28ac7187adc5d7af04c82442271ed0d8530d9fe751810ecc6c75340f81bd03
+
+## Comentários de Lançamento
+
+Muitos *committers*, programadores e utilizadores que forneceram relatórios de *bugs* ajudaram-nos nesta versão.
+Obrigado pelas contribuições.

--- a/pt_br/news/_posts/2016-11-21-ruby-2-3-3-released.md
+++ b/pt_br/news/_posts/2016-11-21-ruby-2-3-3-released.md
@@ -1,0 +1,54 @@
+---
+layout: news_post
+title: "Lançado o Ruby 2.3.3"
+author: "nagachika"
+translator: "Filipe Rocha"
+date: 2016-11-21 10:30:00 +0000
+lang: pt_br
+---
+
+Foi lançado o Ruby 2.3.3.
+
+Esta versão inclui uma correção em `Refinements` e `Module#prepend`.
+Uma utilização de `Module#refine` com `Module#prepend` na mesma classe poderá causar um `NoMethodError`.
+Esta versão é uma regressão ao Ruby 2.3.2 lançado na semana passada.
+Ver [[Bug #12920]](https://bugs.ruby-lang.org/issues/12920) para detalhes.
+
+Inclui, também, algumas correcções de erros.
+Consulte o [ChangeLog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_3/ChangeLog)
+para mais detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2)
+
+      SIZE:   14433673 bytes
+      SHA1:   a8db9ce7f9110320f33b8325200e3ecfbd2b534b
+      SHA256: 882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b
+      SHA512: 88f7782effd35bfe0b4c33140b5eb147d09b63fbb35b9c42d2200c010f387e2b70984ead1eca86569e8ec31f08b35289d440c0ca76b662dadb760f848e863d91
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz)
+
+      SIZE:   17813577 bytes
+      SHA1:   1014ee699071aa2ddd501907d18cbe15399c997d
+      SHA256: 241408c8c555b258846368830a06146e4849a1d58dcaf6b14a3b6a73058115b7
+      SHA512: 80d9f3aaf1d60b9b2f4a6fb8866713ce1e201a3778ef9e16f1bedb7ccda35aefdd7babffbed1560263bd95ddcfe948f0c9967b5077a89db8b2e18cacc7323975
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.xz)
+
+      SIZE:   11444164 bytes
+      SHA1:   f2318460606d410e80dd5c82862a93e5736534de
+      SHA256: 1a4fa8c2885734ba37b97ffdb4a19b8fba0e8982606db02d936e65bac07419dc
+      SHA512: 73dd6ed896ff52d953b153b2cab359c87953ea77521878f1ee16c1e217cc46bcb253100debe61ba631e6ffa0bc773e592d603a374508ed5189a311136ccd8d20
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.zip)
+
+      SIZE:   19862248 bytes
+      SHA1:   f0723ce176a829c9c33c31cdab6eca6ce0aef73e
+      SHA256: cbffda17fdb1bbd86dd36de093524b0a9b5c92e007fd60acac1c9804b429886e
+      SHA512: 5f75b77962c9d01fe591d87e20900d71a54c737e0d1198fae437729f21a9af84278a91ee73e850b5f49361b3cbf48af7a0a3ed9920cce932b58fd8e2420d5b26
+
+## Comentários de Lançamento
+
+Muitos *committers*, programadores e utilizadores que forneceram relatórios de *bugs* ajudaram-nos nesta versão.
+Obrigado pelas contribuições.

--- a/pt_br/news/_posts/2017-04-01-support-of-ruby-2-1-has-ended.md
+++ b/pt_br/news/_posts/2017-04-01-support-of-ruby-2-1-has-ended.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Support of Ruby 2.1 has ended"
+author: "usa"
+translator: "fpgentil"
+date: 2017-04-01 00:00:00 +0000
+lang: pt_br
+---
+
+Anunciamos que o suporte da série Ruby 2.1 foi encerrado.
+
+Após essa _release_ do Ruby 2.1.10 no final de março do último ano,
+o suporte da série do Ruby 2.1 estava em fase de manutenção de segurança.
+Agora, após um ano, esta fase se encerrou. Contudo, em 31 de março de
+2017, todo o suporte da série do Ruby 2.1 foi encerrado. _Bugs_ e correções de
+seguranças de versões mais recentes do Ruby não serão mais trazidas à versão 2.1
+e nenhum _patch release_ do Ruby 2.1 será lançado. Nós recomendamos que você
+atualize para o Ruby 2.4 ou 2.3 o mais rápido possível.
+
+## Sobre as versões do Ruby suportadas atualmente
+
+### Série Ruby 2.4
+
+Atualmente em fase normal de manutenção.
+Nós iremos trazer correções de _bugs_ sempre que necessário. E, se algum _issue_
+crítico de segurança for encontrado, nós iremos lançar uma correção urgente
+para ele.
+
+### Série Ruby 2.3
+
+Atualmente em fase normal de manutenção.
+Nós iremos trazer correções de _bugs_ sempre que necessário. E, se algum _issue_
+crítico de segurança for encontrado, nós iremos lançar uma correção urgente
+para ele.
+
+### Série Ruby 2.2
+
+Atualmente em fase de manutenção de segurança.
+Nós não iremos mais trazer nenhuma correção ao 2.2, a não ser correções de
+segurança. Se algum _issue_ crítico de segurança for encontrado, nós iremos
+lançar uma correção urgente para ele. Nós estamos planejando o fim do surporte
+da série Ruby 2.2 no final de março de 2018

--- a/pt_br/news/_posts/2017-07-21-ruby-prize-2017.md
+++ b/pt_br/news/_posts/2017-07-21-ruby-prize-2017.md
@@ -1,0 +1,28 @@
+---
+layout: news_post
+title: "Nomeações para Ruby Prize 2017 estão abertas"
+author: "Ruby Association"
+translator: "fpgentil"
+date: 2017-07-21 00:00:00 +0000
+lang: pt_br
+---
+
+Estamos felizes em anunciar que o _Ruby Prize_ acontecerá este ano!
+
+_Ruby Prize_ é dado em reconhecimento aos esforços de atividades notáveis e
+conquistas na comunidade Ruby. O prêmio será entregue pelo comitê executivo
+composto de três associações, a _Ruby Association_, _Nihon Ruby no Kai_ e _Matsue City_.
+
+O vencedor do _Ruby Prize_ e os nomeados finais (1-2 pessoas) receberão o prêmio no
+_RubyWorld Conference 2017_, que acontecerá em Matsue, Japão de 1 a 2 de novembro.
+
+Complementando, o vencedor do _Ruby Prize_ será premiado também com 1 milhão de ienes. Yay!
+
+Os nomeados serão selecionados por:
+
+* Indicações do "_Prize Member_" comitê executivo.
+* Indicações do público em geral (você).
+
+Por favor, veja abaixo para mais detalhes em inglês.
+
+[Nominations now being accepted for Ruby Prize 2017](http://www.ruby.or.jp/rubyprize2017/about_en.html)

--- a/pt_br/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
+++ b/pt_br/news/_posts/2017-08-29-multiple-vulnerabilities-in-rubygems.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Múltiplas vulnerabilidades no RubyGems"
+author: "usa"
+translator: "fpgentil"
+date: 2017-08-29 12:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existem múltiplas vulnerabilidades no RubyGems, biblioteca do Ruby.
+Foi reportado no [blog oficial do RubyGems](http://blog.rubygems.org/2017/08/27/2.6.13-released.html). _(em inglês)_
+
+## Detalhes
+
+As seguintes vulnerabilidades foram reportadas.
+
+* vulnerabilidade de redirecionamento de DNS. (CVE-2017-0902)
+* vulnerabilidade de código de escape ANSI. (CVE-2017-0899)
+* vulnerabilidade de ataque DoS. (CVE-2017-0900)
+* vulnerabilidade no instalador de _gems_ que permite uma _gem_ maliciosa sobrescrever arquivos
+arbitrários. (CVE-2017-0901)
+
+É altamente recomendado para os usuários do Ruby que sigam uma das soluções alternativas o mais
+rápido possível.
+
+## Versões Afetadas
+
+* Série do Ruby 2.2: 2.2.7 e anteriores
+* Série do Ruby 2.3: 2.3.4 e anteriores
+* Série do Ruby 2.4: 2.4.1 e anteriores
+* Anteriores ao _trunk revision_ 59672
+
+## Soluções alternativas
+
+Até o momento, não existem _releases_ do Ruby incluindo correções para o RubyGems.
+Mas você pode atualizar o RubyGems para a última versão.
+RubyGems 2.6.13 ou versões mais recentes incluem a correção das vulnerabilidades.
+
+```
+gem update --system
+```
+
+Se você não pode atualizar o RubyGems, você pode aplicar os seguintes _patches_ como soluções
+alternativas.
+
+* [para o Ruby 2.2.7](https://bugs.ruby-lang.org/attachments/download/6690/rubygems-2613-ruby22.patch)
+* [para o Ruby 2.3.4](https://bugs.ruby-lang.org/attachments/download/6691/rubygems-2613-ruby23.patch)
+* para o Ruby 2.4.1: são necessários 2 _patches_.  Aplique-os sequencialmente:
+  1. [RubyGems 2.6.11 até 2.6.12](https://bugs.ruby-lang.org/attachments/download/6692/rubygems-2612-ruby24.patch)
+  2. [RubyGems 2.6.12 até 2.6.13](https://bugs.ruby-lang.org/attachments/download/6693/rubygems-2613-ruby24.patch)
+
+Quanto ao _trunk_, atualize para a última versão.
+
+## Créditos
+
+Baseado no relato do [blog oficial do RubyGems](http://blog.rubygems.org/2017/08/27/2.6.13-released.html). _(em inglês)_
+
+## Histórico
+
+* Originalmente publicado em 2017-08-29 12:00:00 UTC
+* Adicionado números de vulnerabilidades e exposições comuns (CVE) em 2017-08-31 02:00:00 UTC

--- a/pt_br/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
+++ b/pt_br/news/_posts/2017-09-14-json-heap-exposure-cve-2017-14064.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "CVE-2017-14064: Vulnerabilidade de exposição de heap no JSON gerado"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existe uma vulnerabilidade de exposição de heap no JSON empacotado pelo Ruby.
+Esta vulnerabilidade recebeu o identificador CVE [CVE-2017-14064](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14064).
+
+## Detalhes
+
+O método `generate` do módulo `JSON` aceita opcionalmente uma instância da classe `JSON::Ext::Generator::State`.
+Se uma instância maliciosa for passada, o resultado poderá incluir conteúdos do heap.
+
+Todos os usuários rodando uma versão afetada devem fazer upgrade ou usar uma das soluções alternativas imediatamente.
+
+## Versões Afetadas
+
+* Série Ruby 2.2: 2.2.7 e anteriores
+* Série Ruby 2.3: 2.3.4 e anteriores
+* Série Ruby 2.4: 2.4.1 e anteriores
+* antes da revisão do tronco 58323
+
+## Soluções Alternativas
+
+A biblioteca JSON também é distribuida como uma gem.
+Se você não puder fazer upgrade do Ruby, instale uma versão da gem JSON mais nova do que 2.0.4.
+
+## Crédito
+
+Agradecimentos a [ahmadsherif](https://hackerone.com/ahmadsherif) por reportar este problema.
+
+## Histórico
+
+* Originalmente publicado em 14/09/2017 12:00:00 (UTC)

--- a/pt_br/news/_posts/2017-09-14-ruby-2-2-8-released.md
+++ b/pt_br/news/_posts/2017-09-14-ruby-2-2-8-released.md
@@ -1,0 +1,57 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.2.8"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+lang: pt_br
+---
+
+Foi lançado Ruby 2.2.8.
+Esta versão inclui diversas correções de segurança.
+Por favor, confira os tópicos abaixo para detalhes.
+
+* [CVE-2017-0898: Vulnerabilidade de buffer underrun em Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Vulnerabilidade de injeção de sequência de escape na autenticação Basic no WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Vulnerabilidade de buffer underrun em decodificador OpenSSL ASN1](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Vulnerabilidade de buffer underrun em geração de JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [Múltiplas vulnerabilidades em RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Atualizada libyaml empacotada para versão 0.1.7
+
+Ruby 2.2 agora está em estado de fase de manutenção de segurança, até o final de março de 2018.
+Após esta data, manutenção do Ruby 2.2 se encerrará.
+Recomendamos que você comece planejando a migração para versões mais novas de Ruby, como 2.4 ou 2.3.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2)
+
+      SIZE:   13374522 bytes
+      SHA1:   d851324bf783221108ce79343fabbcd559b9e60b
+      SHA256: b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e
+      SHA512: aa1c65f76a51a57d9059a38a13a823112b53850a9e7d6f72c3f3e38d381412014521049f7065c1b00877501b3b554235135d0f308045c2a9da133c766f5b9e46
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz)
+
+      SIZE:   16681654 bytes
+      SHA1:   15a6fca1bfe0488b24a204708a287904028aa367
+      SHA256: 8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a
+      SHA512: b9d355232c1ca3e17b5d4dcb70f0720da75b82787e45eb4ede281290bf42643665385e55428495eb55c17f744395130b4d64ef78ca66c5a5ecb9f4c3b732fdea
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.xz)
+
+      SIZE:   10520648 bytes
+      SHA1:   3a25914aafedc81952899298a18f9c3a4881d2d1
+      SHA256: 37eafc15037396c26870f6a6c5bcd0658d14b46cd5e191a3b56d89dd22d561b0
+      SHA512: e21004bee537f0c706f4ac9526507b414ddb6a8d721e8fad8d7fe88992a4f048eb5eb79f8d8b8af2a8b331dcfa74b560490218a1acb3532c2cdb4fb4909da3c9
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.zip)
+
+      SIZE:   18521461 bytes
+      SHA1:   3b0142bad47e29f429903f6c4ca84540764b5e93
+      SHA256: 58bf98b62d21d6cc622e6ef5c7d024db0458c6860199ab4c1bf68cdc4b36fa9d
+      SHA512: 08cadfa72713f9e3348093c96af4c53f06f681bc29ada2d80f1c55faca6a59a3b2913aa2443bf645fea6f3840b32ce8ce894b358f972b1a295ee0860b656eb02
+
+## Comentário de Versão
+
+Obrigado a todos que ajudaram com esta versão, especialmente, com informe de vulnerabilidades.

--- a/pt_br/news/_posts/2017-09-14-ruby-2-3-5-released.md
+++ b/pt_br/news/_posts/2017-09-14-ruby-2-3-5-released.md
@@ -1,0 +1,68 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.3.5"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.3.5 foi lançado.
+
+Esta versão inclui em torno de 70 correções de bugs após a versão anterior e também inclui diversas correções de segurança.
+Por favor, confira os tópicos abaixo para detalhes.
+
+* [CVE-2017-0898: Vulnerabilidade de buffer underrun em Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Vulnerabilidade de injeção de sequência de escape na autenticação Basic no WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Vulnerabilidade de buffer underrun em decodificador OpenSSL ASN1](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Vulnerabilidade de buffer underrun em geração de JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [últiplas vulnerabilidades em RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Atualizada libyaml empacotada para versão 0.1.7
+
+Veja o [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_3_5/ChangeLog) para detalhes.
+
+## Problemas Conhecidos
+
+_(Esta seção foi adicionada em 15 de setembro de 2017.)_
+
+Um incompatibilidade foi encontrado para Ruby 2.3.5.
+Ruby 2.3.5 não vincula com libgmp e jemalloc.
+Arrumaremos este problema com a próxima versão, mas se você estiver enfrentando problemas agora e precisa corrigir imediatamente, obtenha um _patch_ deste link:
+
+* [Ruby 2.4.2 e 2.3.5 não vincula com libgmp e jemalloc](https://bugs.ruby-lang.org/issues/13899)
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2)
+
+      SIZE:   14439326 bytes
+      SHA1:   48302800c78ef9bbfc293ffcc4b6e2c728705bca
+      SHA256: f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b
+      SHA512: 3ecc7c0ac10672166e1a58cfcd5ae45dfc637c22cec549a30975575cbe59ec39945d806e47661f45071962ef9404566007a982aedccb7d4241b4459cb88507df
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz)
+
+      SIZE:   17836997 bytes
+      SHA1:   3247e217d6745c27ef23bdc77b6abdb4b57a118f
+      SHA256: 5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc
+      SHA512: cd6bbba4fb5a0ab5ce7aa6f3b89d021ea742c5aa7934e24b87554d10e2a3233d416051c11aee90f3d8714d168db523a7bf56ef4dafdd256fc8595169c2db496a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.xz)
+
+      SIZE:   11437868 bytes
+      SHA1:   ef388992fa71cd77c5be960dd7e3bec1280c4441
+      SHA256: 7d3a7dabb190c2da06c963063342ca9a214bcd26f2158e904f0ec059b065ffda
+      SHA512: c55e3b71241f505b6bbad78b3bd40235064faae3443ca14b77b6356556caed6a0d055dc2e2cd7ebdb5290ab908e06d2b7d68f72469af5017eda4b29664b0d889
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.zip)
+
+      SIZE:   19887946 bytes
+      SHA1:   09c80f9021fa2bfc04ae30a1939faad03b0f5b14
+      SHA256: c9971e1ccb6e2f1ab32b1fe05416fce0b19a1cd9ba8fa095c77c4bdf2058e514
+      SHA512: 6f14d0cc48d6eaf6168316cb45e22af8d2118ba058fd888ce930f12a22cf7e849e2e185cc7c516fe980f30ee9a942accf9d9e2d4b8a2e79c97b87d4bab704495
+
+## Comentário de Versão
+
+Obrigado a todos que ajudaram com esta versão.
+
+A manuntenção de Ruby 2.3, incluindo esta versão, é baseado no “Agreement for the Ruby stable version” da _Ruby Association_.

--- a/pt_br/news/_posts/2017-09-14-ruby-2-4-2-released.md
+++ b/pt_br/news/_posts/2017-09-14-ruby-2-4-2-released.md
@@ -1,0 +1,66 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.2"
+author: "nagachika"
+translator: "jcserracampos"
+date: 2017-09-14 00:00:00 +0000
+lang: pt_br
+---
+
+Estamos contentes em anunciar a versão 2.4.2 de Ruby.
+Esta versão contém algumas correções de segurança.
+
+* [CVE-2017-0898: Vulnerabilidade de buffer underrun em Kernel.sprintf](/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/)
+* [CVE-2017-10784: Vulnerabilidade de injeção de sequência de escape na autenticação Basic no WEBrick](/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/)
+* [CVE-2017-14033: Vulnerabilidade de buffer underrun em decodificador OpenSSL ASN1](/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/)
+* [CVE-2017-14064: Vulnerabilidade de buffer underrun em geração de JSON](/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/)
+* [últiplas vulnerabilidades em RubyGems](/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/)
+* Atualizada libyaml empacotada para versão 0.1.7
+
+Também há muitas correções de _bug_.
+Veja [histórico de _commits_](https://github.com/ruby/ruby/compare/v2_4_1...v2_4_2) para mais detalhes.
+
+## Problemas Conhecidos
+
+_(Esta seção foi adicionada em 15 de setembro de 2017.)_
+
+Um incompatibilidade foi encontrado para Ruby 2.4.2.
+Ruby 2.4.2 não vincula com libgmp e jemalloc.
+Arrumaremos este problema com a próxima versão, mas se você estiver enfrentando problemas agora e precisa corrigir imediatamente, obtenha um _patch_ deste link:
+
+* [Ruby 2.4.2 e 2.3.5 não vincula com libgmp e jemalloc](https://bugs.ruby-lang.org/issues/13899)
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2>
+
+      SIZE:   12607283 bytes
+      SHA1:   a8a50a9297ff656e5230bf0f945acd69cc02a097
+      SHA256: 08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc
+      SHA512: 1a5302d2558089a6b91b815fff9b75a29e690f10861de5fdd48211f3f45025a70dad7495f216e6af9c62d72e69ed316f1a52fada704bdc7e6d8c094d141ea77c
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz>
+
+      SIZE:   14187859 bytes
+      SHA1:   b096124469e31e4fc3d00d2b61b11d36992e6bbd
+      SHA256: 93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c
+      SHA512: 96c236bdcd09b2e7cf429da631a487fc00f1255443751c03c8abeb4c2ce57079ad60ef566fecc0bf2c7beb2f080e2b8c4d30f321664547b2dc7d2a62aa1075ef
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.xz>
+
+      SIZE:   10046412 bytes
+      SHA1:   8373e32c63bba2180799da091b572664aa9faf6f
+      SHA256: 748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
+      SHA512: c1d42272fb0d94b693452e703b0ea4942bf59cbd4b08ba83bf039f54be97ebc88511632413da0164970b4cf97bc302bccb88aab48edfa8fa147498e7ee741595
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.zip>
+
+      SIZE:   15645325 bytes
+      SHA1:   861b51de9db0d822ef141ad04383c76aa3cd2fff
+      SHA256: 37d7cb27d8abd4b143556260506306659930548652343076f7f8470f07818824
+      SHA512: 234765091528be1310ac315868f84ae6c505aa696672929df2f00828c1bbdc7cbcb2fc690eab4e73efde6be9104584ba7b6944853861f6d05e775b124ce8dfd5
+
+## Comentário de Versão
+
+Muitos contribuidores, desenvolvedores e usuários que forneceram relatórios de _bug_ que nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
+++ b/pt_br/news/_posts/2017-09-14-sprintf-buffer-underrun-cve-2017-0898.md
@@ -1,0 +1,34 @@
+---
+layout: news_post
+title: "CVE-2017-0898: Vulnerabilidade de buffer underrun em Kernel.sprintf"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+tags: segurança
+lang: pt_br
+---
+
+Existe uma vulnerabilidade de _buffer underrun_ no método `sprintf` do módulo `Kernel`.
+Essa vulnerabilidade foi assinada com o identificador CVE [CVE-2017-0898](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0898).
+
+## Detalhes
+
+Se uma _string_ formatada maliciosamente contendo um especificador (`*`) for passada e um valor negativo enorme também for passado para o especificador, poderá causar _buffer underrun_.
+Nessa situação, o resultado poderá conter _heap_ de memória ou o interpretador Ruby poderá parar.
+
+Todos os usuários rodando uma versão com essa vulnerabilidade devem atualizá-la imediatamente.
+
+## Versões Afetadas
+
+* Série Ruby 2.2: 2.2.7 e anteriores
+* Série Ruby 2.3: 2.3.4 e anteriores
+* Série Ruby 2.4: 2.4.1 e anteriores
+* anterior à revisão de árvore 58453
+
+## Créditos
+
+Obrigado [aerodudrizzt](https://hackerone.com/aerodudrizzt) por reportar este problema.
+
+## Histórico
+
+* Originalmente publicado em 14 de setembro de 2017 12:00:00 (UTC)

--- a/pt_br/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
+++ b/pt_br/news/_posts/2017-09-14-webrick-basic-auth-escape-sequence-injection-cve-2017-10784.md
@@ -1,0 +1,36 @@
+---
+layout: news_post
+title: "CVE-2017-10784: Vulnerabilidade de injeção de sequência de escape na autenticação Basic de WEBrick"
+author: "usa"
+translator: "jcserracampos"
+date: 2017-09-14 12:00:00 +0000
+tags: segurança
+lang: pt_br
+---
+
+Existe uma vulnerabilidade de injeção de sequência de escape na autenticação _Basic_ do WEBrick empacotado com Ruby.
+Essa vulnerabilidade foi assinada com o identificador CVE [CVE-2017-10784](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10784).
+
+## Detalhes
+
+Quando usando autenticação _Basic_ do WEBrick, clientes podem passar _strings_ arbitrárias como nome de usuário.
+WEBrick produz saídas com o nome de usuário intacto no _log_, então o atacante pode injetar sequências de escape maliciosas para o _log_ e _control characters_ perigosos podem ser executados no emulador de terminal da vítima.
+
+Essa vulnerabilidade é similar a [uma vulnerabilidade já corrigida](/en/news/2010/01/10/webrick-escape-sequence-injection/) (Em inglês), mas isso não foi corrigido na autenticação _Basic_.
+
+Todos os usuários rodando uma versão com essa vulnerabilidade devem atualizá-la imediatamente.
+
+## Versões Afetadas
+
+* Série Ruby 2.2: 2.2.7 e anteriores
+* Série Ruby 2.3: 2.3.4 e anteriores
+* Série Ruby 2.4: 2.4.1 e anteriores
+* anterior à revisão de árvore 58453
+
+## Créditos
+
+Obrigado Yusuke Endoh <mame@ruby-lang.org> por reportar este problema.
+
+## History
+
+* Originalmente publicado em 14 de setembro de 2017 12:00:00 (UTC)

--- a/pt_br/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
+++ b/pt_br/news/_posts/2017-10-10-ruby-2-5-0-preview1-released.md
@@ -1,0 +1,78 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.0-preview1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2017-10-10 00:00:00 +0000
+lang: pt_br
+---
+
+Estamos contentes em anunciar a versão 2.5.0-preview1 de Ruby.
+
+Ruby 2.5.0-preview1 é o primeiro _preview_ em direção a Ruby 2.5.0.
+Ele introduz algumas novas funcionalidades e melhorias de desempenho, por exemplo:
+
+## Novas funcionalidades
+
+* Imprime _backtrace_ e mensagens de erros em ordem reversa se STDERR está inalterado e em um tty. [Funcionalidade #8661] [experimental]
+
+* A pesquisa por constantes de nível superior foi removida. [Funcionalidade #11547]
+
+* `rescue/else/ensure` são permitidos dentro de blocos `do/end`.  [Funcionalidade #12906]
+
+* `yield\_self` [Funcionalidade #6721]
+
+## Outras alterações notáveis desde 2.4
+
+* `Merge` Onigmo para 6.1.1.
+  Ele adiciona [operador ausente](https://github.com/k-takata/Onigmo/issues/87).
+  Note que Ruby 2.4.1 também inclui esta alteração.
+* `Merge` bundler para bibliotecas padrões.
+* `Merge` rubygems-2.6.13.
+* `Merge` rdoc-6.0.0.beta2.
+  Altera IRB baseado em lexer para Ripper.
+  Ele melhora muito a velocidade de geração de documentação.
+  https://github.com/ruby/rdoc/pull/512
+  Isso também inclui:
+  * Corrige muitos _bugs_ nos últimos 12 anos ou mais.
+  * Suporta nova sintaxe de Ruby nos últimos anos.
+* Atualiza a versão suportada de Unicode para 10.0.0.
+
+Veja [NEWS](https://github.com/ruby/ruby/blob/v2_5_0_preview1/NEWS)
+ou histórico de _commits_ para mais detalhes.
+
+Com essas alterações,
+[6162 arquivos alterados, 339744 inserções(+), 28699 deleções(-)](https://github.com/ruby/ruby/compare/v2_4_0...v2_5_0_preview1)
+desde Ruby 2.4.0!
+
+Aproveite Ruby 2.5.0-preview1!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.gz>
+
+      SIZE:   16088348 bytes
+      SHA1:   8d1bad4faea258ac7f97ae2b4c7d76335b044c37
+      SHA256: 30994fe5efbf4759a2a616f288121857c69b45665926174680387e286bb83b05
+      SHA512: bcca05333e0aa09c75492ec09e4a82bf7aebef1b96e1c40000b92fa654fd96ae1d70e4f92ecf619b199cba73d754be6c6d97fc488d1e47831bc671f64ce0ab6d
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.zip>
+
+      SIZE:   20036401 bytes
+      SHA1:   e1ad073a17dc814fc8ddb3cbbed761a2278dcc12
+      SHA256: 1a61196a845cb9d9b5a71fd66cb77fbc215f82cb6f90371e309ceddb25e7107b
+      SHA512: 35033b5426142e271d95d438b8442e73cade9462b02014371866882a4a90911b98805b7199b15bedc9847fd2560e211f015fa09b0b1d9efc31a947e41e088b30
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2>
+
+      SIZE:   14110768 bytes
+      SHA1:   0b664c41b75d54ff88c70b5437b20b90675e3348
+      SHA256: 1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446
+      SHA512: 2d39ef64aaf7a52014905f4ad59b53e83b71433e50a9227f9f50cbb7a2c9a5db9cd69fa7dbe01234819f7edd2216b3d915f21676f07d12bb5f0f3276358bce7f
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.xz>
+
+      SIZE:   11383812 bytes
+      SHA1:   eef2901270c235a97d132ebcfb275f130ba368fd
+      SHA256: c2f518eb04b38bdd562ba5611abd2521248a1608fc466368563dd794ddeddd09
+      SHA512: 1153a1fc4eb1a9556af2d392743998eb9cffd2a07e4648bf124dea1044bb378c7f4534dd87c0d30563ec438d2995ba1832faaaf4261db5d0840ca32ae7ea65d9

--- a/pt_br/news/_posts/2017-12-14-net-ftp-command-injection-cve-2017-17405.md
+++ b/pt_br/news/_posts/2017-12-14-net-ftp-command-injection-cve-2017-17405.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "CVE-2017-17405: Vulnerabilidade de injeção de comandos em Net::FTP"
+author: "nagachika"
+translator: "fpgentil"
+date: 2017-12-14 16:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existe uma vulnerabilidade de injeção de comandos em Net::FTP junto do Ruby.
+Essa vulnerabilidade foi atribuída ao identificador
+[CVE-2017-17405](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17405).
+
+## Detalhes
+
+`Net::FTP#get`, `getbinaryfile`, `gettextfile`, `put`, `putbinaryfile`, e
+`puttextfile` usam `Kernel#open` para abrir um arquivo local. Se o argumento de `localfile`
+inicia com o caractere barra vertical (_pipe_) `"|"`, o comando seguido do _pipe_ é executado.
+O valor padrão de `localfile` é `File.basename(remotefile)`, então servidores FTP maliciosos
+podem executar comandos aleatórios.
+
+Todos usuários executando uma versão afetada devem atualizá-la imediatamente.
+
+## Versões Afetadas
+
+* Série do Ruby 2.2: 2.2.8 e anteriores
+* Série do Ruby 2.3: 2.3.5 e anteriores
+* Série do Ruby 2.4: 2.4.2 e anteriores
+* Série do Ruby 2.5: 2.5.0-preview1
+* anteriores ao _trunk_ r61242
+
+## Créditos
+
+Obrigado a Etienne Stalmans do time de segurança do Heroku por reportar o _issue_.
+
+## Histórico
+
+* Publicado originalmente em 2017-12-14 16:00:00 (UTC)

--- a/pt_br/news/_posts/2017-12-14-ruby-2-2-9-released.md
+++ b/pt_br/news/_posts/2017-12-14-ruby-2-2-9-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.2.9"
+author: "usa"
+translator: "fpgentil"
+date: 2017-12-14 16:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.2.9 foi lançado.
+Esse lançamento inclui várias correções de segurança.
+Por favor, verifiquem os tópicos abaixo para mais detalhes.
+
+* [CVE-2017-17405: Vulnerabilidade de injeção de comandos em Net::FTP](/pt_br/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/)
+* [Unsafe Object Deserialization Vulnerability in RubyGems (English)](http://blog.rubygems.org/2017/10/09/unsafe-object-deserialization-vulnerability.html)
+
+Ruby 2.2 está agora em fase de manutenção de segurança até o final de Março de 2018.
+Após essa data, a manutenção do Ruby 2.2 será encerrada.
+Recomendamos fortemente que você planeje em migrar para uma nova versão do Ruby, como 2.4 ou 2.3.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2)
+
+      SIZE:   13371232 bytes
+      SHA1:   773ba9b51bde612866f656c4531f59660e2b0087
+      SHA256: 5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a
+      SHA512: 2a8c8770fda20a22b79c9115b6f468f8e7ea1092c84a5089af7a3122163e5ad298b493e6637e4d93ba02d899d8a619c94064dda8ac98cf3b93f64f45d5401085
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.gz)
+
+      SIZE:   16681209 bytes
+      SHA1:   cbeb1b892ffcaca8728c1cb8d513e1b485bc5eba
+      SHA256: 2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6
+      SHA512: 34e440d529b3bb6b2a7c0e68e64c66c903b96b736ca527398d4493e7451353c08f7cc68b83c55011b53d76411c118fcb3c9e70c1a08439a591eeee98c430c297
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.xz)
+
+      SIZE:   10511456 bytes
+      SHA1:   1144e19b4cdc77ee036847d261013c88fc59b5f8
+      SHA256: 313b44b1105589d00bb30b9cccf7da44d263fe20a2d8d269ada536d4a7ef285c
+      SHA512: c4ef84cd00f72f60d6c168f0726d9d7e9573549c2bbae83893e1a9d5e64fc7938f4c9d50a47147b28b37cbf36263f95e10a810c0797bad941775a48d75a8c933
+
+* [https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.zip](https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.zip)
+
+      SIZE:   18523114 bytes
+      SHA1:   ebc8ba0ae1178bf4a84b38dd0fdd97de82406cf4
+      SHA256: c3055ef4f985079d392dddebb1eab1e91851bfc19c0e8a11779872647d89b3b1
+      SHA512: 41de195641bc8cca43a726c1d707720dc9d3b8a853002548a31d171508b78dc353328c9a526dfbbc76493307c0e9e5fce669cc9fc3efc9626f84f2af5aca1a55
+
+## Comentários da versão
+
+Obrigado a todos que contribuiram com esse lançamento.

--- a/pt_br/news/_posts/2017-12-14-ruby-2-3-6-released.md
+++ b/pt_br/news/_posts/2017-12-14-ruby-2-3-6-released.md
@@ -1,0 +1,54 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.3.6"
+author: "usa"
+translator: "fpgentil"
+date: 2017-12-14 16:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.3.6 foi lançado.
+
+Esse lançamento inclui cerca de 10 correções de _bugs_ desde o último lançamento, e também inclui algumas correções de segurança.
+Por favor, verifiquem os tópicos abaixo para mais detalhes.
+
+* [CVE-2017-17405: Vulnerabilidade de injeção de comandos em Net::FTP](/pt_br/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/)
+* [Unsafe Object Deserialization Vulnerability in RubyGems (English)](http://blog.rubygems.org/2017/10/09/unsafe-object-deserialization-vulnerability.html)
+
+Veja o [ChangeLog](https://svn.ruby-lang.org/repos/ruby/tags/v2_3_6/ChangeLog) para detalhes.
+
+## Download
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2)
+
+      SIZE:   14429114 bytes
+      SHA1:   07c3b66d544dd22c22fbae3f16cfb3eeb88b7b1e
+      SHA256: 07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0
+      SHA512: bc3c7a115745a38e44bd91eb5637b1e412011c471d9749db7960185ef75737b944dd0e524f22432809649952ca7d93f46d458990e9cd2b0db5ca8abf4bc8ea99
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.gz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.gz)
+
+      SIZE:   17840901 bytes
+      SHA1:   4e6a0f828819e15d274ae58485585fc8b7caace0
+      SHA256: 8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e
+      SHA512: 104553d888f7d49d1b8df0cff0a3e8aee3086183d75e1a88289730e34c2da669874d7abe83e84bf1b3be9a3337a34f19ea9f9dcfbf1f7fc1136bb8f922776ea4
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.xz](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.xz)
+
+      SIZE:   11445628 bytes
+      SHA1:   55e97913180a313f161d2e4e541dd904a477c31d
+      SHA256: e0d969ac22d4a403c1204868bb9c0d068aa35045bb3934cf50b17b7f66059f56
+      SHA512: a09c8715097d16190ee17ee39e7a74438cefc9013add350217b7e3fb4d60aa9dcb30595adf832b0d67a5c45b1fe9d4effb767c995af2759420859f8d763c693a
+
+* [https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.zip](https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.zip)
+
+      SIZE:   19892406 bytes
+      SHA1:   0d631f32e7b360dcbfb9f8f46dfff2445f0a6a51
+      SHA256: 6fee49a2099d49a1b98bf0637fe974fd87af3ae64978392c802ba4d10ac70fb5
+      SHA512: c6dc2ee01a4ef84850b0ca4d1e60841f07fbff263ebbbc44c8bd0f72ced3172c2e0b9c883496bfc4f5a42f4827a061f8f479d05bda5f693a274c451914e0b03e
+
+## Comentários da versão
+
+Obrigado a todos que contribuiram com esse lançamento.
+
+A manutenção do Ruby 2.3, incluindo esse lançamento, é baseada no “Agreement for the Ruby stable version” da _Ruby Association_.

--- a/pt_br/news/_posts/2017-12-14-ruby-2-4-3-released.md
+++ b/pt_br/news/_posts/2017-12-14-ruby-2-4-3-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.3"
+author: "nagachika"
+translator: "fpgentil"
+date: 2017-12-14 00:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.4.3 foi lançado.
+
+Este lançamento inclui algumas correções de _bugs_ e de segurança.
+
+* [CVE-2017-17405: Vulnerabilidade de injeção de comandos em Net::FTP](/pt_br/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/)
+
+Existem também algumas correções de _bugs_.
+Veja [commit logs](https://github.com/ruby/ruby/compare/v2_4_2...v2_4_3) para maiores detalhes.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2>
+
+      SIZE:   12615068 bytes
+      SHA1:   3ca96536320b915762d57fe1ee540df6810bf631
+      SHA256: 0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30
+      SHA512: fb4339e30c04d03b1422b6c32ede45902e072cd26325b36f3fc05c341d42eea6431d88718242dcc9ce24d9cad26f3d26772f2e806bd7d93f40be50268c318409
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz>
+
+      SIZE:   14178729 bytes
+      SHA1:   787b7f4e90fb4b39a61bc1a31eb7765f875a590c
+      SHA256: fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98
+      SHA512: e6859cee49f74bbfbcfc9dd583aa0f1af007354f9b56ec09959d24764e69ed6ea3d1d59a229ad25b451161a1ea2ac60e0621dbbcc484ad219eed9e55f3825e05
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.xz>
+
+      SIZE:   10040072 bytes
+      SHA1:   f0a49dddb4e7903a11a80554fd7a317a854cd365
+      SHA256: 23677d40bf3b7621ba64593c978df40b1e026d8653c74a0599f0ead78ed92b51
+      SHA512: 8bcf60c994a96787da5d743c66f5609a5a6d834d6d61243cdea7fd059197c3b10da43c99e5649be85e2f2329eedcbb1dd76e89ce3ac586be9056348f7449ed09
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.zip>
+
+      SIZE:   15649173 bytes
+      SHA1:   19744d7673914804b46f75b374faee87b2ea18d9
+      SHA256: a4cd07af2cef121582b8bf7ec57fb9a916d99556c713538bc4469be68bfc1961
+      SHA512: 5e51b4337ee12041925dd6b91df6d0c7fc5bf19846c1c8d5aa43823f5410d1291cd428bdb5245f08a399051d06c2cb59fde73a7d3da379cbbd24f9c2b60fcc8c
+
+## Comentários da versão
+
+Muitos contribuintes, desenvolvedores e usuários que reportaram _bugs_ nos ajudaram
+com o lançamento dessa versao.
+Agradecemos suas contribuições.

--- a/pt_br/news/_posts/2017-12-14-ruby-2-5-0-rc1-released.md
+++ b/pt_br/news/_posts/2017-12-14-ruby-2-5-0-rc1-released.md
@@ -1,0 +1,90 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.0-rc1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2017-12-14 00:00:00 +0000
+lang: pt_br
+---
+
+Temos o prazer de anunciar o lançamento do Ruby 2.5.0-rc1.
+
+Ruby 2.5.0-rc1 é o primeiro candidato de lançamento do Ruby 2.5.0.
+Esta versão introduz algumas novas funcionalidades e melhorias de performance, por exemplo:
+
+## Novas Funcionalidades
+
+* Imprime _backtrace_ e mensagens de erros em ordem reversa se STDERR está inalterado e um tty.
+  [Feature #8661] [experimental]
+
+* Pesquisa de constante de alto nível foi removida.  [Feature #11547]
+
+* rescue/else/ensure passam a ser permitidos em blocos do/end.  [Feature #12906]
+
+* Adiciona yield\_self.  [Feature #6721]
+
+## Melhorias de performance
+
+* Instrumentação dinâmica para hooks TracePoint ao invés de usar instrução
+  "trace" para evitar sobrecarga. [Feature #14104]
+
+* Performance de passagem de bloco usando parâmetros de blocos
+  está aprimorado usando lazy Proc allocation. [Feature #14045]
+
+* Mutex está reescrito para ser menor e mais rápido. [Feature #13517]
+
+* SecureRandom agora prefere fontes fornecidas pelo S. O. ao invés de OpenSSL. [Bug #9569]
+
+## Outras mudanças notáveis desde 2.4
+
+* Alteração para Onigmo 6.1.3.
+  Adiciona [absence operator](https://github.com/k-takata/Onigmo/issues/87).
+  Note que Ruby 2.4.1 também inclue esta alteração.
+* Adiciona Bundler nas bibliotecas padrões.
+* Alteração para RubyGems 2.7.0.
+* Alteração para RDoc 6.0.0.
+  * Altera lexer de baseado em IRB based para um em Ripper;
+    isto melhora a velocidade de geração de documentação.
+    [https://github.com/ruby/rdoc/pull/512]
+  * Corrige tantos _bugs_ dos últimos doze anos ou mais.
+  * Suporta novas sintaxes de Ruby dos últimos anos.
+* Atualiza a versão de Unicode suportada para 10.0.0.
+
+Veja as [novidades](https://github.com/ruby/ruby/blob/v2_5_0_rc1/NEWS)
+ou histórico de commits para detalhes.
+
+Com essas mudanças,
+[6162 arquivos modificados, 339744 inserções(+), 28699 remoções(-)](https://github.com/ruby/ruby/compare/v2_4_0...v2_5_0_rc1)
+desde Ruby 2.4.0!
+
+Aprecie Ruby 2.5.0-rc1!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.gz>
+
+      SIZE:   31049529 bytes
+      SHA1:   15df7e8ff99f360a14f7747a07a3021447d65594
+      SHA256: 46c11b347522de174566503d35d2b46e1529b979d292b1f7f7019cfedcd4b07f
+      SHA512: 41cd298e99d7a25fe5f2ec42946ae5dbc4421bb18f39350ba8a1b02e999541ec1b21b5f6ce0489b3a159f47e37d409178ba7c21c00e177b0fdb410ca6e9d6142
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.zip>
+
+      SIZE:   35579788 bytes
+      SHA1:   b7ae42eb733d4a0e3a2d135c9f8d4af043daa728
+      SHA256: 9858e39fd2e7bf207cc9f8846197b11ada5f4424f433ff4df149fe3d48be8e36
+      SHA512: 86c93791d312fd2175909020e448a44892740feb809a532ed706c6d850cb92722fb7ca02ecbdf7a1fbeb5b4f42f1338ce9a15b7c0a41055937bd1fdfb4be6f11
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2>
+
+      SIZE:   29238901 bytes
+      SHA1:   6aad74ed3d30de63c6ff22048cd0fcbcbe123586
+      SHA256: 862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09
+      SHA512: bf0eb114097f9e505ff846f25e7556a2fb393573b4e8b773f94cf5b47998e221f3962a291db15a3cdbdf4ced5a523812937f80d95f4ee3f7b13c4e37f178d7a7
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.xz>
+
+      SIZE:   26096412 bytes
+      SHA1:   05cacd0341b7a23cc68239c2061640643a30da38
+      SHA256: a479a1bce69b2cf656821f10104dcb8b426922b56d3d6cbdf48318842fae752c
+      SHA512: 9f9040abf69337439a3f31b80d440d97736555b0df6533d9d34c141ce52226bc40c3f4f7e596e74b080c879e933649c17a073c893be1a304d9a883bab02e9494

--- a/pt_br/news/_posts/2017-12-25-ruby-2-5-0-released.md
+++ b/pt_br/news/_posts/2017-12-25-ruby-2-5-0-released.md
@@ -1,0 +1,130 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.0"
+author: "naruse"
+translator: "jcserracampos"
+date: 2017-12-25 00:00:00 +0000
+lang: pt_br
+---
+
+Temos o prazer de anunciar o lançamento de Ruby 2.5.0.
+
+Ruby 2.5.0 é a primeira versão estável da série Ruby 2.5.
+Esta versão introduz muitas novas funcionalidades e melhorias de performance.
+As mudanças notáveis são as seguintes:
+
+## Novas funcionalidades
+
+* `rescue`/`else`/`ensure` passam a ser permitidos diretamente em
+  blocos `do`/`end`.
+  [[Funcionalidade #12906]](https://bugs.ruby-lang.org/issues/12906)
+* Adiciona `yield_self` em um bloco yield no seu contexto.
+  Ao contrário de `tap`, retorna o resultado do bloco.
+  [[Funcionalidade #6721]](https://bugs.ruby-lang.org/issues/6721)
+* Adiciona suporte a mensuração de cobertura de ramificação e cobertura de método.
+  A cobertura de ramificação indica quais ramificações (_branches_) são executadas e quais não.
+  A cobertura de método indica quais métodos são invocados e quais não.
+  Ao executar uma suíte de testes com essas novas funcionalidades, você saberá quais
+  ramificações e métodos são executados e mensurará a cobertura total da suíte de
+  testes mais estritamente.
+  [[Funcionalidade #13901]](https://bugs.ruby-lang.org/issues/13901)
+* Hash#slice [[Funcionalidade #8499]](https://bugs.ruby-lang.org/issues/8499)
+  e Hash#transform_keys [[Funcionalidade #13583]](https://bugs.ruby-lang.org/issues/13583)
+* Struct.new pode criar classes que aceitam _keywords_ como argumento.
+  [[Funcionalidade #11925]](https://bugs.ruby-lang.org/issues/11925)
+* Enumerable#any?, all?, none? e one? passam a aceitar um _pattern_ como argumento.
+  [[Funcionalidade #11286]](https://bugs.ruby-lang.org/issues/11286)
+* Pesquisa de constante de alto nível foi removida.
+  [[Funcionalidade #11547]](https://bugs.ruby-lang.org/issues/11547)
+* Uma das mais amadas bibliotecas, pp.rb, agora é automaticamente carregada.
+  Você não precisa mais escrever `require "pp"`.
+  [[Funcionalidade #14123]](https://bugs.ruby-lang.org/issues/14123)
+* Imprime _backtrace_ e mensagens de erro em ordem reversa (primeiro as chamadas mais antigas,
+  chamadas mais recentes por último). Quando um _backtrace_ grande aparece no seu terminal (TTY),
+  você pode facilmente achar a linha causadora no final do seu _backtrace_.
+  Perceba que a ordem só é reversa quando o _backtrace_ é imprimido
+  diretamente no terminal.
+  [[Funcionalidade #8661]](https://bugs.ruby-lang.org/issues/8661) [experimental]
+
+## Melhorias de performance
+
+* Cerca de 5-10% de melhoria de performance ao remover todas as instruções `trace`
+  do _bytecode_ geral (sequências de instrução).
+  A instrução `trace` foi adicionada para suportar o `TracePoint`.
+  Entretanto, na maioria dos casos, `TracePoint` não é utilizado e instruções `trace`
+  são  sobrecargas puras. Ao invés, nós usamos uma técnica de instrumentação dinâmica.
+  Veja [[Funcionalidade #14104]](https://bugs.ruby-lang.org/issues/14104) para mais detalhes.
+* Passagem de bloco por um parâmetro de bloco (por exemplo `def foo(&b); bar(&b); end`)
+  está cerca de 3 vezes mais rápida do que no Ruby 2.4 por causa da técnica "_Lazy Proc allocation_".
+  [[Funcionalidade #14045]](https://bugs.ruby-lang.org/issues/14045)
+* Mutex está reescrito para ser menor e mais rápido.
+  [[Funcionalidade #13517]](https://bugs.ruby-lang.org/issues/13517)
+* ERB agora gera código a partir de um template duas vezes mais rápido do que no Ruby 2.4.
+* Melhora a performance de alguns métodos internos como `Array#concat`,
+  `Enumerable#sort_by`, `String#concat`, `String#index`, `Time#+` e mais.
+* IO.copy_stream usa copy_file_range(2) para copiar usando offloading.
+  [[Funcionalidade #13867]](https://bugs.ruby-lang.org/issues/13867)
+
+## Outras mudanças notáveis desde 2.4
+
+* SecureRandom agora prefere fontes fornecidas pelo sistema operacional ao invés de OpenSSL.
+  [[Bug #9569]](https://bugs.ruby-lang.org/issues/9569)
+* Promove cmath, csv, date, dbm, etc, fcntl, fiddle, fileutils, gdbm, ipaddr,
+  scanf, sdbm, stringio, strscan, webrick, zlib de bibliotecas padrões
+  para gems padrões.
+* Atualiza para [Onigmo](https://github.com/k-takata/Onigmo/) 6.1.3.
+  * Adiciona [operador ausente](https://github.com/k-takata/Onigmo/issues/87).
+  * Note que [Ruby 2.4.1](https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/) também inclui esta mudança.
+* Atualiza para Psych 3.0.2.
+* Atualiza para RubyGems 2.7.3.
+* Atualiza para RDoc 6.0.1.
+  * [Altera o _lexer_ de um baseado em IRB para Ripper](https://github.com/ruby/rdoc/pull/512).
+    Isto melhora consideravelmente a velocidade de geração de documentação.
+  * Corrige uma quantidade significativa de bugs que existiam há 10 anos.
+  * Adiciona suporte para a nova sintaxe de Ruby desde as últimas mudanças.
+* Atualiza a versão suportads de Unicode para 10.0.0.
+* `Thread.report_on_exception` agora é definido como `true` por padrão.
+  Esta alteração ajuda a debugar programas multithreads.
+  [[Funcionalidade #14143]](https://bugs.ruby-lang.org/issues/14143)
+* IO#write agora recebe múltiplos argumentos.
+  [[Funcionalidade #9323]](https://bugs.ruby-lang.org/issues/9323)
+
+Veja as [novidades](https://github.com/ruby/ruby/blob/v2_5_0/NEWS)
+ou [histórico de commits](https://github.com/ruby/ruby/compare/v2_4_0...v2_5_0)
+para detalhes.
+
+Com essas mudanças,
+[6158 arquivos alterados, 348484 inserções(+), 82747 remoções(-)](https://github.com/ruby/ruby/compare/v2_4_0...v2_5_0)
+desde Ruby 2.4.0!
+
+Feliz natal, feliz ano novo e divirta-se programando com Ruby 2.5!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz>
+
+      SIZE:   15834941 bytes
+      SHA1:   58f77301c891c1c4a08f301861c26b1ea46509f6
+      SHA256: 46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab
+      SHA512: 0712fe68611f5d0cd6dd54b814f825478e64b6a62bdf67bce431f4dca2dc00b1a33f77bebfbcd0a151118a1152554ab457decde435b424aa1f004bc0aa40580d
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.zip>
+
+      SIZE:   19495617 bytes
+      SHA1:   700b6f55d689a5c8051c8c292b9e77a1b50bf96e
+      SHA256: 94559ea6e3c619423da604e503ce1dc1c465d6e0747a07fbdc5f294acaf14c24
+      SHA512: e4324064cee8c65b80192e3eff287e915d2d40464d300744c36fb326ae4b1846911400a99d4332192d8a217009d3a5209b43eb5e8bc0b739035bef89cc493e84
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2>
+
+      SIZE:   13955820 bytes
+      SHA1:   827b9a3bcffa86d1fc9ed96d403cb9dc37731688
+      SHA256: d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc
+      SHA512: 8f6fdf6708e7470f55bc009db2567cd8d4e633ad0678d83a015441ecf5b5d88bd7da8fb8533a42157ff83b74d00b6dc617d39bbb17fc2c6c12287a1d8eaa0f2c
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.xz>
+
+      SIZE:   11292472 bytes
+      SHA1:   9c7babcf9e299be3f197d9091024ae458f1a1273
+      SHA256: 1da0afed833a0dab94075221a615c14487b05d0c407f991c8080d576d985b49b
+      SHA512: 55714a33d7661fe8b432f73c34fd67b49699f8b79df1cbd680a74899124d31111ab0f444677672aac1ba725820182940d485efb2db0bf2bc96737c5d40c54578

--- a/pt_br/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
+++ b/pt_br/news/_posts/2017-12-27-fukuoka-ruby-award-2018.md
@@ -1,0 +1,75 @@
+---
+layout: news_post
+title: "Fukuoka Ruby Award 2018 - Inscrições serão julgadas por Matz"
+author: "Fukuoka Ruby"
+translator: "jcserracampos"
+date: 2017-12-27 00:00:00 +0000
+lang: pt_br
+---
+
+Prezada(o) entusiasta de Ruby,
+
+O governo de Fukuoka, Japão, juntamente com "Matz" Matsumoto gostaria
+de convidar-lhe para se inscrever na seguinte competição de Ruby. Se você desenvolveu
+um programa interessante usando Ruby, sinta-se encorajada(o) a se inscrever.
+
+Fukuoka Ruby Award 2018 - Grande Prêmio - 1 milhão de ienes!
+
+Prazo de Inscrição: 31 de janeiro de 2018
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz e um grupo de painelista selecionarão os vencededores da
+Fukuoka Competition. O grande prêmio da Fukuoka Competition
+é 1 milhão de ienes. Vencedores anteriores incluem Rhomobile (USA)
+e APEC Climate Center (Korea).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Programas inscritos na competição não necessariamente precisam ser escritos inteiramente
+em Ruby, mas devem utilizar como vantagem alguma característica única de Ruby.
+
+Os projetos precisam ter sido desenvolvidos ou completados nos últimos 12 meses
+para ser elegíveis. Por favor, acesse os seguintes sites de Fukuoka para mais
+detalhes ou para se inscrever.
+
+[http://www.digitalfukuoka.jp/events/152](http://www.digitalfukuoka.jp/events/152)
+ou
+[http://myfukuoka.com/events/2018-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2018-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/393/RubyAward_ApplicationForm_2018.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/393/RubyAward_ApplicationForm_2018.doc)
+
+Por favor, encaminhe a inscrição para award@f-ruby.com.
+
+Neste ano, haverão os seguintes prêmios especiais:
+
+O vencedor do AWS Prize receberá:
+
+* Amazon Fire Tablet (sujeito a alteração)
+* Consultoria técnica sobre arquitetura AWS
+
+O vencedor do GMO Pepabo Prize receberá:
+
+* Lolipop! serviço de hospedagem compartilhado: assinatura gratuita por 10 anos do plano
+  Standard ou um cupom de ¥100.000 para o plano fracionado de Managed Cloud.
+* Serviço de registro Muumuu Domain DNS: Assinatura gratuita por 10 anos de um
+  domínio (para um domínio que custa ¥10.000 ou menos por ano).
+
+O vencedor do IIJ GIO Prize receberá:
+
+* Mais detalhes serão anunciados em breve.
+
+O vencedor do Money Forward Prize receberá:
+
+* Jantar com Ruby _commiters_ de Money Forward.
+* Um cupom gratuito de 10 anos dos serviços premium de nosso serviço
+  de gerenciamento financeiro pessoal "Money Forward".
+
+O vencedor do Salesforce Prize receberá:
+
+* Brindes de salesforce.com
+
+"Matz testará e revisará seu código fonte completamente,
+então é muito significativo se inscrever! A inscrição da competição é gratuita."
+
+Obrigado!

--- a/pt_br/news/_posts/2018-06-20-support-of-ruby-2-2-has-ended.md
+++ b/pt_br/news/_posts/2018-06-20-support-of-ruby-2-2-has-ended.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "O suporte do Ruby 2.2 acabou"
+author: "antonpaisov"
+translator: "bannergames"
+date: 2018-06-20 00:00:00 +0000
+lang: pt_br
+---
+
+Anunciamos que todo o suporte da série 2.2 do Ruby acabou.
+
+Após o lançamento do Ruby 2.2.7 em 28 de março de 2017,
+o suporte da série 2.2 do Ruby estava em fase de manutenção de segurança.
+Agora, após um ano, essa fase acabou.
+Assim sendo, em 31 de março de 2018, todo o suporte da série 2.2 do Ruby
+acabou. Correções de bugs e de segurança das versões mais recentes do Ruby
+não serão exportados para a versão 2.2, e não haverão mais lançamentos de
+patch da versão 2.2.
+Nós recomendamos altamente que atualize para o Ruby 2.5 ou 2.4 o mais
+rápido possível.
+
+
+## Sobre as versões do Ruby atualmente suportadas
+
+### Série Ruby 2.5
+
+Atualmente em fase de manunteção normal.
+Nós vamos exportar correções de bugs e lançar com as correções sempre
+que necessário.
+E se um problema crítico de segurança for encontrado iremos lançar
+uma correção urgente para resolvê-lo.
+
+### Série Ruby 2.4
+
+Atualmente em fase de manunteção normal.
+Nós vamos exportar correções de bugs e lançar com as correções sempre
+que necessário.
+E se um problema crítico de segurança for encontrado iremos lançar
+uma correção urgente para resolvê-lo.
+
+### Série Ruby 2.3
+
+Atualmente em fase de manunteção de segurança.
+Nós nunca exportaremos quaisquer correções de bugs para a versão 2.3
+exceto correções de segurança.
+Se um problema crítico de segurança for encontrado iremos lançar
+uma correção urgente para resolvê-lo.
+Estamos planeando para acabar com o suporte das séries 2.3 do Ruby
+no final de março de 2019.

--- a/pt_br/news/_posts/2018-11-08-snap.md
+++ b/pt_br/news/_posts/2018-11-08-snap.md
@@ -1,0 +1,64 @@
+---
+layout: news_post
+title: O snap oficial do Ruby está disponível
+author: Hiroshi SHIBATA
+translator: "vnbrs (Vinicius Brasil)"
+date: 2018-11-08 14:58:28 +0000
+lang: pt_br
+---
+
+Nós oficialmente lançamos um pacote snap para a linguagem Ruby.
+
+<https://snapcraft.io/ruby>
+
+Snap é um sistema de pacotes desenvolvido pela Canonical. Ele permite que você
+distribua um software com suas dependências para diferentes sistemas Linux.
+Isso resolve o problema de quando um usuário não consegue instalar a última
+versão do Ruby do repositório padrão de seu sistema, como no  `rpm` or `apt`.
+
+No Ubuntu 16.04 ou superior, você pode instalar o snap do Ruby com o seguinte
+comando:
+
+```
+sudo snap install ruby --classic
+```
+
+(Se você utiliza outras distribuições Linux, por favor acesse
+<https://docs.snapcraft.io/installing-snapd/6735>.)
+
+Nosso snap utiliza a funcionalidade de "canal" para distribuir
+múltiplas versões de Ruby concorrentemente. Por exemplo, sem especificar
+um canal, atualmente a versão 2.5.3 do Ruby será instalada. Mas se você
+quer utilizar a versão 2.4, especifique o canal 2.4 como abaixo:
+
+```
+sudo snap install ruby --classic --channel=2.4/stable
+```
+
+Você pode também utilizar diversos canais. O seguinte comando muda para a versão 2.3:
+
+```
+sudo snap switch ruby --channel=2.3/stable
+sudo snap refresh
+```
+
+Nosso snap configura as variáveis de ambiente `GEM_HOME` e `GEM_PATH`
+para `$HOME/.gem`.
+Então se você quer executar comandos instalados por gems, como `rails` e
+`rspec`, sem utilizar `bundle exec`, você precisará adicionar a seguinte
+linha no seu arquivo shell rc (como `.bashrc`):
+
+```
+eval `ruby.env`
+```
+
+Já que `$HOME/.gem` é compartilhado entre múltiplas versões, se você
+troca de versão e as utiliza, você precisará recompilar as extensões C
+utilizando o comando `gem pristine --extensions`.
+
+A versão inicial do snap oficial do Ruby foi lançada durante o Snapcraft
+summit sediado no escritório da Canonical em Londres entre 6 e 8 de Novembro
+de 2018.
+Qualquer feedback é bem vindo em <https://github.com/ruby/snap.ruby>.
+
+Aproveite!

--- a/pt_br/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
+++ b/pt_br/news/_posts/2018-11-29-fukuoka-ruby-award-2019.md
@@ -1,0 +1,63 @@
+---
+layout: news_post
+title: "Competição Fukuoka Ruby Award 2019 - Aplicações a serem julgadas pelo Matz"
+author: "Fukuoka Ruby"
+translator: "vnbrs (Vinicius Brasil)"
+date: 2018-11-29 00:00:00 +0000
+lang: pt_br
+---
+
+Caros entusiatas de Ruby,
+
+O governo de Fukuoka, Japão, juntamente com "Matz" Matsumoto gostaria de convidá-los para entrar na seguinte competição de Ruby. Se você desenvolveu algum programa interessante em Ruby, por favor seja encorajado a aplicar.
+
+Competição Fukuoka Ruby Award 2019 - Grande Prêmio - 1 Milhão de Ienes!
+
+Data máxima para aplicação: 31 de Janeiro de 2019
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz e um grupo de jurados selecionarão os vencedores da competição de Fukuoka. O grande prêmio para essa competição é 1 milhão de ienes. Fora o grande prêmio, outras premiações incluem Rhomobile (EUA) and APEC Climate Center (Coréia).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Os programas que entrarem na competição não precisam ser inteiramente escritos em Ruby, porém devem utilizar as características únicas do Ruby.
+
+Os projetos devem ter sido desenvolvidos ou sidos completados nos últimos 12 meses para serem elegíves. Por favor visite o seguinte site de Fukuoka para detalhes adicionais, ou para entrar para a competição:
+
+[http://www.digitalfukuoka.jp/events/185](http://www.digitalfukuoka.jp/events/185)
+ou
+[http://myfukuoka.com/events/2019-fukuoka-ruby-award-guidelines-for-applicants/](http://myfukuoka.com/events/2019-fukuoka-ruby-award-guidelines-for-applicants/)
+
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/465/RubyAward_ApplicationForm_2019.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/465/RubyAward_ApplicationForm_2019.doc)
+
+Por favor, envie o formulário de aplicação para award@f-ruby.com
+
+Esse ano, temos alguns prêmios especiais:
+
+O ganhador do prêmio AWS receberá:
+
+* Amazon Echo (sujeito à mudança)
+* Consultoria técnica de arquitetos AWS
+
+O ganhador do prêmio GMO Pepabo receberá:
+
+* Lolipop! (serviço de hospedagem compartilhada): assinatura gratuita por 10 anos do plano Standard, ou um cupom no valor de ¥ 100.000,00 para o plano metrificado da Managed Cloud
+* Muumuu Domain (serviço de registro de DNS): assinatura gratuita por 10 anos de um domínio (válido somente para domínios de ¥ 10.000,00 ou menos por ano)
+
+O ganhador do prêmio IIJ GIO receberá:
+
+* Um cupom de IIJ GIO que vale 500,000 ienes (mais de 6 meses)
+
+O ganhador do prêmio Money Forward receberá:
+
+* Um jantar com os comitters do Ruby do Money Forward
+* Um cupom de 10 anos dos serviços premium de nosso serviço de gerenciamento de finanças "Money Forward"
+
+O ganhador do prêmio Salesforce receberá:
+
+* Alguns mimos novos da salesforce.com
+
+"Matz estará testando e revisando seu código minusciosamente, então é muito oportuno aplicar! A competição é gratuita para entrar."
+
+Obrigado!

--- a/pt_br/news/_posts/2019-01-30-ruby-2-6-1-released.md
+++ b/pt_br/news/_posts/2019-01-30-ruby-2-6-1-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.6.1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2019-01-30 00:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.6.1 foi lançado.
+
+## Mudanças
+
+* [Net::Protocol::BufferedIO#write lança NoMethodError quando mandando um string multi-byte grande](https://bugs.ruby-lang.org/issues/15468) foi corrigido.
+
+Esta versão inclui correções de bug adicionais. Veja os [commit logs](https://github.com/ruby/ruby/compare/v2_6_0...v2_6_1) para mais detalhes.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz>
+
+      SIZE:   16742207 bytes
+      SHA1:   416842bb5b4ca655610df1f0389b6e21d25154f8
+      SHA256: 17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8
+      SHA512: 89e016e60f107fa40da251bc9659584ee3191caee726b5c6818ecbe109f825c553041a5dfda7e6d2889fcf587e63fb5d9fbe6cbdbdc4572e1123c302f0f1b881
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.zip>
+
+      SIZE:   20595342 bytes
+      SHA1:   6fd14990dc411eb58852324d45b29f84d580644d
+      SHA256: ed1537f49d333a809900c1f49ad16c4c06224ebbf5c744cb7b9104ab2a385366
+      SHA512: 8a092486ecefac5bd734897562257a576112e59d90026d0b2ada10aa0b7e0fa86ed1cd803c6254eaa21b19ba36502d9ac268eae6f5714a6eca01904117ab0da6
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2>
+
+      SIZE:   14561930 bytes
+      SHA1:   d4c92d9b0057473238df2fd4792454b43976fda3
+      SHA256: 82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099
+      SHA512: fc41429491935b89532733b95476ab9f8a4efc310aad8f4c2bd3b68fba08fd7b6e9ac84c6c88ca892022d1ba76435295f3299ea466f9b5453c07d41cb539af59
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.xz>
+
+      SIZE:   11872964 bytes
+      SHA1:   ba5f4338bb642e3836dd80b73a9df0d1b6e079ae
+      SHA256: 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+      SHA512: fb36289a955f0596c683cdadf1e4a9a9fd35222b1e1c6160c2e7cd82e5befd40a7aa4361e55f7a8f83c06ee899ec493821c7db34a60c4ac3bca0e874d33ef1a9
+
+## Comentário de Versão
+
+Vários committers, desenvolvedores e usuários que providenciaram relatórios de bug nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2019-03-05-multiple-vulnerabilities-in-rubygems.md
+++ b/pt_br/news/_posts/2019-03-05-multiple-vulnerabilities-in-rubygems.md
@@ -1,0 +1,60 @@
+---
+layout: news_post
+title: "Múltiplas vulnerabilidades em RubyGems"
+author: "hsbt"
+translator: "jcserracampos"
+date: 2019-03-05 00:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existem múltiplas vulnerabilidades no RubyGems empacotado com Ruby.
+Isto foi [reportado no blog oficial do RubyGems](http://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html).
+
+## Detalhes
+
+As seguintes vulnerabilidades foram reportadas:
+
+* CVE-2019-8320: Exclui diretório usando symlink quando descomprimindo tar
+* CVE-2019-8321: Vulnerabilidade de injeção de sequência de escape em `verbose`
+* CVE-2019-8322: Vulnerabilidade de injeção de sequência de escape em `gem owner`
+* CVE-2019-8323: Vulnerabilidade de injeção de sequência de escape em tratamento de respostas de API
+* CVE-2019-8324: A instalação de uma gem maliciosa pode gerar execução arbitrária de código
+* CVE-2019-8325: Vulnerabilidade de injeção de sequência de escape em erros
+
+É fortemente recomendado que usuários de Ruby atualizem sua instalação de Ruby ou tomme uma das seguintes soluções alternativas assim que possível.
+
+## Versões afetadas
+
+* Série Ruby 2.3: todas
+* Série Ruby 2.4: 2.4.5 e anteriores
+* Série Ruby 2.5: 2.5.3 e anteriores
+* Série Ruby 2.6: 2.6.1 e anteriores
+* Antes da revisão de trunk 67168
+
+## Soluções alternativas
+
+Em princípio, você deve atualizar sua instalação do Ruby para a última versão.
+RubyGems 3.0.3 ou posterior incluem a correção para essas vulnerabilidade, então atualize seu RubyGems para a última versão se você não pode atualizar o Ruby em si.
+
+```
+gem update --system
+```
+
+Se você não pode atualizar RubyGems, você pode aplicar os seguintes patches como uma solução alternativa.
+
+* [para Ruby 2.4.5](https://bugs.ruby-lang.org/attachments/7669)
+* [para Ruby 2.5.3](https://bugs.ruby-lang.org/attachments/7670)
+* [para Ruby 2.6.1](https://bugs.ruby-lang.org/attachments/7671)
+
+Em relação ao trunk do Ruby, atualize para a última revisão.
+
+## Créditos
+
+Este relatório é baseado no [blog oficial de RubyGems](http://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html).
+
+## Histórico
+
+* Originalmente publicado em 2019-03-05 00:00:00 UTC
+* Link para os patches atualizado em 2019-03-06 05:26:27 UTC
+* Menção sobre atualizando Ruby em si em 2019-04-01 06:00:00 UTC

--- a/pt_br/news/_posts/2019-03-13-ruby-2-5-4-released.md
+++ b/pt_br/news/_posts/2019-03-13-ruby-2-5-4-released.md
@@ -1,0 +1,49 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.4"
+author: "nagachika"
+translator: "jcserracampos"
+date: 2019-03-13 11:30:00 +0000
+lang: pt_br
+---
+
+Ruby 2.5.4 foi lançado.
+
+Esta versão inclui correções de bug e segurança atualizando o RubyGems empacotado.
+Veja detalhes em [Múltiplas vulnerabilidades em RubyGems](/pt_br/news/2019/03/05/multiple-vulnerabilities-in-rubygems/)
+e os [commit logs](https://github.com/ruby/ruby/compare/v2_5_3...v2_5_4).
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2>
+
+      SIZE:   14167366 bytes
+      SHA1:   ac3248a055b5317cec53d3f922559c5b4a67d410
+      SHA256: 8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc
+      SHA512: 3c4f54f38ee50914a44d07e4fd299e53dddd045f2d38da2140586b8a9c45d1172fec2ad5b0411c228a9b31f5e161214820903a65b98caf3b0dfeeaabf2cab6ad
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz>
+
+      SIZE:   15995815 bytes
+      SHA1:   330bb5472f565b683c7f8c9091d4ee0cc155b51b
+      SHA256: 0e4042bce749352dfcf1b9e3013ba7c078b728f51f8adaf6470ce37675e3cb1f
+      SHA512: 6e58006c30d8ae561967e051ec0a34f34f899eee1b039abb65c9a63dc65965e210d238fff19fa7c7411893df25dfc40426887a195993153fb9e09bbf769dfc14
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.xz>
+
+      SIZE:   11493016 bytes
+      SHA1:   221b8538e75a8d04af8b9a09f56343e463bf94f8
+      SHA256: 46f6eff655a6be1939f70c7a4c1bf58f76663e7e804738bc52f4d47ca31dee3d
+      SHA512: e72294e549d09510f20c808d26a0d21ef0ee2616d8598980a42db260d45340e5c259ac65e5478a8b086042ff6ba7d8447a6c8115454ffe977c4f63175ab89062
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.zip>
+
+      SIZE:   19186174 bytes
+      SHA1:   855be9a5a43a1e0621ad2e81c27de9370d2abcc8
+      SHA256: 823a6a2c9c7baa18554fd78d430837a01ab33cc16ad1759c9842bdd9523e9cea
+      SHA512: a83f90514b09c217fbbd154cfc09c804553353a97cbff7df24185b613e1c7be69a965fe9ec925ac3f4bd6170f2c3d0d60be7ea4ab1037ce64300d7443b6e08e8
+
+## Comentário de Versão
+
+Vários committers, desenvolvedores e usuários que providenciaram relatórios de bug nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2019-03-13-ruby-2-6-2-released.md
+++ b/pt_br/news/_posts/2019-03-13-ruby-2-6-2-released.md
@@ -1,0 +1,48 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.6.2"
+author: "naruse"
+translator: "jcserracampos"
+date: 2019-03-13 11:30:00 +0000
+lang: pt_br
+---
+
+Ruby 2.6.2 foi lançado.
+
+Esta versão inclui correções de bug e segurança atualizando o RubyGems empacotado.
+Veja detalhes em [Múltiplas vulnerabilidades em RubyGems](/pt_br/news/2019/03/05/multiple-vulnerabilities-in-rubygems/)
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz>
+
+      SIZE:   16777765 bytes
+      SHA1:   44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7
+      SHA256: a0405d2bf2c2d2f332033b70dff354d224a864ab0edd462b7a413420453b49ab
+      SHA512: bc96a6793a1e3111598b82b0aad98dc5b465e39cdb5b788c4259818752e028a44545c6489c02c323db0f43a362c26f0900acfba0277d6e2201587d7252f6125f
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.zip>
+
+      SIZE:   20601169 bytes
+      SHA1:   fce5c289842e6e4c4bc7950214d82c0858086baa
+      SHA256: 65b862e5c86346d6bda05fc193c6f2cd728ddfd357f4b0a19d54d48a50984d13
+      SHA512: 60ccabbca50d51186b6715edcd8e4fa704e8b9159a23f073e8d3aafef3858a98ade416156af94a479d1af5555c4c4b5b71267f0f563a518e5e6112ce9921bb8b
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2>
+
+      SIZE:   14634343 bytes
+      SHA1:   5839fc6e6568ac4f26a20382bd8fe0d998dffbb0
+      SHA256: d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915
+      SHA512: cad678d2ced4085e99009e4fef83c067dd0e6ead27a8695bc212c0e5112a7fa09ceb27f82638faf91932ef8bdd090f844e0a878ffdf6845a891da4b858588aa0
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.xz>
+
+      SIZE:   11889840 bytes
+      SHA1:   b7b3432519f80ea50adc9bfb937c7a46865a93d5
+      SHA256: 91fcde77eea8e6206d775a48ac58450afe4883af1a42e5b358320beb33a445fa
+      SHA512: 13f7d7b483a037378eac4bf4bebddc21d69f4e19e6bbb397dd53e7518037ae9a3aa5b41fc20bf1fe410803c6efc3a6a65a65af47648d3a93713f75cfe885326a
+
+## Comentário de Versão
+
+Vários committers, desenvolvedores e usuários que providenciaram relatórios de bug nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2019-03-15-ruby-2-5-5-released.md
+++ b/pt_br/news/_posts/2019-03-15-ruby-2-5-5-released.md
@@ -1,0 +1,48 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.5"
+author: "nagachika"
+translator: "jcserracampos"
+date: 2019-03-15 02:00:00 +0000
+lang: pt_br
+---
+
+Foi lançado o Ruby 2.5.5.
+
+Esta versão inclui uma correção de bug para um deadlock em aplicações multithread/multiprocessaento (usando `Process.fork`), como, por exemplo, Puma.
+
+Veja os [commit logs](https://github.com/ruby/ruby/compare/v2_5_4...v2_5_5) para detalhes das mudanças.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2>
+
+      SIZE:   14165422 bytes
+      SHA1:   1932db85ace80ecdbc5cfc7aada5b5123f7ad739
+      SHA256: 1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb
+      SHA512: 1b56aa79569b818446440b9f2d13122bf7c2976ab9b2865f5fb62d247d7768dd4ac5b5e463709ffec0f757bff7088afd293c2a8c5349c3780763b6444bb354a8
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz>
+
+      SIZE:   15996436 bytes
+      SHA1:   e6a063728950762925108abbdbf68968ec1ab5bb
+      SHA256: 28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c
+      SHA512: 82d0ae019c02822668f7e8c7ad7f62170b059ea70a95a7a7cb26f809e2f2f0f5d25b5bb0ca147413ae42cf0fc5bf60329b56609c266556b1e9f04813c33bb4c9
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.xz>
+
+      SIZE:   11459832 bytes
+      SHA1:   85cee62e47f0707808ff3d7cb68b6cd075a65509
+      SHA256: 9bf6370aaa82c284f193264cc7ca56f202171c32367deceb3599a4f354175d7d
+      SHA512: 06b1d58536ebfacb7b56c1e6ed4b8ab816fadc4f48c845a452554cd262e7908199a30e5793f3cbaec2db56a8803aa5c6089abf7bf06c8fc47867e97870b7dfec
+
+* <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.zip>
+
+      SIZE:   19186230 bytes
+      SHA1:   c0b2bd2b09b40d098b1295303c820d7dd8d97d38
+      SHA256: be630e814c796f3750bd892f1250851e67fc4379f75508a4cb7ca7ceb718ddef
+      SHA512: 95604d47f3436e0be3a59742a89ac5f1c5c9493ddab8b53b154098b876b2fa12418d2adfc1c71e039a6876d209a7832efd88c0e297df5be56b8f7e92094eb487
+
+## Comentário de Versão
+
+Eu quero expressar minha gratidão por sorah e k0kubun por seus informes e investigações. Obrigado.

--- a/pt_br/news/_posts/2019-03-31-support-of-ruby-2-3-has-ended.md
+++ b/pt_br/news/_posts/2019-03-31-support-of-ruby-2-3-has-ended.md
@@ -1,0 +1,41 @@
+---
+layout: news_post
+title: "Suporte ao Ruby 2.3 terminou"
+author: "antonpaisov"
+translator: "jcserracampos"
+date: 2019-03-31 00:00:00 +0000
+lang: pt_br
+---
+
+Anunciamos que todo o suporte para a série do Ruby 2.3 terminou.
+
+Depois do lançamento da versão do Ruby 2.37 em 28 de março de 2018,
+o suporte para a série do Ruby 2.3 estava em fase de manutenção de segurança.
+Agora, após um ano ter se passado, esta fase terminou.
+Assim sendo, em 31 de março de 2019, todo o suporte para a série da versão 2.3 termina.
+Correções de segurança e bugs das versões mais recentes não serão mais
+transportadas para 2.3. Também não haverão mais patchs para o 2.3.
+Nós recomendados fortemente que você migre para o Ruby 2.6 ou 2.5 assim que possível.
+
+## Sobre as versões suportes do Ruby atualmente
+
+### Série Ruby 2.6
+
+Atualmente em fase de manutenção normal.
+Nós iremos transportar correções de bug e lançar com correçoes sempre que necessário.
+E, se algum erro crítico for achado, nós vamos lançar uma correção urgente
+para isso.
+
+### Série Ruby 2.5
+
+Atualmente em fase de manutenção normal.
+Nós iremos transportar correções de bug e lançar com correçoes sempre que necessário.
+E, se algum erro crítico for achado, nós vamos lançar uma correção urgente
+para isso.
+
+### Série Ruby 2.4
+
+Atualmente em fase de manutenção de segurança.
+Nós nunca transportaremos qualquer correção de bug para a 2.4, exceto correções de segurança.
+Se algum erro crítico for achado, nós vamos lançar uma correção urgente para isso.
+Estamos planejando terminar o suporte para a série Ruby 2.4 em 31 de março de 2020.

--- a/pt_br/news/_posts/2019-04-01-ruby-2-4-6-released.md
+++ b/pt_br/news/_posts/2019-04-01-ruby-2-4-6-released.md
@@ -1,0 +1,62 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.6"
+author: "usa"
+translator: "jcserracampos"
+date: 2019-04-01 06:00:00 +0000
+lang: pt_br
+---
+
+Foi lançado o Ruby 2.4.6.
+
+Esta versão inclui cerca de 20 correções de bugs depois das versões anteriores e também inclui várias correções de segurança.
+Por favor, verifique os tópicos abaixo para detalhes.
+
+* [Múltiplas vulnerabilidade em RubyGems](/en/news/2019/03/05/multiple-vulnerabilities-in-rubygems/)
+
+Veja o [commit log](https://github.com/ruby/ruby/compare/v2_4_5...v2_4_6) para detalhes.
+
+Depois desta versão, nós vamos terminar a fase de manutenção normal do Ruby 2.4
+e começará a fase de manutenção de segurança dele.
+Isto signifa que após o lançamento da 2.4.6 nós nunca traremos qualquer correção de bug
+para a 2.4, exceto correções de segurança.
+O período da fase de manutenção de segurança está programda para 1 ano.
+Ao fim deste período, o suporte oficial ao Ruby 2.4 terminará.
+Assim sendo, nós recomendamos que você comece a planejar para migrar para o Ruby 2.6 ou 2.5.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2>
+
+      SIZE:   12623913 bytes
+      SHA1:   b44b5c6637a69b3b95971b1937ecb583dc1de568
+      SHA256: 909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02
+      SHA512: 292802984e5cff6d526d817bde08216fe801d255c4cede0646e450f22d4a3a81ae612ec5d193dcc2a888e3e98b2531af845b6b863a2952bcf3fb863f95368bcf
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz>
+
+      SIZE:   15880585 bytes
+      SHA1:   3bc2d9ab3381887c57e0fb7937dc14e9f419f06c
+      SHA256: de0dc8097023716099f7c8a6ffc751511b90de7f5694f401b59f2d071db910be
+      SHA512: 7eb7720961e98e22e4335c38eeead9db96d049ef3ac1da437769b98fee7a10feb092643ce75822a2fe3bd5fd94938417ab5c2de7c6056afe0abf6e4cf03ca282
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.xz>
+
+      SIZE:   10005544 bytes
+      SHA1:   86a4fa22cb3547005ec4bfcf77489a4254226187
+      SHA256: 25da31b9815bfa9bba9f9b793c055a40a35c43c6adfb1fdbd81a09099f9b529c
+      SHA512: eafb2257747f99e2ed262af142e71175b70f7cceaa4d1253b92c8337f075a9a58a2d93b029d75e11a9b124f112a8f0983273b2b30afc147b5cf71a8dbb5fa0ba
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.zip>
+
+      SIZE:   17469891 bytes
+      SHA1:   0e55d231c0e119304e077e42923ce6a1c3daa1d1
+      SHA256: c5de9f11d4b7608d57139b96f7bc94899bb2fc9dee2e192c8951f6647a9d60f7
+      SHA512: cfa779cdb970dfd35dc2a97951310cb3cde1d380b040c283fda6609c591039817a2847ab7174f7a9ee7f7adbb610709b57914bb26e5c015a20d5fe880c569855
+
+## Comentário de Versão
+
+Desculpas por fazer-lhes esperar muito tempo.
+Obrigado a todas as pessoas que ajudaram nesta versão.
+
+A manutenção do Ruby 2.4, incluindo esta versão, é baseada no “Agreement for the Ruby stable version” da Ruby Association.

--- a/pt_br/news/_posts/2019-04-17-ruby-2-6-3-released.md
+++ b/pt_br/news/_posts/2019-04-17-ruby-2-6-3-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.6.3"
+author: "naruse"
+translator: "jcserracampos"
+date: 2019-04-17 00:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.6.3 foi lançado.
+
+Esta versão adiciona suporte para a nova era japonesa "令和" (Reiwa).
+Ela atualiza a versão do Unicode para 12.1 beta ([#15195](https://bugs.ruby-lang.org/issues/15195)) e atualiza a biblioteca de data ([#15742](https://bugs.ruby-lang.org/issues/15742)).
+
+Esta versão tanbém inclui algumas correções de bug.
+Veja os [commit logs](https://github.com/ruby/ruby/compare/v2_6_2...v2_6_3) para detalhes.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz>
+
+      SIZE:   16784748 bytes
+      SHA1:   2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c
+      SHA256: 577fd3795f22b8d91c1d4e6733637b0394d4082db659fccf224c774a2b1c82fb
+      SHA512: 8503b86da60e38da4f1a1553b2570d4125c1823280e6fb6d07825a0e92dd7b628e13147ebde085702cbf5c5eddfe7fa5a2445996bc29164196a53bc917b02112
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.zip>
+
+      SIZE:   20611578 bytes
+      SHA1:   85e9ffe707fb1c1eb4131c953530bb01105a5948
+      SHA256: 5ef6b8e5b5f242d41e4b3d9ab21a40d3f494dfca42b00b25ab8fd3122325fe2d
+      SHA512: 5c87e1eda0002e95684c08ea4eb55b5ce1941dd6304806117647c0bd44ab0714d50fe3b24c322a4f5978286a5442ceaa2d141ebe7cfe07198e0a0b876af6c004
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2>
+
+      SIZE:   14509165 bytes
+      SHA1:   aed3bd3c5346b3b85a6b184bb320465d98994fe3
+      SHA256: dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e
+      SHA512: c63c3f527bef88922345f4abb4b9ad467117b63f2132e41722ea6b4234cec3446626c3338e673065a06d2894feee92472807c284cbe613a442c8fda234ea7f88
+
+* <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.xz>
+
+      SIZE:   11904360 bytes
+      SHA1:   ee231856cee812cfc67440d643f7451857a760c9
+      SHA256: 11a83f85c03d3f0fc9b8a9b6cad1b2674f26c5aaa43ba858d4b0fcc2b54171e1
+      SHA512: 959a613f5cf5b3185a1d7a7ba0e1921166b3930f30461b391b1c9fcfe396f56dc3c736123dfc7b4e72c32a97dc5a1eb1fd7f09bcc3793a3c5526f6644ba421c8
+
+## Comentário de Versão
+
+Vários committers, desenvolvedores e usuários que providenciaram relatórios de bug nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2019-04-23-move-to-git-from-svn.md
+++ b/pt_br/news/_posts/2019-04-23-move-to-git-from-svn.md
@@ -1,0 +1,40 @@
+---
+layout: news_post
+title: "Repositório do Ruby movido para Git de Subversion"
+author: "hsbt"
+translator: "jcserracampos"
+date: 2019-04-23 00:00:00 +0000
+lang: pt_br
+---
+
+Hoje, o repositório canônico da linguagem de programação Ruby foi movido para Git de Subversion.
+
+A interface web para o novo repositório é [https://git.ruby-lang.org](https://git.ruby-lang.org) e é provida por cgit. Nós podemos manter o hash de commit do contribuidor diretamente no repositório do Ruby.
+
+## Política de desenvolvimento
+
+* Nós não usamos um brach de tópico em cgit.
+* O repositório GitHub permanecerá apenas um espelho. Nós não usamos a funcionalidade "Merge pull request".
+* Os branchs ruby_2_4, ruby_2_5 e ruby_2_6 continuarão a usar SVN. Não empurraremos nada para esses branchs em cgit.
+* Começando por ruby_2_7 nós usaremos cgit para desenvolver branchs estáveis.
+* Nós não usamos merge commits.
+
+## Agradecimentos especiais
+
+* k0kubun
+
+  k0kubun agressivamente desenvolveu cadeias de ferramentas relativas ao lançamento e fluxos de trabalhos de migração e também atualizou o script do hook para git.
+
+* naruse
+
+  naruse atualizou as mudanças de funcionalidade para Ruby CI e Redmine (bugs.ruby-lang.org).
+
+* mame
+
+  mame criou a notificação de commit para slack.
+
+## Trabalho Futuro
+
+Nós ainda temos que completar algumas tarefas. Se você encontrar um problema relacionado a migração para Git, por favor registre isso em [https://bugs.ruby-lang.org/issues/14632](https://bugs.ruby-lang.org/issues/14632).
+
+Aproveite!

--- a/pt_br/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
+++ b/pt_br/news/_posts/2019-05-30-ruby-2-7-0-preview1-released.md
@@ -1,0 +1,145 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.7.0-preview1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2019-05-30 00:00:00 +0000
+lang: pt_br
+---
+
+Temos o prazer de anunciar o lançamento da versão de Ruby 2.7.0-preview1.
+
+Uma versão de pré-visualização (preview) é lançada para coletar opiniões para a versão final planejada para ser lançada em dezembro.
+Ela introduz várias novas funcionalidades e melhorias de performance, mais notavelmente:
+
+* Compactação no coletor de lixo
+* Pattern Matching
+* Melhoria do REPL
+
+## Compactação no coletor de lixo (Compaction GC)
+
+Esta versão introduz compactação na coleta de lixo (Compaction GC) que pode desfragmentar um espaço de memória fragmentado.
+
+Alguns programas multithread Ruby podem causar fragmentação de memória, conduzindo a alto uso de memória e velocidade degradada.
+
+O método `GC.compact` é introduzido para compactar a heap. Esta funcionalidade compacta objetos ativos na heap para que menos
+páginas possam ser usadas e a heap possa ser mais _CoW friendly_. [#15626](https://bugs.ruby-lang.org/issues/15626)
+
+## Pattern Matching [Experimental]
+
+Pattern matching, funcionalidade amplamenta utilizada em linguagens para programação funcional, é introduzida como uma funcionalidade experimental. [#14912](https://bugs.ruby-lang.org/issues/14912)
+Ela pode examinar um dado objeto e definir seu valor se um padrão for.
+
+```ruby
+json ='{
+  "nombre": "Alice",
+  "edad": 30,
+  "hijos": [
+    {
+      "nombre": "Bob",
+      "edad": 2
+    }
+  ]
+}'
+case JSON.parse('{...}', symbolize_names: true)
+in {name: "Alice", children: [{name: "Bob", age: age}]}
+  p age
+  ...
+end
+```
+
+Para mais detalhes, por favor, veja [Pattern matching - New feature in Ruby 2.7](https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7).
+
+## Aprimoramento de REPL
+
+`irb`, ambiente interativo empacotado (REPL; Read-Eval-Print-Loop), agora suporta edição em múltiplas linhas. É fomentado por `reline`, implementação pura em Ruby compatível de `readline`.
+Também prove integração com rdoc. Em `irb` você pode exibir a referência para uma dada classe, módulo ou método.  [#14683](https://bugs.ruby-lang.org/issues/14683), [#14787](https://bugs.ruby-lang.org/issues/14787), [#14918](https://bugs.ruby-lang.org/issues/14918)
+Além de, linhas de código mostradas em `binding.irb` e resultados de inspeções para objetos de classes principais agora são colorizados.
+
+<video autoplay="autoplay" controls="controls" muted="muted" width="576" height="259">
+  <source src="https://cache.ruby-lang.org/pub/media/irb_improved_with_key_take2.mp4" type="video/mp4">
+</video>
+
+## Outras novas funcionalidades notáveis
+
+* Um operador de referência de método, <code>.:</code>, é introduzido como uma característica experimental.  [#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581)
+
+* Parâmetro numerado como o parâmetro de bloco padrão é introduzida como uma característica experimental.  [#4475](https://bugs.ruby-lang.org/issues/4475)
+
+* Um intervalo sem começo é introduzido experimentalmente. Pode não ser tão útil
+  como um intervalo sem fim, mas seria bom para o propósito do DSL. [#14799](https://bugs.ruby-lang.org/issues/14799)
+
+      ary[..3]  # indêntico a ary[0..3]
+      rel.where(sales: ..100)
+
+* `Enumerable#tally` é adicionado. Ele conta a ocorrência de cada elemento.
+
+      ["a", "b", "c", "b"].tally
+      #=> {"a"=>1, "b"=>2, "c"=>1}
+
+## Melhorias de desempenho
+
+* JIT [Experimental]
+
+  * Código em JIT é recompilado para código menos otimizado quando uma suposição de otimização é invalidada.
+
+  * _Inlining_ de método é executado quando um método é considerado puro. Essa otimização ainda é experimental e muitos métodos NÃO são considerados puros ainda
+
+  * Valor padrão de `--jit-min-calls` é alterado de 5 para 10,000
+
+  * Valor padrão `--jit-max-cache` é alterado de 1,000 para 100
+
+## Outras mudanças notáveis desde 2.6
+
+* `Proc.new` e `proc` sem bloco em um método invocado com um bloco é alertado agora.
+
+* `lambda` sem bloco em um método invocado com um bloco produz um erro.
+
+* Atualiza versão do Unicode e Emoji de 11.0.0 para 12.0.0.  [[Feature #15321]](https://bugs.ruby-lang.org/issues/15321)
+
+* Atualiza versão do Unicode para 12.1.0, adicionando suporte para U+32FF SQUARE ERA NAME REIWA.  [[Feature #15195]](https://bugs.ruby-lang.org/issues/15195)
+
+* `Date.jisx0301`, `Date#jisx0301` e `Date.parse` provisoriamente suportam a nova era Japonesa como uma extensão informal, até o novo JIS X 0301 seja emitido.  [[Feature #15742]](https://bugs.ruby-lang.org/issues/15742)
+
+* Requere compiladores para suportar C99 [[Misc #15347]](https://bugs.ruby-lang.org/issues/15347)
+  * Detalhes do nosso dialeto: <https://bugs.ruby-lang.org/projects/ruby-master/wiki/C99>
+
+Veja [NEWS](https://github.com/ruby/ruby/blob/v2_7_0_preview1/NEWS) ou [commit logs](https://github.com/ruby/ruby/compare/v2_6_0...v2_7_0_preview1) para mais detalhes.
+
+Com essas mudanças, [1727 arquivos modificados, 76022 inserções(+), 60286 remoções(-)](https://github.com/ruby/ruby/compare/v2_6_0...v2_7_0_preview1) desde Ruby 2.6.0!
+
+Aproveite programando com Ruby 2.7!
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.gz>
+
+      SIZE:   16021286 bytes
+      SHA1:   2fbecf42b03a9d4391b81de42caec7fa497747cf
+      SHA256: c44500af4a4a0c78a0b4d891272523f28e21176cf9bc1cc108977c5f270eaec2
+      SHA512: f731bc9002edd3a61a4955e4cc46a75b5ab687a19c7964f02d3b5b07423d2360d25d7be5df340e884ca9945e3954e68e5eb11b209b65b3a687c71a1abc24b91f
+
+* <https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.zip>
+
+      SIZE:   20283343 bytes
+      SHA1:   7488346fa8e58203a38158752d03c8be6b1da65b
+      SHA256: fdf25573e72e1769b51b8d541d0e1a894a5394dbfdf1b08215aa093079cca64c
+      SHA512: b3b1f59dce94c242ef88a4e68381a4c3a6f90ba0af699083e5a1a00b0fb1dce580f057dad25571fe789ac9aa95aa6e9c071ebb330328dc822217ac9ea9fbeb3f
+
+* <https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2>
+
+      SIZE:   14038296 bytes
+      SHA1:   f7e70cbc2604c53a9e818a2fc59cd0e2d6c859fa
+      SHA256: d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952
+      SHA512: a36b241fc1eccba121bb7c2cc5675b11609e0153e25a3a8961b67270c05414b1aa669ce5d4a5ebe4c6b2328ea2b8f8635fbba046b70de103320b3fdcb3d51248
+
+* <https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.xz>
+
+      SIZE:   11442988 bytes
+      SHA1:   45e467debc194847a9e3afefb20b11e6dc28ea31
+      SHA256: 8c546df3345398b3edc9d0ab097846f033783d33762889fd0f3dc8bb465c3354
+      SHA512: d416e90bfa3e49cc0675c4c13243c8ec319b7a0836add1bd16bd7662d09eaf46656d26e772ef3b097e10779896e643edd8a6e4f885147e3235257736adfdf3b5
+
+## O que é Ruby?
+
+Ruby foi primeiramente desenvolvido por Matz (Yukihiro Matsumoto) em 1993 e agora é desenvolvido como Open Source. Ele é executado em múltiplas plataformas e é usado em todo o mundo, especialmente para desenvolvimento web.

--- a/pt_br/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
+++ b/pt_br/news/_posts/2019-08-28-multiple-jquery-vulnerabilities-in-rdoc.md
@@ -1,0 +1,63 @@
+---
+layout: news_post
+title: "Múltiplas vulnerabilidades de jQuery em RDoc"
+author: "aycabta"
+translator: "jcserracampos"
+date: 2019-08-28 09:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existem múltiplas vulnerabilidades de Cross-Site Scripting (XSS) no jQuery inserido no RDoc que é embutido em Ruby.
+Todas as pessoas usuárias de Ruby são orientadas a atualizar Ruby para a última versão que inclui a versão corrigida de RDoc.
+
+## Detalhes
+
+As seguintes vulnerabilidades foram reportadas.
+
+- [CVE-2012-6708](https://www.cve.org/CVERecord?id=CVE-2012-6708)
+- [CVE-2015-9251](https://www.cve.org/CVERecord?id=CVE-2015-9251)
+
+É fortemente recomendado para todas as pessoas usuárias de Ruby que atualizem sua instalação de Ruby ou tome uma das seguintes soluções alternativas assim que possível.
+Você também deve regerar toda documentação existente de RDoc para mitigar completamente as vulnerabilidades.
+
+## Versões afetadas
+
+- Ruby 2.3 series: todas
+- Ruby 2.4 series: 2.4.6 e mais recentes
+- Ruby 2.5 series: 2.5.5 e mais recentes
+- Ruby 2.6 series: 2.6.3 e mais recentes
+- anterior a master commit f308ab2131ee675000926540cbb8c13c91dc3be5
+
+## Ações requeridas
+
+RDoc é uma ferramenta de geração de documentação estática.
+Atualizando a ferramenta em si é insuficiente para mitigar essas vulnerabilidades.
+
+Então, Documentações RDoc geradas com versões anteriores devem ser regeradas com RDoc mais novo.
+
+## Soluções alternativas
+
+Em princípio, você deve atualizar sua versão de Ruby para a última versão.
+RDoc 6.1.2 e superiores incluem a correção para essas vulnerabilidade, então atualize RDoc para a última versão se você não pode atualizar o Ruby em si.
+
+Note que conforme mencionado anteriormente, você deve regerar documentação RDoc existente.
+
+```
+gem install rdoc -f
+```
+
+_Atualização:_ A versão inicial desta notícia mencionava rdoc-6.1.1.gem, a qual ainda é vulnerável. Por favor, tenha certeza que você instalou rdoc-6.1.2 ou superior.
+
+Sobre a versão de desenvolvimento, atualize para a última HEAD da branch master.
+
+## Créditos
+
+Obrigado a [Chris Seaton](https://hackerone.com/chrisseaton) por reportar este erro.
+
+## Histórico
+
+- Originalmente publicado em 2019-08-28 09:00:00 UTC
+- Versão de RDoc corrigida em 2019-08-28 11:50:00 UTC
+- Pequenas correções em 2019-08-28 12:30:00 UTC
+- Tradução para Português em 2019-09-03 12:00:00 UTC

--- a/pt_br/news/_posts/2019-08-28-ruby-2-4-7-released.md
+++ b/pt_br/news/_posts/2019-08-28-ruby-2-4-7-released.md
@@ -1,0 +1,54 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.7"
+author: "usa"
+translator: "jcserracampos"
+date: 2019-08-28 09:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.4.7 foi lançado.
+
+Esta versão inclui uma correção de segurança.
+Por favor, verifique os tópicos abaixo para detalhes.
+
+* [Múltiplas vulnerabilidades de jQuery em RDoc](/pt_br/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+Ruby 2.4 agora está no estado de fase de manutenção de segurança até
+o fim de março de 2020. Depois desta data, manutenção de Ruby 2.4
+se encerrará. Nós recomendamos você começar a planejar a migração para versões
+novas de Ruby, como a 2.6 ou 2.5.
+
+## Download
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.bz2>
+
+      SIZE:   12826941 bytes
+      SHA1:   9eac11cd50a2c11ff310e88087f25a0ceb5d0994
+      SHA256: c10d6ba6c890aacdf27b733e96ec3859c3ff33bfebb9b6dc8e96879636be7bf5
+      SHA512: 2665bca5f55d4b37f100eec0e2e632d41158139b85fcb8d5806c6dc1699e64194f17b9fe757b5afd6aa2c6e7ccabba8710a9aa8182a2d697add11f2b76cf6958
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz>
+
+      SIZE:   16036496 bytes
+      SHA1:   607384450348bd87028cd8d1ebf09f21103d0cd2
+      SHA256: cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89
+      SHA512: 2fbada1cf92dc3b1cbdaf05186ff2e5d8e0ce4ac9dc736148116e365bec6d557a2115838404c982b527adbb27677340acfbbb7c873004f0cb4be8a07857e6473
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.xz>
+
+      SIZE:   10118948 bytes
+      SHA1:   6ed0e943bfcbf181384b48e7873361f1acaf106d
+      SHA256: a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
+      SHA512: df637c5803ddd83f759e9c24b0e7ca1f6cae7c7b353409583d92dbffece0d9d02b48905d6552327a1522a4a37d4e2d22c6c11bd991383835be35e2f31739d649
+
+* <https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.zip>
+
+      SIZE:   17659539 bytes
+      SHA1:   3f991d6b5296e9d0df405033e336bb973d418354
+      SHA256: 1016797925e55c78d9c15633da8ddbd19daed2993a99d35377d2a16c3175cfe5
+      SHA512: 1bddd5616edb1a671224bc1c22cc3ac6f70e96e41cb2937efb437e8920fe09ce2ef0f29c591499d3682ac547e1d3eb7474f89ff86a3834d25724329e4927ed76
+
+## Comentário de versão
+
+Obrigado a todas as pessoas que ajudaram com esta versão, principalmente, as que reportaram a vulnerabilidade.

--- a/pt_br/news/_posts/2019-08-28-ruby-2-5-6-released.md
+++ b/pt_br/news/_posts/2019-08-28-ruby-2-5-6-released.md
@@ -1,0 +1,53 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.5.6"
+author: "usa"
+translator: "jcserracampos"
+date: 2019-08-28 09:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.5.6 foi lançado.
+
+Esta versão inclui cerca de 40 correções de bug após a versão anterior e também inclui uma correção de segurança.
+Por favor, verifique os tópicos abaixo para detalhes.
+
+* [Múltiplas vulnerabilidades de jQuery em RDoc](/pt_br/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+Veja o [commit log](https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6) para detalhes.
+
+## Download
+
+- <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.bz2>
+
+      SIZE:   14073430 bytes
+      SHA1:   a1b497237770d2a0d1386408fc264ad16f3efccf
+      SHA256: 24fc2a417e71150cd2229ec204afc8f467ebb15a8e295aab5d4bceebfb05e18d
+      SHA512: e4511d42d19a7bb39ea79f66bb4eca54b63c2a9d27addc035d6d670c1e59ee48a0c6e9c6bc7d082d1f1114b0668831dce3b7422034517f3c4a06ced0e47a7914
+
+- <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz>
+
+      SIZE:   17684288 bytes
+      SHA1:   d2dd34da5f3b63a0075e50133f60eb35d71b7543
+      SHA256: 1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7
+      SHA512: dc34243129a40b4b16fe171d70bcbdac255819868c608f3ca9f2866124fd6cfde0f3990d5e08a42752427d9066981ca14a634679b9bed5bca9f349a8526d0f35
+
+- <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.xz>
+
+      SIZE:   11323612 bytes
+      SHA1:   5008b35d386c4b663b7956a0790b6aa7ae5dc9a9
+      SHA256: 7601e4b83f4f17bc1affe091502dd465282ffba0761dea57c071ead21b132cee
+      SHA512: 4fe5f8bad5d320f8f17b02ce15afee341e7b0074efcfd98d8944e0cb7c448e0660c4553dd5c0328ee3b49fea3247642f85c60bdce431ed57f58b6326dfd48ee1
+
+- <https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.zip>
+
+      SIZE:   21263348 bytes
+      SHA1:   4a3859319dd9f1f4d43e2a2bf874ca8233d39b15
+      SHA256: c86b0a9bfe47df5639cf134eabd3ebc2711794226ccb02e22094e46aa3e887f4
+      SHA512: 8aa96c4e6692ed8c9f8fe4ceb2a91829bb5fa98ef53a4bc85f3a3d0cd66d60bb80985359bd9f7020de7d1cc39c7223559aa20dfdcc01d890624b71b935c6f8da
+
+## Comentários de versão
+
+Obrigado a todas as pessoas que ajudaram com esta versão.
+
+A manutenção de Ruby 2.5, incluindo esta versão, é baseada no “Agreement for the Ruby stable version” da Ruby Association.

--- a/pt_br/news/_posts/2019-08-28-ruby-2-6-4-released.md
+++ b/pt_br/news/_posts/2019-08-28-ruby-2-6-4-released.md
@@ -1,0 +1,52 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.6.4"
+author: "nagachika"
+translator: "jcserracampos"
+date: 2019-08-28 09:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.6.4 foi lançado.
+
+Esta versão inclui uma correção de segurança para RDoc.
+Por favor, verifique os tópicos abaixo para detalhes.
+
+- [Múltiplas vulnerabilidades de jQuery em RDoc](/pt_br/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/)
+
+Veja os [commit logs](https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4) para as mudanças em detalhes.
+
+## Download
+
+- <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2>
+
+      SIZE:   14426299 bytes
+      SHA1:   fa1c7b7f91edb92de449cb1ae665901ba51a8b81
+      SHA256: fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7
+      SHA512: a9fa2f51fb5f86cd8dcaa0925fe6f13d4f19f110b5d4c5fd251f199d16aaf920db39ad3bb50460eb94ab8d471ab2ac8bb54daea4a3bb080eaf45250aac3437fe
+
+- <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz>
+
+      SIZE:   16503137 bytes
+      SHA1:   2eaddc428cb5d210cfc256a7e6947196ed24355b
+      SHA256: 4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937
+      SHA512: 3dad0d98695e10ece015933e96114ffd9a10d3c59d1ead8a9ab041df113aabee3f4100aa7ffe7ef5c43b62ac3c7506c3f3ceeb8828b2a800b6d0f4119d5bf926
+
+- <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.xz>
+
+      SIZE:   11727940 bytes
+      SHA1:   6ef7d60b8aaa5efb04de2eb4b682f91bc0ab3910
+      SHA256: df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+      SHA512: 930a4162fdb008d2446247908c14269fd13db4dc80bd2bb201a65a69c03f5933f97b4c5079ccd2a12db4934ff97b2debaa10a6c6f5c3060e55873f4397747eaa
+
+- <https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.zip>
+
+      SIZE:   19922060 bytes
+      SHA1:   3e1d98afc7804a291abe42f0b8e2e98219e41ca3
+      SHA256: 8446eaaa633a8d55146df0874154b8eb1e5ea5a000d803503d83fd67d9e9372c
+      SHA512: 5696f2921b8488bde42536dd23d933c8a5ab9ce33632760d217d79567324c4a20f8007d4815f33e56c0a764d1ca372b40c41a5937f9938bb1d63ea078d10d657
+
+## Comentários de versão
+
+Vários committers, desenvolvedores e usuários que providenciaram relatórios de bug nos ajudaram a fazer esta versão.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2019-10-01-webrick-regexp-digestauth-dos-cve-2019-16201.md
+++ b/pt_br/news/_posts/2019-10-01-webrick-regexp-digestauth-dos-cve-2019-16201.md
@@ -1,0 +1,33 @@
+---
+layout: news_post
+title: "CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication"
+author: "mame"
+translator: "jcserracampos"
+date: 2019-10-01 11:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Foi encontrada uma vulnerabilidade de negação de serviço de expressão regular no módulo de autenticação do WEBrick. Uma pessoa atacante pode explorar essa vulnerabilidade para causar uma negação de serviço efetiva contra um serviço WEBrick.
+
+[CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16201) foi designado para essa vulnerabilidade.
+
+Todas as pessoas usuárias de qualquer versão afetada devem atualizar assim que possível.
+
+## Versões Afetadas
+
+* Todas as versões Ruby 2.3 ou anteriores
+* Ruby 2.4 series: Ruby 2.4.7 ou anteriores
+* Ruby 2.5 series: Ruby 2.5.6 ou anteriores
+* Ruby 2.6 series: Ruby 2.6.4 ou anteriores
+* Ruby 2.7.0-preview1
+* antes do commit 36e057e26ef2104bc2349799d6c52d22bb1c7d03
+
+## Reconhecimento
+
+Obrigado a [358](https://hackerone.com/358) por descobrir este problema.
+
+## Histórico
+
+* Originalmente publicado em 2019-10-01 11:00:00 (UTC)
+* Traduzido para o português em 2019-10-21 11:00:00 (GMT-0300)

--- a/pt_br/news/_posts/2019-10-02-ruby-2-4-9-released.md
+++ b/pt_br/news/_posts/2019-10-02-ruby-2-4-9-released.md
@@ -1,0 +1,56 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.4.9"
+author: "usa"
+translator: "jcserracampos"
+date: 2019-10-02 09:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.4.9 foi lançado.
+
+Esta versão é um reenpacotamento da 2.4.8 porque o tarball da versão
+Ruby 2.4.8 anterior não instalava.
+(Veja [[Bug #16197]](https://bugs.ruby-lang.org/issues/16197) em detalhes.)
+Essencialmente, não existem mudanças exceto pelo número de versão entre 2.4.8 e 2.4.9.
+
+Ruby 2.4 está sob o estado de fase de manutenção de segurança, até
+o fim de março de 2020. Depois dessa data, manutenção de Ruby 2.4
+será finalizada. Recomendamos que comece a planejar a migração para novas
+versões de Ruby, como a 2.6 ou 2.5.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "2.4.9" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário de Versão
+
+Obrigado a todas as pessoas que ajudaram com esta versão.

--- a/pt_br/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
+++ b/pt_br/news/_posts/2019-10-16-fukuoka-ruby-award-2020.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "Competição 2020 Fukuoka Ruby Award - Submissões serão julgadas por Matz"
+author: "Fukuoka Ruby"
+translator: "jcserracampos"
+date: 2019-10-16 00:00:00 +0000
+lang: pt_br
+---
+
+Entusiastas de Ruby,
+
+O governo de Fukuoka, Japão, juntamente com "Matz" Matsumoto gostariam de lhe convidar a entrar na seguinte competição de Ruby. Se você desenvolveu algum programa interessante em Ruby, sinta-se, por favor, encorajado(a) a aplicar.
+
+2020 Fukuoka Ruby Award Competition - Grande Prêmio - 1 milhão de ienes!
+
+Prazo para inscrição: 11 de dezembro de 2019
+
+![Fukuoka Ruby Award](https://www.digitalfukuoka.jp/javascripts/kcfinder/upload/images/fukuokarubyaward2017.png)
+
+Matz e um grupo de painelistas selecionarão os(as) vencedores(as) da Fukuoka Competition. O grande prêmio da Fukuoka Competition será 1 milhão de ienes. Ganhedores anteriores incluem Rhomobile (USA) e APEC Climate Center (Korea).
+
+[http://myfukuoka.com/category/news/ruby-news/](http://myfukuoka.com/category/news/ruby-news/)
+
+Programas inscritos na competição não precisam ser escritos inteiramente em Ruby, mas deve se aproveitar das características únicas de Ruby.
+
+Projetos devem ter sido desenvolvidos ou completados nos últimos 12 meses para serem elegíveis. Por favor, visite o seguinte site de Fukuoka para detalhes adicionais e se inscrever:
+
+[http://www.digitalfukuoka.jp/events/215](http://www.digitalfukuoka.jp/events/215) ou
+[http://www.digitalfukuoka.jp/uploads/event_detail/file/536/RubyAward_ApplicationForm_2020.doc](http://www.digitalfukuoka.jp/uploads/event_detail/file/536/RubyAward_ApplicationForm_2020.doc)
+
+Por favor, envie sua aplicação por e-mail para award@f-ruby.com
+
+"Matz testará e revisará seu código fonte, então é muito importante se inscrever. A competição é gratuíta."
+
+Obrigado!

--- a/pt_br/news/_posts/2020-09-25-ruby-3-0-0-preview1-released.md
+++ b/pt_br/news/_posts/2020-09-25-ruby-3-0-0-preview1-released.md
@@ -1,0 +1,248 @@
+---
+layout: news_post
+title: "Lançado Ruby 3.0.0 Preview 1"
+author: "naruse"
+translator: "jcserracampos"
+date: 2020-09-25 00:00:00 +0000
+lang: pt_br
+---
+
+Temos o prazer de anunciar o lançamento do Ruby 3.0.0-preview1.
+
+Ele apresenta uma série de novos recursos e melhorias de desempenho.
+
+## RBS
+
+RBS é uma linguagem para descrever os tipos de programas Ruby.
+Os verificadores de tipo, incluindo criador de perfil de tipos e outras ferramentas de suporte ao RBS, compreenderão os programas Ruby muito melhor com as definições do RBS.
+
+Você pode escrever a definição de classes e módulos: métodos definidos na classe, variáveis de instância e seus tipos e relações de herança / mix-in.
+O objetivo do RBS é oferecer suporte a padrões comumente vistos em programas Ruby e permite escrever tipos avançados, incluindo tipos de união, sobrecarga de método e genéricos. Ele também oferece suporte à _duck typing_ com _tipos de interface_.
+
+Ruby 3.0 vem com gem `rbs`, que permite analisar e processar definições de tipo escritas em RBS.
+
+A seguir está um pequeno exemplo de RBS.
+
+``` rbs
+module ChatApp
+  VERSION: String
+
+  class Channel
+    attr_reader name: String
+    attr_reader messages: Array[Message]
+    attr_reader users: Array[User | Bot]              # `|` significa união de tipos, `User` ou `Bot`.
+
+    def initialize: (String) -> void
+
+    def post: (String, from: User | Bot) -> Message   # Sobrecarga de método é suportada.
+            | (File, from: User | Bot) -> Message
+  end
+end
+```
+
+Veja [README da gem rbs](https://github.com/ruby/rbs) para mais detalhes.
+
+## Ractor (experimental)
+
+Ractor é uma abstração concorrente semelhante a um modelo de ator, projetada para fornecer um recurso de execução paralela sem preocupações com a segurança do thread.
+
+Você pode fazer vários ractores e executá-los em paralelo. Ractor permite fazer programas paralelos thread-safe porque ractors não podem compartilhar objetos normais. A comunicação entre os ractores é apoiada pela troca de mensagens.
+
+Para limitar o compartilhamento de objetos, o Ractor apresenta várias restrições à sintaxe do Ruby (sem vários Ractors, não há mudanças).
+
+A especificação e implementação não estão amadurecidas e serão alteradas no futuro, portanto, esse recurso é marcado como experimental e mostra o aviso de recurso experimental se um Ractor for criado.
+
+O pequeno programa a seguir calcula `prime?` em paralelo com dois ractores e cerca de x2 vezes mais rápido com dois ou mais núcleos do que o programa sequencial.
+
+``` ruby
+require 'prime'
+
+# n.prime? com inteiros r1 e r2 enviados rodando em parelelo
+r1, r2 = *(1..2).map do
+  Ractor.new do
+    n = Ractor.recv
+    n.prime?
+  end
+end
+
+# envio de parâmetros
+r1.send 2**61 - 1
+r2.send 2**61 + 15
+
+# aguardando os resultados de expr1, expr2
+p r1.take #=> true
+p r2.take #=> true
+```
+
+Veja [doc/ractor.md](https://github.com/ruby/ruby/blob/master/doc/ractor.md) para mais detalhes.
+
+## Scheduler (Experimental)
+
+`Thread#scheduler` é introduzido para interceptar operações bloqueantes. Isso permite concorrência leve sem alterar o código existente.
+
+Classes/métodos atualmente suportados:
+
+- `Mutex#lock`, `Mutex#unlock`e `Mutex#sleep`
+- `ConditionVariable#wait`
+- `Queue#pop` e `SizedQueue#push`
+- `Thread#join`
+- `Kernel#sleep`
+- `IO#wait`, `IO#read`, `IO#write` e métodos correlatos (ex.: `#wait_readable`, `#gets`, `#puts` etc.).
+- `IO#select` *não é suportado*.
+
+O ponto de entrada atual para concorrência é `Fiber.schedule {...}` no entanto, está sujeito a alterações no momento em que o Ruby 3 for lançado.
+
+Atualmente, existe um agendador de teste disponível em [`Async::Scheduler`](https://github.com/socketry/async/pull/56). Veja [`doc/scheduler.md`](https://github.com/ruby/ruby/blob/master/doc/scheduler.md) para mais detalhes. [Feature #16786]
+
+**cuidado**: Este recurso é fortemente experimental. O nome e o recurso serão alterados na próxima versão de prévia.
+
+## Outros novos recursos notáveis
+
+* A instrução de atribuição para a direita foi adicionada.
+
+  ``` ruby
+  fib(10) => x
+  p x #=> 55
+  ```
+
+* A definição de método sem a keyword _end_ foi adicionada.
+
+  ``` ruby
+  def square(x) = x * x
+  ```
+
+* Find pattern foi adicionada.
+
+  ``` ruby
+  case ["a", 1, "b", "c", 2, "d", "e", "f", 3]
+  in [*pre, String => x, String => y, *post]
+    p pre  #=> ["a", 1]
+    p x    #=> "b"
+    p y    #=> "c"
+    p post #=> [2, "d", "e", "f", 3]
+  end
+  ```
+
+* `Hash#except` agora é nativo.
+
+  ``` ruby
+  h = { a: 1, b: 2, c: 3 }
+  p h.except(:a) #=> {:b=>2, :c=>3}
+  ```
+
+* A visualização da memória é adicionada como um recurso experimental
+
+    * Este é um novo conjunto C-API para trocar uma área de memória bruta, como uma matriz numérica e uma imagem de bitmap, entre bibliotecas de extensão. As bibliotecas de extensão também podem compartilhar os metadados da área de memória que consiste na forma, no formato do elemento e assim por diante. Usando esses tipos de metadados, as bibliotecas de extensão podem compartilhar até mesmo uma matriz multidimensional de forma adequada. Este recurso é projetado com referência ao protocolo de buffer do Python.
+
+## Melhorias de desempenho
+
+* Muitas melhorias foram implementadas no MJIT. Veja NEWS em detalhes.
+
+## Outras mudanças notáveis desde 2.7
+
+* Os argumentos de palavra-chave são separados de outros argumentos.
+  * Em princípio, códigos que imprimem um aviso no Ruby 2.7 não funciona. Veja o [documento](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) em detalhe.
+  * A propósito, o encaminhamento de argumentos agora suporta argumentos principais.
+
+    ``` ruby
+    def method_missing(meth, ...)
+      send(:"do_#{ meth }", ...)
+    end
+    ```
+
+* O recurso de `$SAFE` foi completamente removido; agora é uma variável global normal.
+
+* A ordem de backtrace foi revertida em Ruby 2.5, mas foi cancelada. Agora ele se comporta como Ruby 2.4; uma mensagem de erro e o número da linha onde ocorre a exceção são impressos primeiro e seus chamadores são impressos posteriormente.
+
+* Algumas bibliotecas padrão são atualizadas.
+  * RubyGems 3.2.0.rc.1
+  * Bundler 2.2.0.rc.1
+  * IRB 1.2.6
+  * Reline 0.1.5
+
+* As seguintes bibliotecas não são mais gem padrão.
+  Instale as gems correspondentes para usar esses recursos.
+  * net-telnet
+  * xmlrpc
+
+* Promove gems padrão para gems nativas.
+  * rexml
+  * rss
+
+* Promova stdlib para gem padrão. As seguintes gems padrão foram publicadas em rubygems.org
+  * abbrev
+  * base64
+  * English
+  * erb
+  * find
+  * io-nonblock
+  * io-wait
+  * net-ftp
+  * net-http
+  * net-imap
+  * net-protocol
+  * nkf
+  * open-uri
+  * optparse
+  * resolv
+  * resolv-replace
+  * rinda
+  * securerandom
+  * set
+  * shellwords
+  * tempfile
+  * time
+  * tmpdir
+  * tsort
+  * weakref
+
+Veja [NEWS](https://github.com/ruby/ruby/blob/v3_0_0_preview1/NEWS.md)
+ou [commit logs](https://github.com/ruby/ruby/compare/v2_7_0...v3_0_0_preview1)
+para mais detalhes.
+
+{% assign release = site.data.releases | where: "version", "3.0.0-preview1" | first %}
+
+Com essas mudanças, [{{ release.stats.files_changed }} arquivos alterados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} deleções(-)](https://github.com/ruby/ruby/compare/v2_7_0...v3_0_0_preview1)
+desde Ruby 2.7.0!
+
+Por favor, experimente Ruby 3.0.0-preview1 e nos dê qualquer feedback!
+
+## Download
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Trailer de 3.0.0-preview2
+
+Planejamos incluir ["type-profiler"](https://github.com/mame/ruby-type-profiler) que é um recurso de análise de tipo estático. Fique ligado!
+
+## O que é Ruby
+
+Ruby foi desenvolvido pela primeira vez por Matz (Yukihiro Matsumoto) em 1993,
+e agora é desenvolvido como Open Source. Ele roda em várias plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.

--- a/pt_br/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
+++ b/pt_br/news/_posts/2020-09-29-http-request-smuggling-cve-2020-25613.md
@@ -1,0 +1,32 @@
+---
+layout: news_post
+title: "CVE-2020-25613: Potencial Vulnerabilidade de Smuggling de Requisições HTTP no WEBrick"
+author: "mame"
+translator: "jcserracampos"
+date: 2020-09-29 06:30:00 +0000
+tags: security
+lang: pt_br
+---
+
+Uma potencial vulnerabilidade de __smuggling__ de requisições HTTP no WEBrick foi reportada. Essa vulnerabilidade recebeu o identificador CVE [CVE-2020-25613](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25613). Nós recomendamos fortemente que atualize a gem webrick.
+
+## Detalhes
+
+WEBrick era muito tolerante contra um cabeçalho __Transfer-Encoding__ inválido. Isso pode levar interpretações inconsistentes entre WEBrick e alguns servidores de proxy HTTP, o que pode poermite que uma pessoa atacante "contrabandeie" uma requisição. Veja [CWE-444](https://cwe.mitre.org/data/definitions/444.html) em detalhes.
+
+Por favor, atualiaze a gem webrick para a versão 1.6.1 ou superior. Você pode usar `gem update webrick` para atualizá-la. Se você está usando bundle, por favor, adicione gem `"webrick", ">= 1.6.1"` ao seu `Gemfile`.
+
+## Versões afetadas
+
+* webrick gem 1.6.0 ou inferior
+* versões empacotadas de webrick no ruby 2.7.1 ou inferior
+* versões empacotadas de webrick no ruby 2.6.6 ou inferior
+* versões empacotadas de webrick no ruby 2.5.8 ou inferior
+
+## Créditos
+
+Agradecimentos a [piao](https://hackerone.com/piao) por ter descoberto este problema.
+
+## Histórico
+
+* Originalmente publicado em 2020-09-29 06:30:00 (UTC)

--- a/pt_br/news/_posts/2020-10-02-ruby-2-7-2-released.md
+++ b/pt_br/news/_posts/2020-10-02-ruby-2-7-2-released.md
@@ -1,0 +1,59 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.7.2"
+author: "nagachika"
+translator: "jcserracampos"
+date: 2020-10-02 11:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.7.2 foi lançado.
+
+Esta versão contém incompatibilidade intencional. Alertas de depreciação estão desativadas por padrão no 2.7.2 em diante.
+Você pode ativar esses alertas de depreciação especificando as opções -w ou -W:deprecated na linha de comando.
+Por favor, veja os tópicos abaixo para detalhes.
+
+* [Feature #17000 2.7.2 turns off deprecation warnings by default](https://bugs.ruby-lang.org/issues/17000)
+* [Feature #16345 Don't emit deprecation warnings by default.](https://bugs.ruby-lang.org/issues/16345)
+
+Esta versão contém a nova versão de webrick com uma correção de seguração descrita neste artigo.
+
+* [CVE-2020-25613: Potencial Vulnerabilidade de Smuggling de Requisições HTTP no WEBrick](/pt_br/news/2020/09/29/http-request-smuggling-cve-2020-25613/)
+
+Veja [commit logs](https://github.com/ruby/ruby/compare/v2_7_1...v2_7_2) para outras alterações.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "2.7.2" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário de Versão
+
+Obrigado às várias pessoas que fizeram commits, pessoas desenvolvedoras e usuárias que informaram bugs e contribuíram para que esta versão fosse possível.

--- a/pt_br/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md
+++ b/pt_br/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md
@@ -1,0 +1,35 @@
+---
+layout: news_post
+title: "CVE-2021-33621: HTTP response splitting na CGI"
+author: "mame"
+translator: "guicruzzs"
+date: 2022-11-22 02:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Nós lançamos as versões da gem cgi 0.3.5, 0.2.2, e 0.1.0.2 que possuem uma correção de segurança para uma vulnerabilidade de HTTP response splitting.
+Essa vulnerabilidade foi atribuída ao identificador [CVE-2021-33621](https://www.cve.org/CVERecord?id=CVE-2021-33621).
+
+## Detalhes
+
+Se uma aplicação que gera respostas HTTP usando a gem cgi com uma entrada de dados não confiável do usuário, um atacante pode explorá-la injetando um body e/ou header malicioso na resposta HTTP.
+
+Também, os conteúdos de um objeto `CGI::Cookie` não eram verificados apropriadamente. Se uma aplicação cria um objeto `CGI::Cookie` baseado nos dados de entrada do usuário, um atacante pode explorá-lo para injetar atributos inválidos no cabeçalho `Set-Cookie`. Nós achamos tais aplicações indesejadas, mas incluímos uma alteração para verificar os argumentos em `CGI::Cookie#initialize` preventivamente.
+
+Por favor atualize a gem cgi para as versões 0.3.5, 0.2.2, e 0.1.0.2, ou maiores. Você pode usar `gem update cgi` para atualizá-la.
+Se você está usando o bundler, por favor adicione `gem "cgi", ">= 0.3.5"` ao seu `Gemfile`.
+
+## Versões afetadas
+
+* gem cgi 0.3.3 ou anteriores
+* gem cgi 0.2.1 ou anteriores
+* gem cgi 0.1.1 ou 0.1.0.1 ou 0.1.0
+
+## Créditos
+
+Obrigado ao [Hiroshi Tokumaru](https://hackerone.com/htokumaru?type=user) por descobrir essa issue.
+
+## Histórico
+
+* Originalmente publicado em 2022-11-22 02:00:00 (UTC)

--- a/pt_br/news/_posts/2022-11-24-ruby-2-7-7-released.md
+++ b/pt_br/news/_posts/2022-11-24-ruby-2-7-7-released.md
@@ -1,0 +1,55 @@
+---
+layout: news_post
+title: "Lançado Ruby 2.7.7"
+author: "usa"
+translator: "guicruzzs"
+date: 2022-11-24 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 2.7.7 foi lançado.
+
+Essa release inclui uma correção de segurança
+Por favor verifique os tópicos abaixo para maiores detalhes.
+
+* [CVE-2021-33621: HTTP response splitting na CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
+
+Essa release também inclui algumas correções de problemas do build. Elas não devem afetar a compatibilidade com versões anteriores.
+Veja os [logs de commit](https://github.com/ruby/ruby/compare/v2_7_6...v2_7_7) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "2.7.7" | first %}
+
+* <{{ release.url.bz2 }}>
+
+      SIZE: {{ release.size.bz2 }}
+      SHA1: {{ release.sha1.bz2 }}
+      SHA256: {{ release.sha256.bz2 }}
+      SHA512: {{ release.sha512.bz2 }}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário da Release
+
+Muitos committers, desenvolvedores e usuários que forneceram bug reports ajudaram-nos a fazer esta release.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2022-11-24-ruby-3-0-5-released.md
+++ b/pt_br/news/_posts/2022-11-24-ruby-3-0-5-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Lançado Ruby 3.0.5"
+author: "usa"
+translator: "guicruzzs"
+date: 2022-11-24 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 3.0.5 foi lançado.
+
+Essa release inclui uma correção de segurança.
+Por favor verifique os tópicos abaixo para maiores detalhes.
+
+* [CVE-2021-33621: HTTP response splitting na CGI]({%link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
+
+Essa release também inclui algumas correções de bug.
+Veja o [log de commits](https://github.com/ruby/ruby/compare/v3_0_4...v3_0_5) para maiores detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.0.5" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário da Release
+
+Muitos committers, desenvolvedores, e usuários que forneceram bug reports ajudaram-nos a fazer esta release.
+Obrigado por suas contribuições.
+
+A manutenção do Ruby 3.0, incluindo esta release, é baseada no "Acordo para a versão estável do Ruby" da Associação Ruby.

--- a/pt_br/news/_posts/2022-11-24-ruby-3-1-3-released.md
+++ b/pt_br/news/_posts/2022-11-24-ruby-3-1-3-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Lançado Ruby 3.1.3"
+author: "nagachika"
+translator: "guicruzzs"
+date: 2022-11-24 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 3.1.3 foi lançado.
+
+Essa release inclui correções de segurança.
+Por favor, verifique os tópicos abaixo para maiores detalhes.
+
+* [CVE-2021-33621: HTTP response splitting na CGI]({% link en/news/_posts/2022-11-22-http-response-splitting-in-cgi-cve-2021-33621.md %})
+
+Essa release também inclui uma correção para falhas no build com Xcode 14 e macOS 13 (Ventura).
+Veja [o ticket relacionado](https://bugs.ruby-lang.org/issues/18912) para mais detalhes.
+
+Veja os [logs de commit](https://github.com/ruby/ruby/compare/v3_1_2...v3_1_3) para maiores detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.1.3" | first %}
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário da Release
+
+Muitos committers, desenvolvedores, e usuários que forneceram bug reports ajudaram-nos a fazer esta release.
+Obrigado por suas contribuições.

--- a/pt_br/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
+++ b/pt_br/news/_posts/2022-12-06-ruby-3-2-0-rc1-released.md
@@ -1,0 +1,496 @@
+---
+layout: news_post
+title: "Lançado Ruby 3.2.0 RC 1"
+author: "naruse"
+translator: "guicruzzs"
+date: 2022-12-06 00:00:00 +0000
+lang: pt_br
+---
+
+{% assign release = site.data.releases | where: "version", "3.2.0-rc1" | first %}
+
+Estamos contentes em anunciar o lançamento do Ruby {{ release.version }}. Ruby 3.2 adds many features and performance improvements.
+
+
+## Suporte a WebAssembly com WASI
+
+Esse é um port inicial de suporte a WebAssembly com WASI. Isso permite um binário CRuby ficar disponível num navegador Web, num ambiente Serverless Edge, ou em outros tipos de WebAssembly/WASI embedders. Atualmente esse port passa suítes de teste básica e bootstrap não utilizando a Thread API.
+
+![](https://i.imgur.com/opCgKy2.png)
+
+### Contexto
+
+[WebAssembly (Wasm)](https://webassembly.org/) foi originalmente introduzido para rodar programas seguramente e rápido em navegadores web. Mas seu objetivo - rodar programas eficientemente com segurança em ambiente variado - é desejado há muito tempo não somente para web, mas também para aplicações em geral.
+
+[WASI (The WebAssembly System Interface)](https://wasi.dev/) é projetado para tais casos de uso. Embora tais aplicações precisem  se comunicar com os sistemas operacionais, WebAssembly roda numa máquina virtual que não possui uma interface com o sistema. WASI padroniza isso.
+
+O suporte a WebAssembly/WASI em Ruby pretende alavancar esses projetos. Isso permite aos desenvolvedores Ruby a escreverem aplicações que rodam em tais plataformas.
+
+### Caso de uso
+
+Esse suporte encoraja desenvolvedores a utilizarem CRuby em um ambiente WebAssembly. Um exemplo de caso de uso é o suporte a CRuby do [TryRuby playground](https://try.ruby-lang.org/playground/). Agora você pode testar o CRuby original no seu navegador web.
+
+### Questões técnicas
+
+O WASI e o WebAssembly de hoje estão com algumas funcionalidades faltando para implementar Fiber, exceção, e GC porque ainda estão evoluindo, e também por questões de segurança. Então o CRuby preenche essa lacuna através do Asyncify, que é uma técnica de transformação binária para controlar a execução na userland.
+
+Além disso, nós construímos [um VFS(sistema de arquivo virtual) em cima do WASI](https://github.com/kateinoigakukun/wasi-vfs/wiki/Getting-Started-with-CRuby) assim nós podemos facilmente empacotar aplicações Ruby em um único arquivo .wasm. Isso torna a distribuição de aplicações Ruby um pouco mais fácil.
+
+### Links relacionados
+
+* [Add WASI based WebAssembly support #5407](https://github.com/ruby/ruby/pull/5407)
+* [An Update on WebAssembly/WASI Support in Ruby](https://itnext.io/final-report-webassembly-wasi-support-in-ruby-4aface7d90c9)
+
+## Melhorias em Regexp contra ReDoS
+
+Se sabe que o tempo de verificação de uma Regexp pode ser inesperadamente longo. Se seu código tenta verificar uma Regexp possivelmente ineficiente contra um input não confiável, um invasor pode explorar isso para uma eficiente Denial of Service (então chamada Regular expression DoS, ou ReDoS).
+
+Nós introduzimos duas melhoria que significantemente mitigam ReDoS.
+
+### Algoritmo de verificação de Regexp melhorado
+
+Desde o Ruby 3.2, o algoritmo de verificação de Regexp tem sido grandemente melhorado usando a técnica de memoization.
+
+```
+# Isso leva 10 seg. no Ruby 3.1, e 0.003 seg. no Ruby 3.2
+
+/^a*b?a*$/ =~ "a" * 50000 + "x"
+```
+
+![](https://cache.ruby-lang.org/pub/media/ruby320_regex_1.png)
+![](https://cache.ruby-lang.org/pub/media/ruby320_regex_2.png)
+
+O algoritmo melhorado de verificação permite que a maioria das verificações de Regexp (cerca de 90% em nossos experimentos) sejam completadas em tempo linear.
+
+(Para usuários da prévia: Essa otimização pode consumir memória proporcionalmente à entrada pra cada verificação. Nós esperamos que nenhum problema prático surja porque essa alocação de memória é normalmente atrasada, e uma Regexp normalmente deveria consumir no máximo 10 vezes mais que o comprimento do input. Se você ficar sem memória ao realizar verificações de Regexps numa aplicação do mundo real, por favor nos relate.)
+
+A proposta original é <https://bugs.ruby-lang.org/issues/19104>
+
+### Timeout de Regexp
+
+A otimização acima não pode ser aplicada a alguns tipos de expressões regulares, tais como aquelas que incluem funcionalidades avançadas (e.g., back-references ou look-around), ou com um grande número fixado de repetições. Como medida de fallback, uma funcionalidade de timeout na verificação de Regexp também é introduzida.
+
+```ruby
+Regexp.timeout = 1.0
+
+/^a*b?a*()\1$/ =~ "a" * 50000 + "x"
+#=> Regexp::TimeoutError é devolvido em um segundo
+```
+
+Perceba que `Regexp.timeout` é uma configuração global. Se deseja usar uma configuração diferente de timeout pra alguma Regexp em especial, você pode usar a chave `timeout` no `Regexp.new`.
+
+```ruby
+Regexp.timeout = 1.0
+
+# Essa regexp não possui timeout
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
+
+long_time_re =~ "a" * 50000 + "x" # nunca é interrompida
+```
+
+A proposta original é <https://bugs.ruby-lang.org/issues/17837>.
+
+## Outras Novas Funcionalidades Notórias
+
+### SyntaxSuggest
+
+* A funcionalidade de `syntax_suggest` (anteriormente `dead_end`) está integrada ao Ruby. Isso ajuda você a encontrar a posição dos erros tais como `end`s faltantes ou supérfluos, pra te trazer de volta ao seu caminho mais rapidamente, assim com o exemplo a seguir:
+
+  ```
+  Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
+
+    1  class Dog
+  > 2    defbark
+  > 3    end
+    4  end
+  ```
+
+  [[Feature #18159]]
+
+
+### ErrorHighlight
+
+* Agora ele aponta aos argumentos relevantes para TypeError e ArgumentError
+
+```
+test.rb:2:in `+': nil can't be coerced into Integer (TypeError)
+
+sum = ary[0] + ary[1]
+               ^^^^^^
+```
+
+### Linguagem
+
+* Argumentos rest anônimos e palavra-chave rest agora podem ser passados como
+  argumentos, em vez de serem usados apenas em parâmetros do método.
+  [[Feature #18351]]
+
+    ```ruby
+    def foo(*)
+      bar(*)
+    end
+    def baz(**)
+      quux(**)
+    end
+    ```
+
+* Uma proc que aceita um único argumento posicional e palavras-chave não
+  irá mais autosplat. [[Bug #18633]]
+
+  ```ruby
+  proc{|a, **k| a}.call([1, 2])
+  # Ruby 3.1 e antes
+  # => 1
+  # Ruby 3.2 e depois
+  # => [1, 2]
+  ```
+
+* A ordem de avaliação de atribuição da constante para constantes
+  definidas em objetos explícitos tornou-se consistente com a ordem de avaliação
+  de atribuição de atributo único. Com esse código:
+
+    ```ruby
+    foo::BAR = baz
+    ```
+
+  `foo` agora é chamado antes de `baz`. Similarmente, para múltiplas atribuições
+  para constantes a ordem esquerda-para-direita é usada. Com esse código:
+
+    ```ruby
+      foo1::BAR1, foo2::BAR2 = baz1, baz2
+    ```
+
+  A seguinte ordem de avaliação agora é utilizada:
+
+  1. `foo1`
+  2. `foo2`
+  3. `baz1`
+  4. `baz2`
+
+  [[Bug #15928]]
+
+* O find pattern não é mais experimental.
+  [[Feature #18585]]
+
+* Métodos recebendo um parâmetro rest (como `*args`) e desejando delegar argumentos
+  de palavra-chave através de `foo(*args)` devem agora serem marcados com `ruby2_keywords`
+  (se ainda não for o caso). Em outras palavras, todos métodos que desejam delegar
+  argumentos de palavras-chave através do `*args` devem agora serem marcados com
+  `ruby2_keywords`, sem exceção. Isso fará mais fácil a transição para outras formas
+  de delegação uma vez que uma biblioteca requira Ruby 3+. Anteriormente, a flag
+  `ruby2_keywords` foi mantida se o método recebedor levava `*args`, mas isso era
+  um bug de inconsistência. Uma boa técnica pra encontrar potenciais `ruby2_keywords`
+  faltantes é rodar a suíte de testes, encontrar o último método que deve receber
+  argumentos para cada lugar onte a suíte de teste falha, e usar `puts nil, caller, nil`
+  lá. Então verifique que cada método/bloco da cadeia de chamada que deve delegar
+  palavras-chave está corretamente marcado com `ruby2_keywords`. [[Bug #18625]] [[Bug #16466]]
+
+    ```ruby
+    def target(**kw)
+    end
+
+    # Acidentalmente funcionou sem ruby2_keywords no Ruby 2.7-3.1, ruby2_keywords
+    # é necessário em 3.2+. Assim como (*args, **kwargs) ou (...) seriam necessários
+    # em #foo e #bar quando migrar de ruby2_keywords.
+    ruby2_keywords def bar(*args)
+      target(*args)
+    end
+
+    ruby2_keywords def foo(*args)
+      bar(*args)
+    end
+
+    foo(k: 1)
+    ```
+
+## Melhorias de desempenho
+
+### YJIT
+
+* YJIT agora suporta x86-64 e arm64/aarch64 CPUs no Linux, MacOS, BSD e outras plataformas UNIX.
+    * Essa release trás suporte para os processadores Mac M1/M2, AWS Graviton e Raspberry Pi 4 ARM64.
+* O build do YJIT agora requer Rust 1.58.0+. [[Feature #18481]]
+    * Para garantir que CRuby seja buildado com YJIT, por favor instale rustc >= 1.58.0 e
+      rode `./configure` com `--enable-yjit`.
+    * Por favor entre em contato com o time do YJITP caso tenha qualquer problema.
+* Memória física para o código JIT é alocada de forma lazy. Diferente do Ruby 3.1,
+    o RSS de um processo Ruby é minimizado por conta das páginas de memória virtual
+    alocadas por `--yjit-exec-mem-size` que não serão mapeadas para páginas de memória
+    física até que sejam utilizadas pelo código JIT.
+  * Introduz GC(Garbage collector) que libera todas as páginas de código quando o
+    consumo de memória do código JIT atinge `--yjit-exec-mem-size`.
+    * `RubyVM::YJIT.runtime_stats` retorna métricas do GC além das chaves existentes
+    em `inline_code_size` e `outlined_code_size`:
+    `code_gc_count`, `live_page_count`, `freed_page_count`, e `freed_code_size`.
+* A maioria das estastísticas produzidas por RubyVM::YJIT.runtime_stats estão agora disponíveis nas release builds.
+    * Simplesmente rode ruby com `--yjit-stats` para calcular e obter estatísticas
+    (fica sujeito a sobrecarga de tempo de execução).
+* YJIT agora está otimizado para tirar vantagem de formatos de objetos. [[Feature #18776]]
+* Tira vantagem de invalidação de constantes de forma mais granular para invalidar menos código ao definir novas constantes. [[Feature #18589]]
+
+### MJIT
+
+* O compilador MJIT está reimplementado em Ruby como uma bilioteca padrão `mjit`.
+* O compilador MJIT é executado sob um processo fork ao invés de
+  fazer isso em uma thread nativa chamada worker MJIT. [[Feature #18968]]
+    * Como resultado, Microsoft Visual Studio (MSWIN) não é mais suportado.
+* MinGW não é mais suportado. [[Feature #18824]]
+* Renomeado `--mjit-min-calls` para `--mjit-call-threshold`.
+* Mudado valor padrão `--mjit-max-cache` de 10000 para 100.
+
+### PubGrub
+
+* Bundler 2.4 agora utiliza o resolvedor de versão [PubGrub](https://github.com/jhawthorn/pub_grub) ao invés de [Molinillo](https://github.com/CocoaPods/Molinillo).
+
+  * PubGrub é a próxima geração de algoritmo resolvedor utilizado pelo gerenciador de pacote `pub` da linguagem de programação Dart.
+  * Você pode obter um resultado de resolução de versões diferentes depois dessa mudança. Por favor relate tais casos para [RubyGems/Bundler issues](https://github.com/rubygems/rubygems/issues)
+
+* RubyGems ainda utiliza o resolvedor Molinillo no Ruby 3.2. Nós planejamos trocá-lo pelo PubGrub no futuro.
+
+## Other notable changes since 3.1
+
+* Hash
+    * Hash#shift agora sempre retorna nil se o hash está
+      vazio, ao invés de retornar o valor padrão ou chamar
+      a proc padrão. [[Bug #16908]]
+
+* MatchData
+    * MatchData#byteoffset foi adicionado. [[Feature #13110]]
+
+* Module
+    * Module.used_refinements foi adicionado. [[Feature #14332]]
+    * Module#refinements foi adicionado. [[Feature #12737]]
+    * Module#const_added foi adicionado. [[Feature #17881]]
+
+* Proc
+    * Proc#dup retorna uma instância da subclasse. [[Bug #17545]]
+    * Proc#parameters agora aceita a palavra-chave lambda. [[Feature #15357]]
+
+* Refinement
+    * Refinement#refined_class foi adicionado. [[Feature #12737]]
+
+* RubyVM::AbstractSyntaxTree
+    * Adicionada opção `error_tolerant` para `parse`, `parse_file` e `of`. [[Feature #19013]]
+
+* Set
+    * Set agora está disponível como uma classe builtin sem necessidade de `require "set"`. [[Feature #16989]]
+      Ela está atualmente autoloaded via constante `Set` ou chamada em `Enumerable#to_set`.
+
+* String
+    * String#byteindex e String#byterindex foram adicionados. [[Feature #13110]]
+    * Atualizado Unicode para Versão 15.0.0 e Emoji Versão 15.0. [[Feature #18639]]
+      (também aplicado para Regexp)
+    * String#bytesplice foi adicionado. [[Feature #18598]]
+
+* Struct
+    * Uma classe Struct pode também ser inicializada com argumentos de palavras-chave
+      sem `keyword_init: true` em `Struct.new` [[Feature #16806]]
+
+## Issues de compatibilidade
+
+Nota: Excluindo correção de bugs de funcionalidades.
+
+### Constantes removidas
+
+As seguintes constantes obsoletas foram removidas.
+
+* `Fixnum` e `Bignum` [[Feature #12005]]
+* `Random::DEFAULT` [[Feature #17351]]
+* `Struct::Group`
+* `Struct::Passwd`
+
+### Métodos removidos
+
+Os seguintes métodos obsoletos foram removidos.
+
+* `Dir.exists?` [[Feature #17391]]
+* `File.exists?` [[Feature #17391]]
+* `Kernel#=~` [[Feature #15231]]
+* `Kernel#taint`, `Kernel#untaint`, `Kernel#tainted?`
+  [[Feature #16131]]
+* `Kernel#trust`, `Kernel#untrust`, `Kernel#untrusted?`
+  [[Feature #16131]]
+
+### Não empacota mais código fonte de terceiros
+
+* Nós não empacotamos mais código fonte de terceiro como `libyaml`, `libffi`.
+
+    * O código fonte do libyaml foi removido do psych. Você pode precisar instalar
+    `libyaml-dev` na plataforma Ubuntu/Debian. O nome do pacote é diferente pra cada
+    plataforma.
+
+    * O código fonte empacotado do libffi também foi removido do `fiddle`
+
+* Psych e fiddle suportaram builds estáticos com versões específicas dos fontes de libyaml e libffi. Você pode rodar o build do psych com libyaml-0.2.5 assim:
+
+    ```bash
+    $ ./configure --with-libyaml-source-dir=/path/to/libyaml-0.2.5
+    ```
+
+    E você pode rodar o build do fiddle com libffi-3.4.4 assim:
+
+    ```bash
+    $ ./configure --with-libffi-source-dir=/path/to/libffi-3.4.4
+    ```
+
+  [[Feature #18571]]
+
+## Atualizações da API de C
+
+### APIs de C atualizadas
+
+As seguintes APIs foram atualizadas.
+
+* Atualização do PRNG
+  * `rb_random_interface_t` atualizado e versionado.
+    Bibliotecas de extensão que usam essa interface e buildadas para versões antigas.
+    E também a função `init_int32` precisa ser definida.
+
+### APIs de C removidas
+
+As seguintes APIs se tornaram obsoletas e foram removidas.
+
+* Variável `rb_cData`.
+* Funções "taintedness" e "trustedness". [[Feature #16131]]
+
+## Atualizações da biblioteca padrão
+
+*   As seguintes gems padrão foram atualizadas.
+    * RubyGems 3.4.0.dev
+    * benchmark 0.2.1
+    * bigdecimal 3.1.3
+    * bundler 2.4.0.dev
+    * cgi 0.3.6
+    * date 3.3.0
+    * delegate 0.3.0
+    * did_you_mean 1.6.2
+    * digest 3.1.1
+    * drb 2.1.1
+    * erb 4.0.2
+    * error_highlight 0.5.1
+    * etc 1.4.1
+    * fcntl 1.0.2
+    * fiddle 1.1.1
+    * fileutils 1.7.0
+    * forwardable 1.3.3
+    * getoptlong 0.2.0
+    * io-console 0.5.11
+    * io-nonblock 0.2.0
+    * io-wait 0.3.0.pre
+    * ipaddr 1.2.5
+    * irb 1.5.1
+    * json 2.6.2
+    * logger 1.5.2
+    * mutex_m 0.1.2
+    * net-http 0.3.1
+    * net-protocol 0.2.0
+    * nkf 0.1.2
+    * open-uri 0.3.0
+    * openssl 3.1.0.pre
+    * optparse 0.3.0
+    * ostruct 0.5.5
+    * pathname 0.2.1
+    * pp 0.4.0
+    * pstore 0.1.2
+    * psych 5.0.0
+    * racc 1.6.1
+    * rdoc 6.5.0
+    * reline 0.3.1
+    * resolv 0.2.2
+    * securerandom 0.2.1
+    * set 1.0.3
+    * stringio 3.0.3
+    * syntax_suggest 1.0.1
+    * timeout 0.3.1
+    * tmpdir 0.1.3
+    * tsort 0.1.1
+    * un 0.2.1
+    * uri 0.12.0
+    * win32ole 1.8.9
+    * zlib 3.0.0
+*   As seguintes gems empacotadas foram atualizadas.
+    * minitest 5.16.3
+    * power_assert 2.0.2
+    * test-unit 3.5.5
+    * net-ftp 0.2.0
+    * net-imap 0.3.1
+    * net-pop 0.1.2
+    * net-smtp 0.3.3
+    * rbs 2.8.1
+    * typeprof 0.21.3
+    * debug 1.7.0
+
+Veja [NOVIDADES](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
+ou [commit logs](https://github.com/ruby/ruby/compare/v3_1_0...{{ release.tag }})
+para mais detalhes.
+
+Com estas mudanças, [{{ release.stats.files_changed }} arquivos mudados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} remoções(-)](https://github.com/ruby/ruby/compare/v3_1_0...{{ release.tag }}#file_bucket)
+desde o Ruby 3.1.0!
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## What is Ruby
+
+Ruby foi primeiramente desenvolvido por Matz (Yukihiro Matsumoto) em 1993
+e agora é desenvolvido como Open Source. Ele roda em múltiplas plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.
+
+
+
+[Feature #12005]: https://bugs.ruby-lang.org/issues/12005
+[Feature #12655]: https://bugs.ruby-lang.org/issues/12655
+[Feature #12737]: https://bugs.ruby-lang.org/issues/12737
+[Feature #13110]: https://bugs.ruby-lang.org/issues/13110
+[Feature #14332]: https://bugs.ruby-lang.org/issues/14332
+[Feature #15231]: https://bugs.ruby-lang.org/issues/15231
+[Feature #15357]: https://bugs.ruby-lang.org/issues/15357
+[Bug #15928]:     https://bugs.ruby-lang.org/issues/15928
+[Feature #16131]: https://bugs.ruby-lang.org/issues/16131
+[Bug #16466]:     https://bugs.ruby-lang.org/issues/16466
+[Feature #16806]: https://bugs.ruby-lang.org/issues/16806
+[Bug #16889]:     https://bugs.ruby-lang.org/issues/16889
+[Bug #16908]:     https://bugs.ruby-lang.org/issues/16908
+[Feature #16989]: https://bugs.ruby-lang.org/issues/16989
+[Feature #17351]: https://bugs.ruby-lang.org/issues/17351
+[Feature #17391]: https://bugs.ruby-lang.org/issues/17391
+[Bug #17545]:     https://bugs.ruby-lang.org/issues/17545
+[Feature #17881]: https://bugs.ruby-lang.org/issues/17881
+[Feature #18639]: https://bugs.ruby-lang.org/issues/18639
+[Feature #18159]: https://bugs.ruby-lang.org/issues/18159
+[Feature #18351]: https://bugs.ruby-lang.org/issues/18351
+[Feature #18481]: https://bugs.ruby-lang.org/issues/18481
+[Bug #18487]:     https://bugs.ruby-lang.org/issues/18487
+[Feature #18571]: https://bugs.ruby-lang.org/issues/18571
+[Feature #18585]: https://bugs.ruby-lang.org/issues/18585
+[Feature #18589]: https://bugs.ruby-lang.org/issues/18589
+[Feature #18598]: https://bugs.ruby-lang.org/issues/18598
+[Bug #18625]:     https://bugs.ruby-lang.org/issues/18625
+[Bug #18633]:     https://bugs.ruby-lang.org/issues/18633
+[Feature #18685]: https://bugs.ruby-lang.org/issues/18685
+[Feature #18776]: https://bugs.ruby-lang.org/issues/18776
+[Bug #18782]:     https://bugs.ruby-lang.org/issues/18782
+[Feature #18788]: https://bugs.ruby-lang.org/issues/18788
+[Feature #18809]: https://bugs.ruby-lang.org/issues/18809
+[Bug #19100]:     https://bugs.ruby-lang.org/issues/19100
+[Bug #19013]:     https://bugs.ruby-lang.org/issues/19013

--- a/pt_br/news/_posts/2022-12-25-ruby-3-2-0-released.md
+++ b/pt_br/news/_posts/2022-12-25-ruby-3-2-0-released.md
@@ -1,0 +1,672 @@
+---
+layout: news_post
+title: "Lançado Ruby 3.2.0"
+author: "naruse"
+translator: "guicruzzs"
+date: 2022-12-25 00:00:00 +0000
+lang: pt_br
+---
+
+{% assign release = site.data.releases | where: "version", "3.2.0" | first %}
+
+Estamos contentes em anunciar o lançamento do Ruby {{ release.version }}. Ruby 3.2 adiciona muitas funcionalidades e melhorias de desempenho.
+
+## Suporte a WebAssembly com WASI
+
+Esse é um port inicial de suporte a WebAssembly com WASI. Isso permite um binário CRuby ficar disponível num navegador Web, num ambiente Serverless Edge, ou em outros tipos de WebAssembly/WASI embedders. Atualmente esse port passa suítes de teste básica e bootstrap não utilizando a Thread API.
+
+![](https://i.imgur.com/opCgKy2.png)
+
+### Contexto
+
+[WebAssembly (Wasm)](https://webassembly.org/) foi originalmente introduzido para rodar programas seguramente e rápido em navegadores web. Mas seu objetivo - rodar programas eficientemente com segurança em ambiente variado - é desejado há muito tempo não somente para web, mas também para aplicações em geral.
+
+[WASI (The WebAssembly System Interface)](https://wasi.dev/) é projetado para tais casos de uso. Embora tais aplicações precisem  se comunicar com os sistemas operacionais, WebAssembly roda numa máquina virtual que não possui uma interface com o sistema. WASI padroniza isso.
+
+O suporte a WebAssembly/WASI em Ruby pretende alavancar esses projetos. Isso permite aos desenvolvedores Ruby a escreverem aplicações que rodam em tais plataformas.
+
+### Caso de uso
+
+Esse suporte encoraja desenvolvedores a utilizarem CRuby em um ambiente WebAssembly. Um exemplo de caso de uso é o suporte a CRuby do [TryRuby playground](https://try.ruby-lang.org/playground/). Agora você pode testar o CRuby original no seu navegador web.
+
+### Questões técnicas
+
+O WASI e o WebAssembly de hoje estão com algumas funcionalidades faltando para implementar Fiber, exceção, e GC porque ainda estão evoluindo, e também por questões de segurança. Então o CRuby preenche essa lacuna através do Asyncify, que é uma técnica de transformação binária para controlar a execução na userland.
+
+Além disso, nós construímos [um VFS(sistema de arquivo virtual) em cima do WASI](https://github.com/kateinoigakukun/wasi-vfs/wiki/Getting-Started-with-CRuby) assim nós podemos facilmente empacotar aplicações Ruby em um único arquivo .wasm. Isso torna a distribuição de aplicações Ruby um pouco mais fácil.
+
+### Links relacionados
+
+* [Add WASI based WebAssembly support #5407](https://github.com/ruby/ruby/pull/5407)
+* [An Update on WebAssembly/WASI Support in Ruby](https://itnext.io/final-report-webassembly-wasi-support-in-ruby-4aface7d90c9)
+
+
+## YJIT em Produção
+
+![](https://i.imgur.com/X9ulfac.png)
+
+* YJIT não é mais experimental
+    * Foi testado em cargas de produção por um ano e provou ser bastante estável.
+* YJIT agora suporta x86-64 e arm64/aarch64 CPUs no Linux, MacOS, BSD e outras plataformas UNIX.
+    * Essa release traz suporte para Apple M1/M2, AWS Graviton, Raspberry Pi 4 e mais.
+* O build do YJIT agora requer Rust 1.58.0+. [[Feature #18481]]
+    * Para garantir que CRuby seja buildado com YJIT, por favor instale `rustc` >= 1.58.0
+      antes de rodar o script `./configure`.
+    * Por favor entre em contato com o time do YJITP caso tenha qualquer problema.
+* A release 3.2 do YJIT é mais rápida que a 3.1, e tem cerca de 1/3 de sobrecarga de memória.
+  * No geral, YJIT é 41% mais rápido (média geométrica) que o interpretador Ruby em [yjit-bench](https://github.com/Shopify/yjit-bench).
+  * Memória física para o código JIT é alocada de forma lazy. Diferente do Ruby 3.1,
+    o RSS de um processo Ruby é minimizado por conta das páginas de memória virtual
+    alocadas por `--yjit-exec-mem-size` que não serão mapeadas para páginas de memória
+    física até que sejam utilizadas pelo código JIT.
+  * Introduz GC(Garbage collector) que libera todas as páginas de código quando o
+    consumo de memória do código JIT atinge `--yjit-exec-mem-size`.
+  * `RubyVM::YJIT.runtime_stats` retorna métricas do GC além das chaves existentes
+    em `inline_code_size` e `outlined_code_size`:
+    `code_gc_count`, `live_page_count`, `freed_page_count`, e `freed_code_size`.
+* A maioria das estastísticas produzidas por `RubyVM::YJIT.runtime_stats` estão agora disponíveis nas release builds.
+    * Simplesmente rode ruby com `--yjit-stats` para calcular e obter estatísticas
+    (fica sujeito a sobrecarga de tempo de execução).
+* YJIT agora está otimizado para tirar vantagem de formatos de objetos. [[Feature #18776]]
+* Tira vantagem de invalidação de constantes de forma mais granular para invalidar menos código ao definir novas constantes. [[Feature #18589]]
+* O valor padrão de `--yjit-exec-mem-size` é alterado para 64 (MiB).
+* O valor padrão de `--yjit-call-threshold` é alterado para 30.
+
+## Melhorias em Regexp contra ReDoS
+
+Se sabe que o tempo de verificação de uma Regexp pode ser inesperadamente longo. Se seu código tenta verificar uma Regexp possivelmente ineficiente contra um input não confiável, um invasor pode explorar isso para uma eficiente Denial of Service (então chamada Regular expression DoS, ou ReDoS).
+
+Nós introduzimos duas melhoria que significantemente mitigam ReDoS.
+
+### Algoritmo de verificação de Regexp melhorado
+
+Desde o Ruby 3.2, o algoritmo de verificação de Regexp tem sido grandemente melhorado usando a técnica de memoization.
+
+```
+# Isso leva 10 seg. no Ruby 3.1, e 0.003 seg. no Ruby 3.2
+
+/^a*b?a*$/ =~ "a" * 50000 + "x"
+```
+
+![](https://cache.ruby-lang.org/pub/media/ruby320_regex_1.png)
+![](https://cache.ruby-lang.org/pub/media/ruby320_regex_2.png)
+
+O algoritmo melhorado de verificação permite que a maioria das verificações de Regexp (cerca de 90% em nossos experimentos) sejam completadas em tempo linear.
+
+Essa otimização pode consumir memória proporcionalmente à entrada pra cada verificação. Nós esperamos que nenhum problema prático surja porque essa alocação de memória é normalmente atrasada, e uma Regexp normalmente deveria consumir no máximo 10 vezes mais que o comprimento do input. Se você ficar sem memória ao realizar verificações de Regexps numa aplicação do mundo real, por favor nos relate.
+
+A proposta original é <https://bugs.ruby-lang.org/issues/19104>
+
+### Timeout de Regexp
+
+A otimização acima não pode ser aplicada a alguns tipos de expressões regulares, tais como aquelas que incluem funcionalidades avançadas (e.g., back-references ou look-around), ou com um grande número fixado de repetições. Como medida de fallback, uma funcionalidade de timeout na verificação de Regexp também é introduzida.
+
+```ruby
+Regexp.timeout = 1.0
+
+/^a*b?a*()\1$/ =~ "a" * 50000 + "x"
+#=> Regexp::TimeoutError é devolvido em um segundo
+```
+
+Perceba que `Regexp.timeout` é uma configuração global. Se deseja usar uma configuração diferente de timeout pra alguma Regexp em especial, você pode usar a chave `timeout` no `Regexp.new`.
+
+```ruby
+Regexp.timeout = 1.0
+
+# Essa regexp não possui timeout
+long_time_re = Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)
+
+long_time_re =~ "a" * 50000 + "x" # nunca é interrompida
+```
+
+A proposta original é <https://bugs.ruby-lang.org/issues/17837>.
+
+## Outras Novas Funcionalidades Notórias
+
+### SyntaxSuggest
+
+* A funcionalidade de `syntax_suggest` (anteriormente `dead_end`) está integrada ao Ruby. Isso ajuda você a encontrar a posição dos erros tais como `end`s faltantes ou supérfluos, pra te trazer de volta ao seu caminho mais rapidamente, assim com o exemplo a seguir:
+
+  ```
+  Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
+
+    1  class Dog
+  > 2    defbark
+  > 3    end
+    4  end
+  ```
+
+  [[Feature #18159]]
+
+
+### ErrorHighlight
+
+* Agora ele aponta aos argumentos relevantes para TypeError e ArgumentError
+
+```
+test.rb:2:in `+': nil can't be coerced into Integer (TypeError)
+
+sum = ary[0] + ary[1]
+               ^^^^^^
+```
+
+### Linguagem
+
+* Argumentos rest anônimos e palavra-chave rest agora podem ser passados como
+  argumentos, em vez de serem usados apenas em parâmetros do método.
+  [[Feature #18351]]
+
+    ```ruby
+    def foo(*)
+      bar(*)
+    end
+    def baz(**)
+      quux(**)
+    end
+    ```
+
+* Uma proc que aceita um único argumento posicional e palavras-chave não
+  irá mais autosplat. [[Bug #18633]]
+
+  ```ruby
+  proc{|a, **k| a}.call([1, 2])
+  # Ruby 3.1 e antes
+  # => 1
+  # Ruby 3.2 e depois
+  # => [1, 2]
+  ```
+
+* A ordem de avaliação de atribuição da constante para constantes
+  definidas em objetos explícitos tornou-se consistente com a ordem de avaliação
+  de atribuição de atributo único. Com esse código:
+
+    ```ruby
+    foo::BAR = baz
+    ```
+
+  `foo` agora é chamado antes de `baz`. Similarmente, para múltiplas atribuições
+  para constantes a ordem esquerda-para-direita é usada. Com esse código:
+
+    ```ruby
+      foo1::BAR1, foo2::BAR2 = baz1, baz2
+    ```
+
+  A seguinte ordem de avaliação agora é utilizada:
+
+  1. `foo1`
+  2. `foo2`
+  3. `baz1`
+  4. `baz2`
+
+  [[Bug #15928]]
+
+* O find pattern não é mais experimental.
+  [[Feature #18585]]
+
+* Métodos recebendo um parâmetro rest (como `*args`) e desejando delegar argumentos
+  de palavra-chave através de `foo(*args)` devem agora serem marcados com `ruby2_keywords`
+  (se ainda não for o caso). Em outras palavras, todos métodos que desejam delegar
+  argumentos de palavras-chave através do `*args` devem agora serem marcados com
+  `ruby2_keywords`, sem exceção. Isso fará mais fácil a transição para outras formas
+  de delegação uma vez que uma biblioteca requira Ruby 3+. Anteriormente, a flag
+  `ruby2_keywords` foi mantida se o método recebedor levava `*args`, mas isso era
+  um bug de inconsistência. Uma boa técnica pra encontrar potenciais `ruby2_keywords`
+  faltantes é rodar a suíte de testes, encontrar o último método que deve receber
+  argumentos para cada lugar onde a suíte de teste falha, e usar `puts nil, caller, nil`
+  lá. Então verifique que cada método/bloco da cadeia de chamada que deve delegar
+  palavras-chave está corretamente marcado com `ruby2_keywords`. [[Bug #18625]] [[Bug #16466]]
+
+    ```ruby
+    def target(**kw)
+    end
+
+    # Acidentalmente funcionou sem ruby2_keywords no Ruby 2.7-3.1, ruby2_keywords
+    # é necessário em 3.2+. Assim como (*args, **kwargs) ou (...) seriam necessários
+    # em #foo e #bar quando migrar de ruby2_keywords.
+    ruby2_keywords def bar(*args)
+      target(*args)
+    end
+
+    ruby2_keywords def foo(*args)
+      bar(*args)
+    end
+
+    foo(k: 1)
+    ```
+
+## Melhorias de desempenho
+
+### MJIT
+
+* O compilador MJIT está reimplementado em Ruby como `ruby_vm/mjit/compiler`.
+* O compilador MJIT é executado sob um processo fork ao invés de
+  fazer isso em uma thread nativa chamada worker MJIT. [[Feature #18968]]
+    * Como resultado, Microsoft Visual Studio (MSWIN) não é mais suportado.
+* MinGW não é mais suportado. [[Feature #18824]]
+* Renomeado `--mjit-min-calls` para `--mjit-call-threshold`.
+* Mudado valor padrão `--mjit-max-cache` de 10000 para 100.
+
+### PubGrub
+
+* Bundler 2.4 agora utiliza o resolvedor de versão [PubGrub](https://github.com/jhawthorn/pub_grub) ao invés de [Molinillo](https://github.com/CocoaPods/Molinillo).
+
+  * PubGrub é a próxima geração de algoritmo resolvedor utilizado pelo gerenciador de pacote `pub` da linguagem de programação Dart.
+  * Você pode obter um resultado de resolução de versões diferentes depois dessa mudança. Por favor relate tais casos para [RubyGems/Bundler issues](https://github.com/rubygems/rubygems/issues)
+
+* RubyGems ainda utiliza o resolvedor Molinillo no Ruby 3.2. Nós planejamos trocá-lo pelo PubGrub no futuro.
+
+## Outras mudanças notórias desde 3.1
+
+* Data
+    * Nova classe core para representar objetos de valor imutável simples. A classe
+      é similar à Struct e parcialmente compartilha uma implementação, mas tem API
+      mais estrita e enxuta. [[Feature #16122]]
+
+        ```ruby
+        Measure = Data.define(:amount, :unit)
+        distance = Measure.new(100, 'km')            #=> #<data Measure amount=100, unit="km">
+        weight = Measure.new(amount: 50, unit: 'kg') #=> #<data Measure amount=50, unit="kg">
+        weight.with(amount: 40)                      #=> #<data Measure amount=40, unit="kg">
+        weight.amount                                #=> 50
+        weight.amount = 40                           #=> NoMethodError: undefined method `amount='
+        ```
+
+* Hash
+    * `Hash#shift` agora sempre retorna nil se o hash está
+      vazio, ao invés de retornar o valor padrão ou chamar
+      a proc padrão. [[Bug #16908]]
+
+* MatchData
+    * `MatchData#byteoffset` foi adicionado. [[Feature #13110]]
+
+* Module
+    * `Module.used_refinements` foi adicionado. [[Feature #14332]]
+    * `Module#refinements` foi adicionado. [[Feature #12737]]
+    * `Module#const_added` foi adicionado. [[Feature #17881]]
+
+* Proc
+    * `Proc#dup` retorna uma instância da subclasse. [[Bug #17545]]
+    * `Proc#parameters` agora aceita a palavra-chave lambda. [[Feature #15357]]
+
+* Refinement
+    * `Refinement#refined_class` foi adicionado. [[Feature #12737]]
+
+* RubyVM::AbstractSyntaxTree
+    * Adicionada opção `error_tolerant` para `parse`, `parse_file` e `of`. [[Feature #19013]]
+      Com essa opção
+        1. SyntaxError é suprimido
+        2. AST é retornada por input inválido
+        3. `end` é complementado quando um parser alcança o fim do input, mas o `end` é insuficiente
+        4. `end` é tratado como palavra-chave baseado na indentação
+
+        ```ruby
+        # Sem opção error_tolerant
+        root = RubyVM::AbstractSyntaxTree.parse(<<~RUBY)
+        def m
+          a = 10
+          if
+        end
+        RUBY
+        # => <internal:ast>:33:in `parse': syntax error, unexpected `end' (SyntaxError)
+
+        # Com opção error_tolerant
+        root = RubyVM::AbstractSyntaxTree.parse(<<~RUBY, error_tolerant: true)
+        def m
+          a = 10
+          if
+        end
+        RUBY
+        p root # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-4:3>
+
+        # `end` é tratado como palavra-chave baseado na indentação
+        root = RubyVM::AbstractSyntaxTree.parse(<<~RUBY, error_tolerant: true)
+        module Z
+          class Foo
+            foo.
+          end
+
+          def bar
+          end
+        end
+        RUBY
+        p root.children[-1].children[-1].children[-1].children[-2..-1]
+        # => [#<RubyVM::AbstractSyntaxTree::Node:CLASS@2:2-4:5>, #<RubyVM::AbstractSyntaxTree::Node:DEFN@6:2-7:5>]
+        ```
+
+    * Adiciona opção `keep_tokens` para `parse`, `parse_file` e `of`. [[Feature #19070]]
+
+        ```ruby
+        root = RubyVM::AbstractSyntaxTree.parse("x = 1 + 2", keep_tokens: true)
+        root.tokens # => [[0, :tIDENTIFIER, "x", [1, 0, 1, 1]], [1, :tSP, " ", [1, 1, 1, 2]], ...]
+        root.tokens.map{_1[2]}.join # => "x = 1 + 2"
+        ```
+
+* Set
+    * Set agora está disponível como uma classe builtin sem necessidade de `require "set"`. [[Feature #16989]]
+      Ela está atualmente autoloaded via constante `Set` ou chamada em `Enumerable#to_set`.
+
+* String
+    * `String#byteindex` e `String#byterindex` foram adicionados. [[Feature #13110]]
+    * Atualizado Unicode para Versão 15.0.0 e Emoji Versão 15.0. [[Feature #18639]]
+      (também aplicado para Regexp)
+    * `String#bytesplice` foi adicionado. [[Feature #18598]]
+
+* Struct
+    * Uma classe Struct pode também ser inicializada com argumentos de palavras-chave
+      sem `keyword_init: true` em `Struct.new` [[Feature #16806]]
+
+        ```ruby
+        Post = Struct.new(:id, :name)
+        Post.new(1, "hello") #=> #<struct Post id=1, name="hello">
+        # Do Ruby 3.2, o seguinte código também funciona sem keyword_init: true.
+        Post.new(id: 1, name: "hello") #=> #<struct Post id=1, name="hello">
+        ```
+
+## Issues de compatibilidade
+
+Nota: Excluindo correção de bugs de funcionalidades.
+
+### Constantes removidas
+
+As seguintes constantes obsoletas foram removidas.
+
+* `Fixnum` e `Bignum` [[Feature #12005]]
+* `Random::DEFAULT` [[Feature #17351]]
+* `Struct::Group`
+* `Struct::Passwd`
+
+### Métodos removidos
+
+Os seguintes métodos obsoletos foram removidos.
+
+* `Dir.exists?` [[Feature #17391]]
+* `File.exists?` [[Feature #17391]]
+* `Kernel#=~` [[Feature #15231]]
+* `Kernel#taint`, `Kernel#untaint`, `Kernel#tainted?`
+  [[Feature #16131]]
+* `Kernel#trust`, `Kernel#untrust`, `Kernel#untrusted?`
+  [[Feature #16131]]
+
+## Issues de compatibilidade na Stdlib
+
+### Não empacota mais código fonte de terceiros
+
+* Nós não empacotamos mais código fonte de terceiro como `libyaml`, `libffi`.
+
+    * O código fonte do libyaml foi removido do psych. Você pode precisar instalar
+    `libyaml-dev` na plataforma Ubuntu/Debian. O nome do pacote é diferente pra cada
+    plataforma.
+
+    * O código fonte empacotado do libffi também foi removido do `fiddle`
+
+* Psych e fiddle suportaram builds estáticos com versões específicas dos fontes de libyaml e libffi. Você pode rodar o build do psych com libyaml-0.2.5 assim:
+
+    ```bash
+    $ ./configure --with-libyaml-source-dir=/path/to/libyaml-0.2.5
+    ```
+
+    E você pode rodar o build do fiddle com libffi-3.4.4 assim:
+
+    ```bash
+    $ ./configure --with-libffi-source-dir=/path/to/libffi-3.4.4
+    ```
+
+  [[Feature #18571]]
+
+## Atualizações da API de C
+
+### APIs de C atualizadas
+
+As seguintes APIs foram atualizadas.
+
+* Atualização do PRNG
+  * `rb_random_interface_t` atualizado e versionado.
+    Bibliotecas de extensão que usam essa interface e buildadas para versões antigas.
+    E também a função `init_int32` precisa ser definida.
+
+### APIs de C removidas
+
+As seguintes APIs se tornaram obsoletas e foram removidas.
+
+* Variável `rb_cData`.
+* Funções "taintedness" e "trustedness". [[Feature #16131]]
+
+## Atualizações da biblioteca padrão
+
+* Bundler
+
+    * Adiciona suporte a --ext=rust para empacotar gem e criar gems simples com extensões de Rust.
+      [[GH-rubygems-6149]]
+    * Clonar repositórios git mais rápido [[GH-rubygems-4475]]
+
+* RubyGems
+
+    * Adiciona suporte a mswin para builder cargo. [[GH-rubygems-6167]]
+
+* ERB
+
+    * `ERB::Util.html_escape` mais rápido que `CGI.escapeHTML`.
+        * Não aloca um objeto String quando não há caracteres para escapar.
+        * Pula a chamada do método `#to_s` quando o argumento já é uma String.
+        * `ERB::Escape.html_escape` é adicionado como alias para `ERB::Util.html_escape`,
+          que não é monkey-patched pelo Rails.
+
+* IRB
+
+    * Comandos de integração do debug.gem foram adicionado: `debug`, `break`, `catch`,
+      `next`, `delete`, `step`, `continue`, `finish`, `backtrace`, `info`
+        * Eles funcionam mesmo se você não possuir `gem "debug"` no seu Gemfile.
+        * Veja também: [What's new in Ruby 3.2's IRB?](https://st0012.dev/whats-new-in-ruby-3-2-irb)
+    * Mais comandos e funcionalidades Pry-like foram adicionados.
+        * `edit` e `show_cmds` (como o `help` do Pry) foram adicionados.
+        * `ls` leva a opção `-g` ou `-G` para filtrar outputs.
+        * `show_source` é alias de `$` e aceita inputs sem aspas.
+        * `whereami` é alias de `@`.
+
+*   As seguintes gems padrão foram atualizadas.
+
+    * RubyGems 3.4.1
+    * abbrev 0.1.1
+    * benchmark 0.2.1
+    * bigdecimal 3.1.3
+    * bundler 2.4.1
+    * cgi 0.3.6
+    * csv 3.2.6
+    * date 3.3.3
+    * delegate 0.3.0
+    * did_you_mean 1.6.3
+    * digest 3.1.1
+    * drb 2.1.1
+    * english 0.7.2
+    * erb 4.0.2
+    * error_highlight 0.5.1
+    * etc 1.4.2
+    * fcntl 1.0.2
+    * fiddle 1.1.1
+    * fileutils 1.7.0
+    * forwardable 1.3.3
+    * getoptlong 0.2.0
+    * io-console 0.6.0
+    * io-nonblock 0.2.0
+    * io-wait 0.3.0
+    * ipaddr 1.2.5
+    * irb 1.6.2
+    * json 2.6.3
+    * logger 1.5.3
+    * mutex_m 0.1.2
+    * net-http 0.3.2
+    * net-protocol 0.2.1
+    * nkf 0.1.2
+    * open-uri 0.3.0
+    * open3 0.1.2
+    * openssl 3.1.0
+    * optparse 0.3.1
+    * ostruct 0.5.5
+    * pathname 0.2.1
+    * pp 0.4.0
+    * pstore 0.1.2
+    * psych 5.0.1
+    * racc 1.6.2
+    * rdoc 6.5.0
+    * readline-ext 0.1.5
+    * reline 0.3.2
+    * resolv 0.2.2
+    * resolv-replace 0.1.1
+    * securerandom 0.2.2
+    * set 1.0.3
+    * stringio 3.0.4
+    * strscan 3.0.5
+    * syntax_suggest 1.0.2
+    * syslog 0.1.1
+    * tempfile 0.1.3
+    * time 0.2.1
+    * timeout 0.3.1
+    * tmpdir 0.1.3
+    * tsort 0.1.1
+    * un 0.2.1
+    * uri 0.12.0
+    * weakref 0.1.2
+    * win32ole 1.8.9
+    * yaml 0.2.1
+    * zlib 3.0.0
+
+*   As seguintes gems empacotadas foram atualizadas.
+
+    * minitest 5.16.3
+    * power_assert 2.0.3
+    * test-unit 3.5.7
+    * net-ftp 0.2.0
+    * net-imap 0.3.3
+    * net-pop 0.1.2
+    * net-smtp 0.3.3
+    * rbs 2.8.2
+    * typeprof 0.21.3
+    * debug 1.7.1
+
+Veja as releases do GitHub como [GitHub Releases of logger](https://github.com/ruby/logger/releases) ou changelog para detalhes das gems padrão ou gems empacotadas.
+
+Veja [NOVIDADES](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
+ou [commit logs](https://github.com/ruby/ruby/compare/v3_1_0...{{ release.tag }})
+para mais detalhes.
+
+Com estas mudanças, [{{ release.stats.files_changed }} arquivos mudados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} remoções(-)](https://github.com/ruby/ruby/compare/v3_1_0...{{ release.tag }}#file_bucket)
+desde o Ruby 3.1.0!
+
+Feliz Natal, Boas Festas, e aproveite programando com Ruby 3.2!
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## O que é Ruby
+
+Ruby foi primeiramente desenvolvido por Matz (Yukihiro Matsumoto) em 1993
+e agora é desenvolvido como Open Source. Ele roda em múltiplas plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.
+
+[Feature #12005]:     https://bugs.ruby-lang.org/issues/12005
+[Feature #12084]:     https://bugs.ruby-lang.org/issues/12084
+[Feature #12655]:     https://bugs.ruby-lang.org/issues/12655
+[Feature #12737]:     https://bugs.ruby-lang.org/issues/12737
+[Feature #13110]:     https://bugs.ruby-lang.org/issues/13110
+[Feature #14332]:     https://bugs.ruby-lang.org/issues/14332
+[Feature #15231]:     https://bugs.ruby-lang.org/issues/15231
+[Feature #15357]:     https://bugs.ruby-lang.org/issues/15357
+[Bug #15928]:         https://bugs.ruby-lang.org/issues/15928
+[Feature #16122]:     https://bugs.ruby-lang.org/issues/16122
+[Feature #16131]:     https://bugs.ruby-lang.org/issues/16131
+[Bug #16466]:         https://bugs.ruby-lang.org/issues/16466
+[Feature #16663]:     https://bugs.ruby-lang.org/issues/16663
+[Feature #16806]:     https://bugs.ruby-lang.org/issues/16806
+[Bug #16889]:         https://bugs.ruby-lang.org/issues/16889
+[Bug #16908]:         https://bugs.ruby-lang.org/issues/16908
+[Feature #16989]:     https://bugs.ruby-lang.org/issues/16989
+[Feature #17351]:     https://bugs.ruby-lang.org/issues/17351
+[Feature #17391]:     https://bugs.ruby-lang.org/issues/17391
+[Bug #17545]:         https://bugs.ruby-lang.org/issues/17545
+[Bug #17767]:         https://bugs.ruby-lang.org/issues/17767
+[Feature #17837]:     https://bugs.ruby-lang.org/issues/17837
+[Feature #17881]:     https://bugs.ruby-lang.org/issues/17881
+[Feature #18033]:     https://bugs.ruby-lang.org/issues/18033
+[Feature #18159]:     https://bugs.ruby-lang.org/issues/18159
+[Feature #18239]:     https://bugs.ruby-lang.org/issues/18239#note-17
+[Feature #18351]:     https://bugs.ruby-lang.org/issues/18351
+[Feature #18367]:     https://bugs.ruby-lang.org/issues/18367
+[Bug #18435]:         https://bugs.ruby-lang.org/issues/18435
+[Feature #18462]:     https://bugs.ruby-lang.org/issues/18462
+[Feature #18481]:     https://bugs.ruby-lang.org/issues/18481
+[Bug #18487]:         https://bugs.ruby-lang.org/issues/18487
+[Feature #18564]:     https://bugs.ruby-lang.org/issues/18564
+[Feature #18571]:     https://bugs.ruby-lang.org/issues/18571
+[Feature #18585]:     https://bugs.ruby-lang.org/issues/18585
+[Feature #18589]:     https://bugs.ruby-lang.org/issues/18589
+[Feature #18595]:     https://bugs.ruby-lang.org/issues/18595
+[Feature #18598]:     https://bugs.ruby-lang.org/issues/18598
+[Bug #18625]:         https://bugs.ruby-lang.org/issues/18625
+[Feature #18630]:     https://bugs.ruby-lang.org/issues/18630
+[Bug #18633]:         https://bugs.ruby-lang.org/issues/18633
+[Feature #18639]:     https://bugs.ruby-lang.org/issues/18639
+[Feature #18685]:     https://bugs.ruby-lang.org/issues/18685
+[Bug #18729]:         https://bugs.ruby-lang.org/issues/18729
+[Bug #18751]:         https://bugs.ruby-lang.org/issues/18751
+[Feature #18774]:     https://bugs.ruby-lang.org/issues/18774
+[Feature #18776]:     https://bugs.ruby-lang.org/issues/18776
+[Bug #18782]:         https://bugs.ruby-lang.org/issues/18782
+[Feature #18788]:     https://bugs.ruby-lang.org/issues/18788
+[Feature #18798]:     https://bugs.ruby-lang.org/issues/18798
+[Feature #18809]:     https://bugs.ruby-lang.org/issues/18809
+[Feature #18821]:     https://bugs.ruby-lang.org/issues/18821
+[Feature #18822]:     https://bugs.ruby-lang.org/issues/18822
+[Feature #18824]:     https://bugs.ruby-lang.org/issues/18824
+[Feature #18832]:     https://bugs.ruby-lang.org/issues/18832
+[Feature #18875]:     https://bugs.ruby-lang.org/issues/18875
+[Feature #18925]:     https://bugs.ruby-lang.org/issues/18925
+[Feature #18944]:     https://bugs.ruby-lang.org/issues/18944
+[Feature #18949]:     https://bugs.ruby-lang.org/issues/18949
+[Feature #18968]:     https://bugs.ruby-lang.org/issues/18968
+[Feature #19008]:     https://bugs.ruby-lang.org/issues/19008
+[Feature #19013]:     https://bugs.ruby-lang.org/issues/19013
+[Feature #19026]:     https://bugs.ruby-lang.org/issues/19026
+[Feature #19036]:     https://bugs.ruby-lang.org/issues/19036
+[Feature #19060]:     https://bugs.ruby-lang.org/issues/19060
+[Feature #19070]:     https://bugs.ruby-lang.org/issues/19070
+[Feature #19071]:     https://bugs.ruby-lang.org/issues/19071
+[Feature #19078]:     https://bugs.ruby-lang.org/issues/19078
+[Bug #19087]:         https://bugs.ruby-lang.org/issues/19087
+[Bug #19100]:         https://bugs.ruby-lang.org/issues/19100
+[Feature #19104]:     https://bugs.ruby-lang.org/issues/19104
+[Feature #19135]:     https://bugs.ruby-lang.org/issues/19135
+[Feature #19138]:     https://bugs.ruby-lang.org/issues/19138
+[Feature #19194]:     https://bugs.ruby-lang.org/issues/19194
+[Molinillo]:          https://github.com/CocoaPods/Molinillo
+[PubGrub]:            https://github.com/jhawthorn/pub_grub
+[GH-net-protocol-14]: https://github.com/ruby/net-protocol/pull/14
+[GH-pathname-20]:     https://github.com/ruby/pathname/pull/20
+[GH-6791]:            https://github.com/ruby/ruby/pull/6791
+[GH-6868]:            https://github.com/ruby/ruby/pull/6868
+[GH-rubygems-4475]:   https://github.com/rubygems/rubygems/pull/4475
+[GH-rubygems-6149]:   https://github.com/rubygems/rubygems/pull/6149
+[GH-rubygems-6167]:   https://github.com/rubygems/rubygems/pull/6167
+[sec-156615]:         https://hackerone.com/reports/156615
+[CVE-2021-33621]:     https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621/
+[wasm/README.md]:     https://github.com/ruby/ruby/blob/master/wasm/README.md
+[ruby.wasm]:          https://github.com/ruby/ruby.wasm

--- a/pt_br/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
+++ b/pt_br/news/_posts/2024-10-28-redos-rexml-cve-2024-49761.md
@@ -1,0 +1,31 @@
+---
+layout: news_post
+title: "CVE-2024-49761: Vulnerabilidade ReDoS na REXML"
+author: "kou"
+translator: nbluis
+date: 2024-10-28 03:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existe uma vulnerabilidade ReDoS na gem REXML. Esta vulnerabilidade foi atribuída ao identificador CVE [CVE-2024-49761](https://www.cve.org/CVERecord?id=CVE-2024-49761). Recomendamos fortemente a atualização da gem REXML.
+
+Isso não acontece com Ruby 3.2 ou posterior. Ruby 3.1 é a única versão mantida afetada. Note que Ruby 3.1 atingirá EOL em 2025-03.
+
+## Detalhes
+
+Ao analisar um XML que possui muitos dígitos entre `&#` e `x...;` em uma referência de caractere numérico hexadecimal (`&#x...;`).
+
+Por favor, atualize a gem REXML para a versão 3.3.9 ou posterior.
+
+## Versões afetadas
+
+* Gem REXML 3.3.8 ou anterior com Ruby 3.1 ou anterior
+
+## Créditos
+
+Agradecimentos a [manun](https://hackerone.com/manun) por descobrir este problema.
+
+## Histórico
+
+* Publicado originalmente em 2024-10-28 03:00:00 (UTC)

--- a/pt_br/news/_posts/2024-10-30-ruby-3-2-6-released.md
+++ b/pt_br/news/_posts/2024-10-30-ruby-3-2-6-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 3.2.6 Lançado"
+author: nagachika
+translator: nbluis
+date: 2024-10-30 10:00:00 +0000
+lang: pt_br
+---
+
+Ruby 3.2.6 foi lançado.
+
+Por favor, consulte os [lançamentos no GitHub](https://github.com/ruby/ruby/releases/tag/v3_2_6) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário do Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas suas contribuições.

--- a/pt_br/news/_posts/2024-11-05-ruby-3-3-6-released.md
+++ b/pt_br/news/_posts/2024-11-05-ruby-3-3-6-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 3.3.6 Lançado"
+author: k0kubun
+translator: nbluis
+date: 2024-11-05 04:25:00 +0000
+lang: pt_br
+---
+
+Ruby 3.3.6 foi lançado.
+
+Esta é uma atualização de rotina que inclui correções de bugs menores.
+Esta versão também para de notificar sobre a ausência de dependências de gems padrões que serão incorporadas no Ruby 3.5.
+Para mais detalhes, por favor, consulte [as notas de lançamento no GitHub](https://github.com/ruby/ruby/releases/tag/v3_3_6).
+
+## Cronograma de Lançamento
+
+Conforme [anunciado](https://www.ruby-lang.org/en/news/2024/07/09/ruby-3-3-4-released/) anteriormente, pretendemos lançar a versão estável mais recente do Ruby (atualmente Ruby 3.3) a cada 2 meses após um lançamento `.1`.
+
+Esperamos lançar o Ruby 3.3.7 em 7 de janeiro. Se surgirem mudanças significativas que impactem um grande número de usuários, podemos lançar uma nova versão antes do previsto.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.3.6" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário sobre o Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas suas contribuições.

--- a/pt_br/news/_posts/2024-12-12-ruby-3-4-0-rc1-released.md
+++ b/pt_br/news/_posts/2024-12-12-ruby-3-4-0-rc1-released.md
@@ -1,0 +1,189 @@
+---
+layout: news_post
+title: "Ruby 3.4.0 rc1 Lançado"
+author: "naruse"
+translator: nbluis
+date: 2024-12-12 00:00:00 +0000
+lang: pt_br
+---
+
+{% assign release = site.data.releases | where: "version", "3.4.0-rc1" | first %}
+Estamos felizes em anunciar o lançamento do Ruby {{ release.version }}.
+
+## Prism
+
+Alterado o parser padrão de parse.y para Prism. [[Feature #20564]]
+
+## GC Modular
+
+* Implementações alternativas de garbage collector (GC) podem ser carregadas dinamicamente
+  através do recurso de garbage collector modular. Para habilitar este recurso,
+  configure o Ruby com `--with-modular-gc` no momento da compilação. Bibliotecas de GC podem ser
+  carregadas em tempo de execução usando a variável de ambiente `RUBY_GC_LIBRARY`.
+  [[Feature #20351]]
+
+* O garbage collector embutido do Ruby foi dividido em um arquivo separado em
+  `gc/default/default.c` e interage com o Ruby usando uma API definida em
+  `gc/gc_impl.h`. O garbage collector embutido agora também pode ser compilado como uma
+  biblioteca usando `make modular-gc MODULAR_GC=default` e habilitado usando a
+  variável de ambiente `RUBY_GC_LIBRARY=default`. [[Feature #20470]]
+
+* Uma biblioteca experimental de GC é fornecida com base no [MMTk](https://www.mmtk.io/).
+  Esta biblioteca de GC pode ser compilada usando `make modular-gc MODULAR_GC=mmtk` e
+  habilitada usando a variável de ambiente `RUBY_GC_LIBRARY=mmtk`. Isso requer
+  a ferramenta Rust na máquina de compilação. [[Feature #20860]]
+
+## Mudanças na linguagem
+
+* Literais de string em arquivos sem um comentário `frozen_string_literal` agora emitem um aviso de descontinuação
+  quando são mutados.
+  Esses avisos podem ser habilitados com `-W:deprecated` ou configurando `Warning[:deprecated] = true`.
+  Para desativar essa mudança, você pode executar o Ruby com o argumento de linha de comando `--disable-frozen-string-literal`. [[Feature #20205]]
+
+* `it` foi adicionado para referenciar um parâmetro de bloco. [[Feature #18980]]
+
+* O splatting de palavra-chave `nil` ao chamar métodos agora é suportado.
+  `**nil` é tratado de maneira semelhante a `**{}`, não passando palavras-chave,
+  e não chamando nenhum método de conversão. [[Bug #20064]]
+
+* Passagem de bloco não é mais permitida em índice. [[Bug #19918]]
+
+* Argumentos de palavra-chave não são mais permitidos em índice. [[Bug #20218]]
+
+## YJIT
+
+TL;DR:
+* Melhor desempenho na maioria dos benchmarks em plataformas x86-64 e arm64.
+* Uso reduzido de memória de metadados de compilação
+* Várias correções de bugs. YJIT agora é ainda mais robusto e melhor testado.
+
+Novos recursos:
+* Adiciona limite de memória unificado via opção de linha de comando `--yjit-mem-size` (padrão 128MiB)
+  que rastreia o uso total de memória do YJIT e é mais intuitivo do que o
+  antigo `--yjit-exec-mem-size`.
+* Mais estatísticas agora sempre disponíveis via `RubyVM::YJIT.runtime_stats`
+* Adiciona log de compilação para rastrear o que é compilado via `--yjit-log`
+  * Final do log também disponível em tempo de execução via `RubyVM::YJIT.log`
+* Adiciona suporte para constantes compartilháveis em modo multi-ractor
+* Agora pode rastrear saídas contadas com `--yjit-trace-exits=COUNTER`
+
+Novas otimizações:
+* Contexto comprimido reduz a memória necessária para armazenar metadados do YJIT
+* Alocador aprimorado com capacidade de alocar registradores para variáveis locais
+* Quando o YJIT está habilitado, use mais primitivas Core escritas em Ruby:
+  * `Array#each`, `Array#select`, `Array#map` reescritos em Ruby para melhor desempenho [[Feature #20182]].
+* Capacidade de inline de métodos pequenos/triviais, como:
+  * Métodos vazios
+  * Métodos que retornam uma constante
+  * Métodos que retornam `self`
+  * Métodos que retornam diretamente um argumento
+* Geração de código especializada para muitos mais métodos em tempo de execução
+* Otimiza `String#getbyte`, `String#setbyte` e outros métodos de string
+* Otimiza operações bitwise para acelerar a manipulação de bits/bytes de baixo nível
+* Várias outras otimizações incrementais
+
+## Atualizações das classes principais
+
+Nota: Estamos listando apenas atualizações notáveis das classes principais.
+
+* Exception
+
+  * `Exception#set_backtrace` agora aceita um array de `Thread::Backtrace::Location`.
+    `Kernel#raise`, `Thread#raise` e `Fiber#raise` também aceitam este novo formato. [[Feature #13557]]
+
+* Range
+
+  * `Range#size` agora levanta `TypeError` se o intervalo não for iterável. [[Misc #18984]]
+
+## Problemas de compatibilidade
+
+Nota: Excluindo correções de bugs.
+
+* As mensagens de erro e exibições de backtrace foram alteradas.
+  * Usa uma aspa simples em vez de um acento grave como uma aspa de abertura. [[Feature #16495]]
+  * Exibe o nome de classe antes de um nome de método (somente quando a classe tiver um nome permanente). [[Feature #19117]]
+  * `Kernel#caller`, métodos de `Thread::Backtrace::Location`, etc. também foram alterados de acordo.
+
+  ```
+  Antes:
+  test.rb:1:in `foo': undefined method `time' for an instance of Integer
+          from test.rb:2:in `<main>'
+
+  Agora:
+  test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
+          from test.rb:2:in '<main>'
+  ```
+
+## Atualizações da C API
+
+* `rb_newobj` e `rb_newobj_of` (e macros correspondentes `RB_NEWOBJ`, `RB_NEWOBJ_OF`, `NEWOBJ`, `NEWOBJ_OF`) foram removidos. [[Feature #20265]]
+* Removida a função obsoleta `rb_gc_force_recycle`. [[Feature #18290]]
+
+## Mudanças diversas
+
+* Passar um bloco para um método que não usa o bloco passado mostrará
+  um aviso no modo verbose (`-w`).
+  [[Feature #15554]]
+
+* Redefinir alguns métodos principais que são especialmente otimizados pelo interpretador
+  e JIT como `String.freeze` ou `Integer#+` agora emite um aviso de classe de desempenho
+  (`-W:performance` ou `Warning[:performance] = true`).
+  [[Feature #20429]]
+
+Veja lançamentos no GitHub como [Logger](https://github.com/ruby/logger/releases) ou
+changelog para detalhes das gems padrão ou gems incluídas.
+
+Veja [NEWS](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
+ou [logs de commits](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }})
+para mais detalhes.
+
+Com essas mudanças, [{{ release.stats.files_changed }} arquivos alterados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} deleções(-)](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }}#file_bucket)
+desde  Ruby 3.3.0!
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## O que é Ruby
+
+Ruby foi desenvolvido pela primeira vez por Matz (Yukihiro Matsumoto) em 1993,
+e agora é desenvolvido como Open Source. Ele roda em várias plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.
+
+[Feature #13557]: https://bugs.ruby-lang.org/issues/13557
+[Feature #15554]: https://bugs.ruby-lang.org/issues/15554
+[Feature #16495]: https://bugs.ruby-lang.org/issues/16495
+[Feature #18290]: https://bugs.ruby-lang.org/issues/18290
+[Feature #18980]: https://bugs.ruby-lang.org/issues/18980
+[Misc #18984]:    https://bugs.ruby-lang.org/issues/18984
+[Feature #19117]: https://bugs.ruby-lang.org/issues/19117
+[Bug #19918]:     https://bugs.ruby-lang.org/issues/19918
+[Bug #20064]:     https://bugs.ruby-lang.org/issues/20064
+[Feature #20182]: https://bugs.ruby-lang.org/issues/20182
+[Feature #20205]: https://bugs.ruby-lang.org/issues/20205
+[Bug #20218]:     https://bugs.ruby-lang.org/issues/20218
+[Feature #20265]: https://bugs.ruby-lang.org/issues/20265
+[Feature #20351]: https://bugs.ruby-lang.org/issues/20351
+[Feature #20429]: https://bugs.ruby-lang.org/issues/20429
+[Feature #20470]: https://bugs.ruby-lang.org/issues/20470
+[Feature #20564]: https://bugs.ruby-lang.org/issues/20564
+[Feature #20860]: https://bugs.ruby-lang.org/issues/20860

--- a/pt_br/news/_posts/2024-12-25-ruby-3-4-0-released.md
+++ b/pt_br/news/_posts/2024-12-25-ruby-3-4-0-released.md
@@ -1,0 +1,343 @@
+---
+layout: news_post
+title: "Ruby 3.4.0 Lançado"
+author: "naruse"
+translator: nbluis
+date: 2024-12-25 00:00:00 +0000
+lang: pt_br
+---
+
+{% assign release = site.data.releases | where: "version", "3.4.0" | first %}
+Estamos felizes em anunciar o lançamento do Ruby {{ release.version }}. Ruby 3.4 adiciona a referência de parâmetro de bloco `it`,
+altera o Prism como parser padrão, adiciona suporte ao Happy Eyeballs Versão 2 na biblioteca de socket, melhora o YJIT,
+adiciona GC Modular, e muito mais.
+
+## `it` é introduzido
+
+`it` foi adicionado para referenciar um parâmetro de bloco sem nome de variável. [[Feature #18980]]
+
+```ruby
+ary = ["foo", "bar", "baz"]
+
+p ary.map { it.upcase } #=> ["FOO", "BAR", "BAZ"]
+```
+
+`it` se comporta de maneira muito semelhante a `_1`. Quando a intenção é usar apenas `_1` em um bloco, a possibilidade de outros parâmetros numerados como `_2` aparecer impõe uma carga cognitiva extra aos leitores. Então `it` foi introduzido como um alias prático. Use `it` em casos simples onde `it` representa itself, como em blocos de uma linha.
+
+## Prism agora é o parser padrão
+
+Alteração do parser padrão de parse.y para Prism. [[Feature #20564]]
+
+Esta é uma melhoria interna e deve haver pouca mudança visível para o usuário. Se você notar algum problema de compatibilidade, por favor, reporte para nós.
+
+Para usar o parser convencional, use o argumento de linha de comando `--parser=parse.y`.
+
+## A biblioteca de socket agora possui Happy Eyeballs Versão 2 (RFC 8305)
+
+A biblioteca de socket agora possui [Happy Eyeballs Version 2 (RFC 8305)](https://datatracker.ietf.org/doc/html/rfc8305), a versão padronizada mais recente de uma abordagem amplamente adotada para melhor conectividade em muitas linguagens de programação, em `TCPSocket.new` (`TCPSocket.open`) e `Socket.tcp`.
+Esta melhoria permite que o Ruby forneça conexões de rede eficientes e confiáveis, adaptadas aos ambientes modernos da internet.
+
+Até o Ruby 3.3, esses métodos realizavam a resolução de nomes e tentativas de conexão de forma serial. Com este algoritmo, eles agora operam da seguinte forma:
+
+1. Realiza a resolução de nomes IPv6 e IPv4 simultaneamente
+2. Tenta conexões com os endereços IP resolvidos, priorizando IPv6, com tentativas paralelas escalonadas em intervalos de 250ms
+3. Retorna a primeira conexão bem-sucedida enquanto cancela quaisquer outras
+
+Isso garante atrasos mínimos de conexão, mesmo se um protocolo específico ou endereço IP estiver atrasado ou indisponível.
+Este recurso é habilitado por padrão, portanto, configuração adicional não é necessária para usá-lo. Para desativá-lo globalmente, defina a variável de ambiente `RUBY_TCP_NO_FAST_FALLBACK=1` ou chame `Socket.tcp_fast_fallback=false`. Ou para desativá-lo em um método específico, use o argumento `fast_fallback: false`.
+
+## YJIT
+
+### TL;DR
+
+* Melhor desempenho na maioria dos benchmarks em plataformas x86-64 e arm64.
+* Uso reduzido de memória através de metadados comprimidos e um limite de memória unificado.
+* Várias correções de bugs: YJIT agora é mais robusto e testado exaustivamente.
+
+### Novos recursos
+
+* Opções de linha de comando
+    * `--yjit-mem-size` introduz um limite de memória unificado (padrão 128MiB) para rastrear o uso total de memória do YJIT,
+      fornecendo uma alternativa mais intuitiva à antiga opção `--yjit-exec-mem-size`.
+    * `--yjit-log` habilita um log de compilação para rastrear o que é compilado.
+* API Ruby
+    * `RubyVM::YJIT.log` fornece acesso ao final do log de compilação em tempo de execução.
+* Estatísticas do YJIT
+    * `RubyVM::YJIT.runtime_stats` agora sempre fornece estatísticas adicionais sobre
+       invalidação, inlining e codificação de metadados.
+
+### Novas otimizações
+
+* Contexto comprimido reduz a memória necessária para armazenar metadados do YJIT
+* Alocar registradores para variáveis locais e argumentos de métodos Ruby
+* Quando o YJIT está habilitado, usa mais primitivas Core escritas em Ruby:
+    * `Array#each`, `Array#select`, `Array#map` reescritos em Ruby para melhor desempenho [[Feature #20182]].
+* Capacidade de inline de métodos pequenos/triviais, como:
+    * Métodos vazios
+    * Métodos que retornam uma constante
+    * Métodos que retornam `self`
+    * Métodos que retornam diretamente um argumento
+* Geração de código especializada para muitos mais métodos em tempo de execução
+* Otimiza `String#getbyte`, `String#setbyte` e outros métodos de string
+* Otimiza operações bitwise para acelerar a manipulação de bits/bytes de baixo nível
+* Suporte a constantes compartilháveis em modo multi-ractor
+* Várias outras otimizações incrementais
+
+## Modular GC
+
+* Implementações alternativas de garbage collector (GC) podem ser carregadas dinamicamente
+  através do recurso de garbage collector modular. Para habilitar este recurso,
+  configure o Ruby com `--with-modular-gc` no momento da compilação. Bibliotecas de GC podem ser
+  carregadas em tempo de execução usando a variável de ambiente `RUBY_GC_LIBRARY`.
+  [[Feature #20351]]
+
+* O garbage collector embutido do Ruby foi dividido em um arquivo separado em
+  `gc/default/default.c` e interage com o Ruby usando uma API definida em
+  `gc/gc_impl.h`. O garbage collector embutido agora também pode ser compilado como uma
+  biblioteca usando `make modular-gc MODULAR_GC=default` e habilitado usando a
+  variável de ambiente `RUBY_GC_LIBRARY=default`. [[Feature #20470]]
+
+* Uma biblioteca experimental de GC é fornecida com base no [MMTk](https://www.mmtk.io/).
+  Esta biblioteca de GC pode ser compilada usando `make modular-gc MODULAR_GC=mmtk` e
+  habilitada usando a variável de ambiente `RUBY_GC_LIBRARY=mmtk`. Isso requer
+  a ferramenta Rust na máquina de compilação. [[Feature #20860]]
+
+## Mudanças na linguagem
+
+* Literais de string em arquivos sem um comentário `frozen_string_literal` agora emitem um aviso de descontinuação
+  quando são mutados.
+  Esses avisos podem ser habilitados com `-W:deprecated` ou configurando `Warning[:deprecated] = true`.
+  Para desativar essa mudança, você pode executar o Ruby com o argumento de linha de comando `--disable-frozen-string-literal`. [[Feature #20205]]
+
+* O splatting de palavra-chave `nil` ao chamar métodos agora é suportado.
+  `**nil` é tratado de maneira semelhante a `**{}`, não passando palavras-chave,
+  e não chamando nenhum método de conversão. [[Bug #20064]]
+
+* Passagem de bloco não é mais permitida em índice. [[Bug #19918]]
+
+* Argumentos de palavra-chave não são mais permitidos em índice. [[Bug #20218]]
+
+* O nome de nível superior `::Ruby` agora está reservado, e a definição será avisada quando `Warning[:deprecated]`. [[Feature #20884]]
+
+## Atualizações de classes principais
+
+Nota: Estamos listando apenas atualizações notáveis das classes principais.
+
+* Exception
+
+  * `Exception#set_backtrace` agora aceita um array de `Thread::Backtrace::Location`.
+    `Kernel#raise`, `Thread#raise` e `Fiber#raise` também aceitam este novo formato. [[Feature #13557]]
+
+* GC
+
+    * `GC.config` adicionado para permitir a configuração de variáveis no Garbage
+      Collector. [[Feature #20443]]
+
+    * Parâmetro de configuração do GC `rgengc_allow_full_mark` introduzido. Quando `false`
+      o GC marcará apenas objetos jovens. O padrão é `true`. [[Feature #20443]]
+
+* Ractor
+
+    * `require` em Ractor é permitido. O processo de requisição será executado no
+      Ractor principal.
+      `Ractor._require(feature)` é adicionado para executar o processo de requisição no
+      Ractor principal. [[Feature #20627]]
+
+    * `Ractor.main?` é adicionado. [[Feature #20627]]
+
+    * `Ractor.[]` e `Ractor.[]=` são adicionados para acessar o armazenamento local
+       do Ractor atual. [[Feature #20715]]
+
+    * `Ractor.store_if_absent(key){ init }` é adicionado para inicializar variáveis locais do ractor
+      de forma segura para threads. [[Feature #20875]]
+
+* Range
+
+  * `Range#size` agora levanta `TypeError` se o intervalo não for iterável. [[Misc #18984]]
+
+## Atualizações da Biblioteca Padrão
+
+Nota: Estamos listando apenas atualizações notáveis das bibliotecas padrão.
+
+* RubyGems
+    * Adicionada a opção `--attestation` ao gem push. Ela permite armazenar a assinatura no [sigstore.dev]
+
+* Bundler
+    * Adicionada uma configuração `lockfile_checksums` para incluir checksums em novos arquivos lockfile.
+    * Adicionado bundle lock `--add-checksums` para adicionar checksums a um arquivo lockfile existente
+
+* JSON
+
+    * Melhorias de desempenho do `JSON.parse` cerca de 1,5 vezes mais rápido que json-2.7.x.
+
+* Tempfile
+
+    * O argumento de palavra-chave `anonymous: true` foi implementado para Tempfile.create.
+      `Tempfile.create(anonymous: true)` remove o arquivo temporário criado imediatamente.
+      Assim, as aplicações não precisam remover o arquivo.
+      [[Feature #20497]]
+
+* win32/sspi.rb
+
+    * Esta biblioteca agora foi extraída do repositório Ruby para [ruby/net-http-sspi].
+      [[Feature #20775]]
+
+## Problemas de compatibilidade
+
+Nota: Excluindo correções de bugs.
+
+* As mensagens de erro e exibições de backtrace foram alteradas.
+  * Usa uma aspa simples em vez de um acento grave como uma aspa de abertura. [[Feature #16495]]
+  * Exibe o nome de classe antes de um nome de método (somente quando a classe tiver um nome permanente). [[Feature #19117]]
+  * `Kernel#caller`, métodos de `Thread::Backtrace::Location`, etc. também foram alterados de acordo.
+
+  ```
+  Antes:
+  test.rb:1:in `foo': undefined method `time' for an instance of Integer
+          from test.rb:2:in `<main>'
+
+  Agora:
+  test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
+          from test.rb:2:in '<main>'
+  ```
+
+* A renderização de Hash#inspect foi alterada. [[Bug #20433]]
+
+  * Chaves de símbolo são exibidas usando a sintaxe moderna de chave de símbolo: `"{user: 1}"`
+  * Outras chaves agora têm espaços ao redor de `=>`: `'{"user" => 1}'`, enquanto anteriormente não tinham: `'{"user"=>1}'`
+
+* Kernel#Float() agora aceita uma string decimal com a parte decimal omitida. [[Feature #20705]]
+
+  ```rb
+  Float("1.")    #=> 1.0 (anteriormente, um ArgumentError era levantado)
+  Float("1.E-1") #=> 0.1 (anteriormente, um ArgumentError era levantado)
+  ```
+
+* String#to_f agora aceita uma string decimal com a parte decimal omitida. Note que o resultado muda quando um expoente é especificado. [[Feature #20705]]
+
+  ```rb
+  "1.".to_f    #=> 1.0
+  "1.E-1".to_f #=> 0.1 (anteriormente, 1.0 era retornado)
+  ```
+
+* Refinement#refined_class foi removido. [[Feature #19714]]
+
+## Problemas de compatibilidade da biblioteca padrão
+
+* DidYouMean
+
+    * `DidYouMean::SPELL_CHECKERS[]=` e `DidYouMean::SPELL_CHECKERS.merge!` foram removidos.
+
+* Net::HTTP
+
+    * Removidas as seguintes constantes obsoletas:
+        * `Net::HTTP::ProxyMod`
+        * `Net::NetPrivate::HTTPRequest`
+        * `Net::HTTPInformationCode`
+        * `Net::HTTPSuccessCode`
+        * `Net::HTTPRedirectionCode`
+        * `Net::HTTPRetriableCode`
+        * `Net::HTTPClientErrorCode`
+        * `Net::HTTPFatalErrorCode`
+        * `Net::HTTPServerErrorCode`
+        * `Net::HTTPResponseReceiver`
+        * `Net::HTTPResponceReceiver`
+
+      Essas constantes foram obsoletas desde 2012.
+
+* Timeout
+
+    * Rejeita valores negativos para Timeout.timeout. [[Bug #20795]]
+
+* URI
+
+    * Alterado o parser padrão para compatível com RFC 3986 em vez de RFC 2396.
+      [[Bug #19266]]
+
+## Atualizações da C API
+
+* `rb_newobj` e `rb_newobj_of` (e macros correspondentes `RB_NEWOBJ`, `RB_NEWOBJ_OF`, `NEWOBJ`, `NEWOBJ_OF`) foram removidos. [[Feature #20265]]
+* Removida a função obsoleta `rb_gc_force_recycle`. [[Feature #18290]]
+
+## Mudanças diversas
+
+* Passar um bloco para um método que não usa o bloco passado mostrará
+  um aviso no modo verbose (`-w`).
+  [[Feature #15554]]
+
+* Redefinir alguns métodos principais que são especialmente otimizados pelo interpretador
+  e JIT como `String.freeze` ou `Integer#+` agora emite um aviso de classe de desempenho
+  (`-W:performance` ou `Warning[:performance] = true`).
+  [[Feature #20429]]
+
+Veja [NEWS](https://docs.ruby-lang.org/en/3.4/NEWS_md.html)
+ou [logs de commits](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }})
+para mais detalhes.
+
+Com essas mudanças, [{{ release.stats.files_changed }} arquivos alterados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} deleções(-)](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }}#file_bucket)
+desde Ruby 3.3.0!
+
+Feliz Natal, Boas Festas e aproveite a programação com Ruby 3.4!
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## O que é Ruby
+
+Ruby foi desenvolvido pela primeira vez por Matz (Yukihiro Matsumoto) em 1993,
+e agora é desenvolvido como Open Source. Ele roda em várias plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.
+
+[Feature #13557]: https://bugs.ruby-lang.org/issues/13557
+[Feature #15554]: https://bugs.ruby-lang.org/issues/15554
+[Feature #16495]: https://bugs.ruby-lang.org/issues/16495
+[Feature #18290]: https://bugs.ruby-lang.org/issues/18290
+[Feature #18980]: https://bugs.ruby-lang.org/issues/18980
+[Misc #18984]:    https://bugs.ruby-lang.org/issues/18984
+[Feature #19117]: https://bugs.ruby-lang.org/issues/19117
+[Bug #19266]:     https://bugs.ruby-lang.org/issues/19266
+[Feature #19714]: https://bugs.ruby-lang.org/issues/19714
+[Bug #19918]:     https://bugs.ruby-lang.org/issues/19918
+[Bug #20064]:     https://bugs.ruby-lang.org/issues/20064
+[Feature #20182]: https://bugs.ruby-lang.org/issues/20182
+[Feature #20205]: https://bugs.ruby-lang.org/issues/20205
+[Bug #20218]:     https://bugs.ruby-lang.org/issues/20218
+[Feature #20265]: https://bugs.ruby-lang.org/issues/20265
+[Feature #20351]: https://bugs.ruby-lang.org/issues/20351
+[Feature #20429]: https://bugs.ruby-lang.org/issues/20429
+[Feature #20443]: https://bugs.ruby-lang.org/issues/20443
+[Feature #20470]: https://bugs.ruby-lang.org/issues/20470
+[Feature #20497]: https://bugs.ruby-lang.org/issues/20497
+[Feature #20564]: https://bugs.ruby-lang.org/issues/20564
+[Bug #20620]: https://bugs.ruby-lang.org/issues/20620
+[Feature #20627]: https://bugs.ruby-lang.org/issues/20627
+[Feature #20705]: https://bugs.ruby-lang.org/issues/20705
+[Feature #20715]: https://bugs.ruby-lang.org/issues/20715
+[Feature #20775]: https://bugs.ruby-lang.org/issues/20775
+[Bug #20795]: https://bugs.ruby-lang.org/issues/20795
+[Bug #20433]: https://bugs.ruby-lang.org/issues/20433
+[Feature #20860]: https://bugs.ruby-lang.org/issues/20860
+[Feature #20875]: https://bugs.ruby-lang.org/issues/20875
+[Feature #20884]: https://bugs.ruby-lang.org/issues/20884
+[sigstore.dev]: https://www.sigstore.dev
+[ruby/net-http-sspi]: https://github.com/ruby/net-http-sspi

--- a/pt_br/news/_posts/2024-12-25-ruby-3-4-1-released.md
+++ b/pt_br/news/_posts/2024-12-25-ruby-3-4-1-released.md
@@ -1,0 +1,39 @@
+---
+layout: news_post
+title: "Ruby 3.4.1 Lançado"
+author: "naruse"
+translator: nbluis
+date: 2024-12-25 00:00:00 +0000
+lang: pt_br
+---
+
+Ruby 3.4.1 foi lançado.
+
+Isso corrige a descrição da versão.
+
+Veja os [lançamentos no GitHub](https://github.com/ruby/ruby/releases/tag/v3_4_1) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.4.1" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}

--- a/pt_br/news/_posts/2025-01-15-ruby-3-3-7-released.md
+++ b/pt_br/news/_posts/2025-01-15-ruby-3-3-7-released.md
@@ -1,0 +1,43 @@
+---
+layout: news_post
+title: "Ruby 3.3.7 Lançado"
+author: k0kubun
+translator: nbluis
+date: 2025-01-15 07:51:59 +0000
+lang: pt_br
+---
+
+Ruby 3.3.7 foi lançado.
+
+Esta é uma atualização de rotina que inclui correções de bugs menores.
+Por favor, consulte [as notas de lançamento no GitHub](https://github.com/ruby/ruby/releases/tag/v3_3_7) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.3.7" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário sobre o Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas suas contribuições.

--- a/pt_br/news/_posts/2025-02-04-ruby-3-2-7-released.md
+++ b/pt_br/news/_posts/2025-02-04-ruby-3-2-7-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 3.2.7 Lançado"
+author: nagachika
+translator: nbluis
+date: 2025-02-04 12:00:00 +0000
+lang: pt_br
+---
+
+Ruby 3.2.7 foi lançado.
+
+Por favor, consulte os [lançamentos no GitHub](https://github.com/ruby/ruby/releases/tag/v3_2_7) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.7" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário do Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas contribuições.

--- a/pt_br/news/_posts/2025-02-10-dos-net-imap-cve-2025-25186.md
+++ b/pt_br/news/_posts/2025-02-10-dos-net-imap-cve-2025-25186.md
@@ -1,0 +1,29 @@
+---
+layout: news_post
+title: "CVE-2025-25186: Vulnerabilidade de DoS em net-imap"
+author: "nevans"
+translator: nbluis
+date: 2025-02-10 03:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Existe uma possibilidade de DoS na gem net-imap. Esta vulnerabilidade foi atribuída ao identificador CVE [CVE-2025-25186](https://www.cve.org/CVERecord?id=CVE-2025-25186). Recomendamos atualizar a gem net-imap.
+
+## Detalhes
+
+Um servidor malicioso pode enviar dados uid-set altamente compactados, que são lidos automaticamente pelo thread receptor do cliente. O parser de resposta usa Range#to_a para converter os dados uid-set em arrays de inteiros, sem limitação no tamanho expandido dos intervalos.
+
+Atualize a gem net-imap para a versão 0.3.8, 0.4.19, 0.5.6 ou posterior.
+
+## Versões afetadas
+
+* gem net-imap entre 0.3.2 e 0.3.7, 0.4.0 e 0.4.18, ou 0.5.0 e 0.5.5
+
+## Créditos
+
+Obrigado a [manun](https://hackerone.com/manun) por descobrir este problema.
+
+## Histórico
+
+* Publicado originalmente em 2025-02-10 03:00:00 (UTC)

--- a/pt_br/news/_posts/2025-02-14-ruby-3-4-2-released.md
+++ b/pt_br/news/_posts/2025-02-14-ruby-3-4-2-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_post
+title: "Ruby 3.4.2 Lançado"
+author: k0kubun
+translator: nbluis
+date: 2025-02-14 21:55:17 +0000
+lang: pt_br
+---
+
+Ruby 3.4.2 foi lançado.
+
+Esta é uma atualização de rotina que inclui correções de bugs. Por favor consulte as
+[notas de lançamento no GitHub](https://github.com/ruby/ruby/releases/tag/v3_4_2) para maiores detalhes.
+
+## Cronograma de Lançamento
+
+Nosso objetivo é lançar a versão estável mais recente do Ruby (atualmente Ruby 3.4) a cada 2 meses.
+O Ruby 3.4.3 será lançado em abril, 3.4.4 em junho, 3.4.5 em agosto, 3.4.6 em outubro e 3.4.7 em dezembro.
+
+Caso haja alguma alteração que afete um número considerável de pessoas, essas versões podem ser lançadas antes do esperado.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.4.2" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário sobre o Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas contribuições.

--- a/pt_br/news/_posts/2025-02-26-security-advisories.md
+++ b/pt_br/news/_posts/2025-02-26-security-advisories.md
@@ -1,0 +1,69 @@
+---
+layout: news_post
+title: "Avisos de segurança: CVE-2025-27219, CVE-2025-27220 e CVE-2025-27221"
+author: "hsbt"
+translator: nbluis
+date: 2025-02-26 07:00:00 +0000
+tags: security
+lang: pt_br
+---
+
+Publicamos avisos de segurança para CVE-2025-27219, CVE-2025-27220 e CVE-2025-27221. Por favor, leia os detalhes abaixo.
+
+## CVE-2025-27219: Negação de Serviço em `CGI::Cookie.parse`.
+
+Há uma possibilidade de DoS na gem cgi. Esta vulnerabilidade foi identificada com o CVE [CVE-2025-27219](https://www.cve.org/CVERecord?id=CVE-2025-27219). Recomendamos atualizar a gem cgi.
+
+### Detalhes
+
+`CGI::Cookie.parse` levava tempo super-linear para analisar uma string de cookie em alguns casos. Alimentar uma string de cookie maliciosamente criada no método poderia levar a uma Negação de Serviço.
+
+Por favor, atualize a gem CGI para a versão 0.3.5.1, 0.3.7, 0.4.2 ou posterior.
+
+### Versões afetadas
+
+* Versões da gem cgi <= 0.3.5, 0.3.6, 0.4.0 e 0.4.1.
+
+### Créditos
+
+Obrigado a [lio346](https://hackerone.com/lio346) por descobrir este problema. Também agradecemos a [mame](https://github.com/mame) por corrigir esta vulnerabilidade.
+
+## CVE-2025-27220: ReDoS em `CGI::Util#escapeElement`.
+
+Há uma possibilidade de Negação de Serviço por expressão regular (ReDoS) na gem cgi. Esta vulnerabilidade foi identificada com o CVE [CVE-2025-27220](https://www.cve.org/CVERecord?id=CVE-2025-27220). Recomendamos atualizar a gem cgi.
+
+### Detalhes
+
+A expressão regular usada em `CGI::Util#escapeElement` é vulnerável a ReDoS. A entrada criada poderia levar a um alto consumo de CPU.
+
+Esta vulnerabilidade afeta apenas Ruby 3.1 e 3.2. Se você estiver usando essas versões, por favor, atualize a gem CGI para a versão 0.3.5.1, 0.3.7, 0.4.2 ou posterior.
+
+### Versões afetadas
+
+* Versões da gem cgi <= 0.3.5, 0.3.6, 0.4.0 e 0.4.1.
+
+### Créditos
+
+Obrigado a [svalkanov](https://hackerone.com/svalkanov) por descobrir este problema. Também agradecemos a [nobu](https://github.com/nobu) por corrigir esta vulnerabilidade.
+
+## CVE-2025-27221: vazamento de informações de usuário em `URI#join`, `URI#merge` e `URI#+`.
+
+Há uma possibilidade de vazamento de informações de usuário na gem uri. Esta vulnerabilidade foi identificada com o CVE [CVE-2025-27221](https://www.cve.org/CVERecord?id=CVE-2025-27221). Recomendamos atualizar a gem uri.
+
+### Detalhes
+
+Os métodos `URI#join`, `URI#merge` e `URI#+` mantinham informações de usuário, como `user:password`, mesmo após o host ser substituído. Ao gerar uma URL para um host malicioso a partir de uma URL contendo informações de usuário secretas usando esses métodos, e fazer alguém acessar essa URL, poderia ocorrer um vazamento não intencional de informações de usuário.
+
+Por favor, atualize a gem URI para a versão 0.11.3, 0.12.4, 0.13.2, 1.0.3 ou posterior.
+
+### Versões afetadas
+
+* Versões da gem uri < 0.11.3, 0.12.0 a 0.12.3, 0.13.0, 0.13.1 e 1.0.0 a 1.0.2.
+
+### Créditos
+
+Obrigado a [Tsubasa Irisawa (lambdasawa)](https://hackerone.com/lambdasawa) por descobrir este problema. Também agradecemos a [nobu](https://github.com/nobu) por correções adicionais desta vulnerabilidade.
+
+## Histórico
+
+* Publicado originalmente em 2025-02-26 7:00:00 (UTC)

--- a/pt_br/news/_posts/2025-12-25-ruby-4-0-0-released.md
+++ b/pt_br/news/_posts/2025-12-25-ruby-4-0-0-released.md
@@ -1,0 +1,965 @@
+---
+layout: news_post
+title: "Ruby 4.0.0 Lançado"
+author: "naruse"
+translator: guicruzzs
+date: 2025-12-25 00:00:00 +0000
+lang: pt_br
+---
+
+{% assign release = site.data.releases | where: "version", "4.0.0" | first %}
+Estamos felizes em anunciar o lançamento do Ruby {{ release.version }}.
+Ruby 4.0 introduz o "Ruby Box" e o "ZJIT", além de muitas melhorias.
+
+## Ruby Box
+
+Ruby Box é um novo recurso (experimental) para fornecer separação de definições.
+Ruby Box é habilitado quando a variável de ambiente `RUBY_BOX=1` é especificada.
+A classe é `Ruby::Box`.
+
+Definições carregadas em uma box são isoladas dentro dela.
+Ruby Box pode isolar/separar monkey patches, alterações em variáveis globais/de classe,
+definições de classes/módulos e bibliotecas nativas/Ruby carregadas de outras boxes.
+
+Casos de uso esperados incluem:
+
+* Executar casos de teste em uma box para proteger outros testes quando o caso de teste usa
+  monkey patches para sobrescrever algo
+* Executar boxes de aplicações web em paralelo para fazer blue‑green deployment
+  em um servidor de aplicação dentro de um processo Ruby
+* Executar boxes de aplicações web em paralelo para avaliar atualizações de dependências
+  por um certo período de tempo, verificando o diff da resposta usando código Ruby
+* Ser usada como a API de base (baixo nível) para implementar algum tipo de API de "pacotes"
+  (alto nível) (ainda não foi projetada)
+
+Para mais detalhes sobre o "Ruby Box", consulte
+[`Ruby::Box`](https://docs.ruby-lang.org/en/master/Ruby/Box.html).
+[[Feature #21311]] [[Misc #21385]]
+
+## ZJIT
+
+ZJIT é um novo compilador just‑in‑time (JIT), desenvolvido como a próxima geração do YJIT.
+Você precisa do Rust 1.85.0 ou mais recente para construir o Ruby com suporte ao ZJIT, e
+o ZJIT é habilitado quando `--zjit` é especificado.
+
+Estamos construindo um novo compilador para Ruby porque queremos tanto elevar o teto de
+desempenho (unidade de compilação maior e IR em SSA) quanto incentivar mais contribuições
+externas (tornando‑se um compilador de métodos mais tradicional).
+Veja [nosso post no blog](https://railsatscale.com/2025-12-24-launch-zjit/) para mais detalhes.
+<!-- the blog post will be auto-published on 2025-12-24 9:00am UTC. -->
+
+ZJIT é mais rápido que o interpretador, mas ainda não é tão rápido quanto o YJIT.
+Incentivamos você a experimentar o ZJIT, mas talvez seja melhor adiar o uso em produção por enquanto.
+Fique de olho no ZJIT do Ruby 4.1.
+
+## Melhorias em Ractor
+
+Ractor, o mecanismo de execução paralela do Ruby, recebeu várias melhorias.
+Uma nova classe, `Ractor::Port`, foi introduzida para resolver problemas relacionados
+ao envio e recebimento de mensagens (veja
+[este post no blog](https://dev.to/ko1/ractorport-revamping-the-ractor-api-98)).
+Além disso, `Ractor.shareable_proc` facilita compartilhar objetos `Proc` entre Ractors.
+
+Do ponto de vista de desempenho, muitas estruturas de dados internas foram melhoradas
+para reduzir significativamente a contenção em um lock global, liberando mais paralelismo.
+Ractors também agora compartilham menos dados internos, resultando em menos contenção de
+cache de CPU quando executados em paralelo.
+
+Ractor foi introduzido pela primeira vez no Ruby 3.0 como um recurso experimental.
+Nosso objetivo é remover o status de "experimental" no próximo ano.
+
+## Mudanças na linguagem
+
+* `*nil` não chama mais `nil.to_a`, de forma semelhante a como `**nil` não chama
+  `nil.to_hash`. [[Feature #21047]]
+
+* Operadores lógicos binários (`||`, `&&`, `and` e `or`) no início de uma linha
+  continuam a linha anterior, assim como o encadeamento por ponto.
+  Os exemplos de código a seguir são equivalentes:
+
+    ```ruby
+    if condition1
+       && condition2
+      ...
+    end
+    ```
+
+    Anteriormente:
+
+    ```ruby
+    if condition1 && condition2
+      ...
+    end
+    ```
+
+    ```ruby
+    if condition1 &&
+       condition2
+      ...
+    end
+    ```
+
+    [[Feature #20925]]
+
+## Atualizações de classes principais
+
+Nota: Estamos listando apenas atualizações notáveis das classes principais.
+
+* Array
+
+    * `Array#rfind` foi adicionado como uma alternativa mais eficiente a
+      `array.reverse_each.find`. [[Feature #21678]]
+    * `Array#find` foi adicionado como uma sobrescrita mais eficiente de
+      `Enumerable#find`. [[Feature #21678]]
+
+* Binding
+
+    * `Binding#local_variables` não inclui mais parâmetros numerados.
+      Além disso, `Binding#local_variable_get`, `Binding#local_variable_set` e
+      `Binding#local_variable_defined?` deixam de lidar com parâmetros numerados.
+      [[Bug #21049]]
+
+    * `Binding#implicit_parameters`, `Binding#implicit_parameter_get` e
+      `Binding#implicit_parameter_defined?` foram adicionados para acessar
+      parâmetros numerados e o parâmetro `it`. [[Bug #21049]]
+
+* Enumerator
+
+    * `Enumerator.produce` agora aceita um argumento de palavra‑chave opcional `size`
+      para especificar o tamanho do enumerador. Pode ser um inteiro,
+      `Float::INFINITY`, um objeto chamável (como uma lambda) ou `nil` para indicar
+      tamanho desconhecido. Quando não especificado, o tamanho padrão é
+      `Float::INFINITY`.
+
+        ```ruby
+        # Enumerador infinito
+        enum = Enumerator.produce(1, size: Float::INFINITY, &:succ)
+        enum.size  # => Float::INFINITY
+
+        # Enumerador finito com tamanho conhecido/computável
+        abs_dir = File.expand_path("./baz") # => "/foo/bar/baz"
+        traverser = Enumerator.produce(abs_dir, size: -> { abs_dir.count("/") + 1 }) {
+          raise StopIteration if it == "/"
+          File.dirname(it)
+        }
+        traverser.size  # => 4
+        ```
+
+      [[Feature #21701]]
+
+* ErrorHighlight
+
+    * Quando um `ArgumentError` é levantado, agora são exibidos trechos de código
+      tanto da chamada de método (caller) quanto da definição de método (callee).
+      [[Feature #21543]]
+
+      ```
+      test.rb:1:in 'Object#add': wrong number of arguments (given 1, expected 2) (ArgumentError)
+
+          caller: test.rb:3
+          | add(1)
+            ^^^
+          callee: test.rb:1
+          | def add(x, y) = x + y
+                ^^^
+              from test.rb:3:in '<main>'
+      ```
+
+* Fiber
+
+    * Suporte ao argumento `Fiber#raise(cause:)` foi introduzido, semelhante a
+      `Kernel#raise`. [[Feature #21360]]
+
+* Fiber::Scheduler
+
+    * Introduz `Fiber::Scheduler#fiber_interrupt` para interromper um fiber com
+      uma exceção específica. O caso de uso inicial é interromper um fiber que
+      está aguardando uma operação de IO bloqueante quando essa operação é
+      encerrada. [[Feature #21166]]
+
+    * Introduz `Fiber::Scheduler#yield` para permitir que o escalonador de fibers
+      continue processando quando exceções de sinal estão desabilitadas.
+      [[Bug #21633]]
+
+    * Reintroduz o hook `Fiber::Scheduler#io_close` para `IO#close` assíncrono.
+
+    * Invoca `Fiber::Scheduler#io_write` ao esvaziar o buffer de escrita de IO.
+      [[Bug #21789]]
+
+* File
+
+    * `File::Stat#birthtime` agora está disponível no Linux via a chamada de
+      sistema `statx`, quando suportada pelo kernel e pelo sistema de arquivos.
+      [[Feature #21205]]
+
+* IO
+
+    * `IO.select` aceita `Float::INFINITY` como argumento de timeout.
+      [[Feature #20610]]
+
+    * Um comportamento obsoleto, criação de processos por métodos da classe `IO`
+      com um `|` inicial, foi removido. [[Feature #19630]]
+
+* Kernel
+
+    * `Kernel#inspect` agora verifica a existência de um método
+      `#instance_variables_to_inspect`, permitindo controlar quais variáveis de
+      instância são exibidas na string de `#inspect`:
+
+        ```ruby
+        class DatabaseConfig
+          def initialize(host, user, password)
+            @host = host
+            @user = user
+            @password = password
+          end
+
+          private def instance_variables_to_inspect = [:@host, :@user]
+        end
+
+        conf = DatabaseConfig.new("localhost", "root", "hunter2")
+        conf.inspect #=> #<DatabaseConfig:0x0000000104def350 @host="localhost", @user="root">
+        ```
+
+        [[Feature #21219]]
+
+    * Um comportamento obsoleto, criação de processos por `Kernel#open` com um
+      `|` inicial, foi removido. [[Feature #19630]]
+
+* Math
+
+    * `Math.log1p` e `Math.expm1` foram adicionados. [[Feature #21527]]
+
+* Pathname
+
+    * `Pathname` foi promovida de gem padrão para classe principal do Ruby.
+      [[Feature #17473]]
+
+* Proc
+
+    * `Proc#parameters` agora mostra parâmetros opcionais anônimos como `[:opt]`
+      em vez de `[:opt, nil]`, tornando a saída consistente com o caso em que
+      o parâmetro anônimo é obrigatório. [[Bug #20974]]
+
+* Ractor
+
+    * A classe `Ractor::Port` foi adicionada como um novo mecanismo de
+      sincronização para comunicação entre Ractors. [[Feature #21262]]
+
+        ```ruby
+        port1 = Ractor::Port.new
+        port2 = Ractor::Port.new
+        Ractor.new port1, port2 do |port1, port2|
+          port1 << 1
+          port2 << 11
+          port1 << 2
+          port2 << 12
+        end
+        2.times{ p port1.receive } #=> 1, 2
+        2.times{ p port2.receive } #=> 11, 12
+        ```
+
+        `Ractor::Port` fornece os seguintes métodos:
+
+        * `Ractor::Port#receive`
+        * `Ractor::Port#send` (ou `Ractor::Port#<<`)
+        * `Ractor::Port#close`
+        * `Ractor::Port#closed?`
+
+        Como resultado, `Ractor.yield` e `Ractor#take` foram removidos.
+
+    * `Ractor#join` e `Ractor#value` foram adicionados para aguardar o término
+      de um Ractor. São semelhantes a `Thread#join` e `Thread#value`.
+
+    * `Ractor#monitor` e `Ractor#unmonitor` foram adicionados como interfaces
+      de baixo nível usadas internamente para implementar `Ractor#join`.
+
+    * `Ractor.select` agora aceita apenas Ractors e Ports. Se Ractors forem
+      fornecidos, retorna quando um Ractor termina.
+
+    * `Ractor#default_port` foi adicionado. Cada `Ractor` possui uma porta
+      padrão, usada por `Ractor.send` e `Ractor.receive`.
+
+    * `Ractor#close_incoming` e `Ractor#close_outgoing` foram removidos.
+
+    * `Ractor.shareable_proc` e `Ractor.shareable_lambda` foram introduzidos
+      para criar `Proc` ou lambda compartilháveis.
+      [[Feature #21550]], [[Feature #21557]]
+
+* Range
+
+    * `Range#to_set` agora realiza verificações de tamanho para evitar problemas
+      com ranges infinitos. [[Bug #21654]]
+
+    * `Range#overlap?` agora lida corretamente com ranges infinitos (sem limites).
+      [[Bug #21185]]
+
+    * O comportamento de `Range#max` em ranges inteiros sem início foi corrigido.
+      [[Bug #21174]] [[Bug #21175]]
+
+* Ruby
+
+    * Um novo módulo de nível superior `Ruby` foi definido, contendo constantes
+      relacionadas ao Ruby. Este módulo foi reservado no Ruby 3.4 e agora é
+      oficialmente definido. [[Feature #20884]]
+
+* Ruby::Box
+
+    * Um novo recurso (experimental) para fornecer separação de definições.
+      Para mais detalhes sobre o "Ruby Box", veja
+      [doc/language/box.md](https://docs.ruby-lang.org/en/4.0/language/box_md.html).
+      [[Feature #21311]] [[Misc #21385]]
+
+* Set
+
+    * `Set` agora é uma classe principal, em vez de uma classe da biblioteca
+      padrão carregada sob demanda. [[Feature #21216]]
+
+    * `Set#inspect` agora usa uma forma de exibição mais simples, semelhante a
+      arrays literais (por exemplo, `Set[1, 2, 3]` em vez de
+      `#<Set: {1, 2, 3}>`). [[Feature #21389]]
+
+    * Passar argumentos para `Set#to_set` e `Enumerable#to_set` agora é
+      desencorajado (deprecated). [[Feature #21390]]
+
+* Socket
+
+    * `Socket.tcp` e `TCPSocket.new` aceitam um argumento de palavra‑chave
+      `open_timeout` para especificar o timeout da conexão inicial.
+      [[Feature #21347]]
+
+    * Quando um timeout especificado pelo usuário ocorria em `TCPSocket.new`,
+      anteriormente podiam ser levantadas `Errno::ETIMEDOUT` ou `IO::TimeoutError`,
+      dependendo da situação. Esse comportamento foi unificado para que agora
+      `IO::TimeoutError` seja sempre levantado.
+      (Observe que, em `Socket.tcp`, ainda podem existir casos em que
+      `Errno::ETIMEDOUT` seja levantada em situações semelhantes, e que, em ambos
+      os casos, `Errno::ETIMEDOUT` pode ser levantada quando o timeout ocorre no
+      nível do sistema operacional.)
+
+* String
+
+    * Atualização do Unicode para a versão 17.0.0 e do Emoji para a versão 17.0.
+      [[Feature #19908]][[Feature #20724]][[Feature #21275]] (também se aplica a `Regexp`)
+
+    * `String#strip`, `strip!`, `lstrip`, `lstrip!`, `rstrip` e `rstrip!`
+       foram estendidos para aceitar argumentos `*selectors`.
+       [[Feature #21552]]
+
+* Thread
+
+    * Suporte ao argumento `Thread#raise(cause:)` foi introduzido, semelhante a
+      `Kernel#raise`. [[Feature #21360]]
+
+## Atualizações da Biblioteca Padrão
+
+Listamos aqui apenas mudanças na biblioteca padrão que são alterações de recurso notáveis.
+
+Outras mudanças estão listadas nas seções seguintes. Também listamos o histórico de
+lançamentos desde a versão anterior empacotada, Ruby 3.4.0, quando há releases no GitHub.
+
+As seguintes gems empacotadas foram promovidas de gems padrão:
+
+* ostruct 0.6.3
+  * 0.6.1 até [v0.6.2][ostruct-v0.6.2], [v0.6.3][ostruct-v0.6.3]
+* pstore 0.2.0
+  * 0.1.4 até [v0.2.0][pstore-v0.2.0]
+* benchmark 0.5.0
+  * 0.4.0 até [v0.4.1][benchmark-v0.4.1], [v0.5.0][benchmark-v0.5.0]
+* logger 1.7.0
+  * 1.6.4 até [v1.6.5][logger-v1.6.5], [v1.6.6][logger-v1.6.6], [v1.7.0][logger-v1.7.0]
+* rdoc 7.0.2
+  * 6.14.0 até [v6.14.1][rdoc-v6.14.1], [v6.14.2][rdoc-v6.14.2], [v6.15.0][rdoc-v6.15.0],
+    [v6.15.1][rdoc-v6.15.1], [v6.16.0][rdoc-v6.16.0], [v6.16.1][rdoc-v6.16.1],
+    [v6.17.0][rdoc-v6.17.0], [v7.0.0][rdoc-v7.0.0], [v7.0.1][rdoc-v7.0.1],
+    [v7.0.2][rdoc-v7.0.2], [v7.0.3][rdoc-v7.0.3]
+* win32ole 1.9.2
+  * 1.9.1 até [v1.9.2][win32ole-v1.9.2]
+* irb 1.16.0
+  * 1.14.3 até [v1.15.0][irb-v1.15.0], [v1.15.1][irb-v1.15.1], [v1.15.2][irb-v1.15.2],
+    [v1.15.3][irb-v1.15.3], [v1.16.0][irb-v1.16.0]
+* reline 0.6.3
+  * 0.6.0 até [v0.6.1][reline-v0.6.1], [v0.6.2][reline-v0.6.2], [v0.6.3][reline-v0.6.3]
+* readline 0.0.4
+* fiddle 1.1.8
+  * 1.1.6 até [v1.1.7][fiddle-v1.1.7], [v1.1.8][fiddle-v1.1.8]
+
+As seguintes gems padrão foram adicionadas:
+
+* win32-registry 0.1.2
+
+As seguintes gems padrão foram atualizadas:
+
+* RubyGems 4.0.3
+* bundler 4.0.3
+* date 3.5.1
+  * 3.4.1 até [v3.5.0][date-v3.5.0], [v3.5.1][date-v3.5.1]
+* delegate 0.6.1
+  * 0.4.0 até [v0.5.0][delegate-v0.5.0], [v0.6.0][delegate-v0.6.0],
+    [v0.6.1][delegate-v0.6.1]
+* digest 3.2.1
+  * 3.2.0 até [v3.2.1][digest-v3.2.1]
+* english 0.8.1
+  * 0.8.0 até [v0.8.1][english-v0.8.1]
+* erb 6.0.1
+  * 4.0.4 até [v5.1.2][erb-v5.1.2], [v5.1.3][erb-v5.1.3], [v6.0.0][erb-v6.0.0],
+    [v6.0.1][erb-v6.0.1]
+* error_highlight 0.7.1
+* etc 1.4.6
+* fcntl 1.3.0
+  * 1.2.0 até [v1.3.0][fcntl-v1.3.0]
+* fileutils 1.8.0
+  * 1.7.3 até [v1.8.0][fileutils-v1.8.0]
+* forwardable 1.4.0
+  * 1.3.3 até [v1.4.0][forwardable-v1.4.0]
+* io-console 0.8.2
+  * 0.8.1 até [v0.8.2][io-console-v0.8.2]
+* io-nonblock 0.3.2
+* io-wait 0.4.0
+  * 0.3.2 até [v0.3.3][io-wait-v0.3.3], [v0.3.5.test1][io-wait-v0.3.5.test1],
+    [v0.3.5][io-wait-v0.3.5], [v0.3.6][io-wait-v0.3.6], [v0.4.0][io-wait-v0.4.0]
+* ipaddr 1.2.8
+* json 2.18.0
+  * 2.9.1 até [v2.10.0][json-v2.10.0], [v2.10.1][json-v2.10.1],
+    [v2.10.2][json-v2.10.2], [v2.11.0][json-v2.11.0], [v2.11.1][json-v2.11.1],
+    [v2.11.2][json-v2.11.2], [v2.11.3][json-v2.11.3], [v2.12.0][json-v2.12.0],
+    [v2.12.1][json-v2.12.1], [v2.12.2][json-v2.12.2], [v2.13.0][json-v2.13.0],
+    [v2.13.1][json-v2.13.1], [v2.13.2][json-v2.13.2], [v2.14.0][json-v2.14.0],
+    [v2.14.1][json-v2.14.1], [v2.15.0][json-v2.15.0], [v2.15.1][json-v2.15.1],
+    [v2.15.2][json-v2.15.2], [v2.16.0][json-v2.16.0], [v2.17.0][json-v2.17.0],
+    [v2.17.1][json-v2.17.1], [v2.18.0][json-v2.18.0]
+* net-http 0.9.1
+  * 0.6.0 até [v0.7.0][net-http-v0.7.0], [v0.8.0][net-http-v0.8.0],
+    [v0.9.0][net-http-v0.9.0], [v0.9.1][net-http-v0.9.1]
+* openssl 4.0.0
+  * 3.3.1 até [v3.3.2][openssl-v3.3.2], [v4.0.0][openssl-v4.0.0]
+* optparse 0.8.1
+  * 0.6.0 até [v0.7.0][optparse-v0.7.0], [v0.8.0][optparse-v0.8.0],
+    [v0.8.1][optparse-v0.8.1]
+* pp 0.6.3
+  * 0.6.2 até [v0.6.3][pp-v0.6.3]
+* prism 1.7.0
+  * 1.5.2 até [v1.6.0][prism-v1.6.0], [v1.7.0][prism-v1.7.0]
+* psych 5.3.1
+  * 5.2.2 até [v5.2.3][psych-v5.2.3], [v5.2.4][psych-v5.2.4],
+    [v5.2.5][psych-v5.2.5], [v5.2.6][psych-v5.2.6], [v5.3.0][psych-v5.3.0],
+    [v5.3.1][psych-v5.3.1]
+* resolv 0.7.0
+  * 0.6.2 até [v0.6.3][resolv-v0.6.3], [v0.7.0][resolv-v0.7.0]
+* stringio 3.2.0
+  * 3.1.2 até [v3.1.3][stringio-v3.1.3], [v3.1.4][stringio-v3.1.4],
+    [v3.1.5][stringio-v3.1.5], [v3.1.6][stringio-v3.1.6], [v3.1.7][stringio-v3.1.7],
+    [v3.1.8][stringio-v3.1.8], [v3.1.9][stringio-v3.1.9], [v3.2.0][stringio-v3.2.0]
+* strscan 3.1.6
+  * 3.1.2 até [v3.1.3][strscan-v3.1.3], [v3.1.4][strscan-v3.1.4],
+    [v3.1.5][strscan-v3.1.5], [v3.1.6][strscan-v3.1.6]
+* time 0.4.2
+  * 0.4.1 até [v0.4.2][time-v0.4.2]
+* timeout 0.6.0
+  * 0.4.3 até [v0.4.4][timeout-v0.4.4], [v0.5.0][timeout-v0.5.0],
+    [v0.6.0][timeout-v0.6.0]
+* uri 1.1.1
+  * 1.0.4 até [v1.1.0][uri-v1.1.0], [v1.1.1][uri-v1.1.1]
+* weakref 0.1.4
+  * 0.1.3 até [v0.1.4][weakref-v0.1.4]
+* zlib 3.2.2
+  * 3.2.1 até [v3.2.2][zlib-v3.2.2]
+
+As seguintes gems empacotadas foram atualizadas:
+
+* minitest 6.0.0
+* power_assert 3.0.1
+  * 2.0.5 até [v3.0.0][power_assert-v3.0.0], [v3.0.1][power_assert-v3.0.1]
+* rake 13.3.1
+  * 13.2.1 até [v13.3.0][rake-v13.3.0], [v13.3.1][rake-v13.3.1]
+* test-unit 3.7.5
+  * 3.6.7 até [3.6.8][test-unit-3.6.8], [3.6.9][test-unit-3.6.9],
+    [3.7.0][test-unit-3.7.0], [3.7.1][test-unit-3.7.1], [3.7.2][test-unit-3.7.2],
+    [3.7.3][test-unit-3.7.3], [3.7.4][test-unit-3.7.4], [3.7.5][test-unit-3.7.5]
+* rexml 3.4.4
+* rss 0.3.2
+  * 0.3.1 até [0.3.2][rss-0.3.2]
+* net-ftp 0.3.9
+  * 0.3.8 até [v0.3.9][net-ftp-v0.3.9]
+* net-imap 0.6.2
+  * 0.5.8 até [v0.5.9][net-imap-v0.5.9], [v0.5.10][net-imap-v0.5.10],
+    [v0.5.11][net-imap-v0.5.11], [v0.5.12][net-imap-v0.5.12],
+    [v0.5.13][net-imap-v0.5.13], [v0.6.0][net-imap-v0.6.0],
+    [v0.6.1][net-imap-v0.6.1], [v0.6.2][net-imap-v0.6.2]
+* net-smtp 0.5.1
+  * 0.5.0 até [v0.5.1][net-smtp-v0.5.1]
+* matrix 0.4.3
+  * 0.4.2 até [v0.4.3][matrix-v0.4.3]
+* prime 0.1.4
+  * 0.1.3 até [v0.1.4][prime-v0.1.4]
+* rbs 3.10.0
+  * 3.8.0 até [v3.8.1][rbs-v3.8.1], [v3.9.0.dev.1][rbs-v3.9.0.dev.1],
+    [v3.9.0.pre.1][rbs-v3.9.0.pre.1], [v3.9.0.pre.2][rbs-v3.9.0.pre.2],
+    [v3.9.0][rbs-v3.9.0], [v3.9.1][rbs-v3.9.1], [v3.9.2][rbs-v3.9.2],
+    [v3.9.3][rbs-v3.9.3], [v3.9.4][rbs-v3.9.4], [v3.9.5][rbs-v3.9.5],
+    [v3.10.0.pre.1][rbs-v3.10.0.pre.1], [v3.10.0.pre.2][rbs-v3.10.0.pre.2],
+    [v3.10.0][rbs-v3.10.0]
+* typeprof 0.31.1
+* debug 1.11.1
+  * 1.11.0 até [v1.11.1][debug-v1.11.1]
+* base64 0.3.0
+  * 0.2.0 até [v0.3.0][base64-v0.3.0]
+* bigdecimal 4.0.1
+  * 3.1.8 até [v3.2.0][bigdecimal-v3.2.0], [v3.2.1][bigdecimal-v3.2.1],
+    [v3.2.2][bigdecimal-v3.2.2], [v3.2.3][bigdecimal-v3.2.3],
+    [v3.3.0][bigdecimal-v3.3.0], [v3.3.1][bigdecimal-v3.3.1],
+    [v4.0.0][bigdecimal-v4.0.0], [v4.0.1][bigdecimal-v4.0.1]
+* drb 2.2.3
+  * 2.2.1 até [v2.2.3][drb-v2.2.3]
+* syslog 0.3.0
+  * 0.2.0 até [v0.3.0][syslog-v0.3.0]
+* csv 3.3.5
+  * 3.3.2 até [v3.3.3][csv-v3.3.3], [v3.3.4][csv-v3.3.4],
+    [v3.3.5][csv-v3.3.5]
+* repl_type_completor 0.1.12
+
+### RubyGems e Bundler
+
+Ruby 4.0 empacota RubyGems e Bundler versão 4. Veja os links a seguir para mais detalhes.
+
+* [Upgrading to RubyGems/Bundler 4 - RubyGems Blog](https://blog.rubygems.org/2025/12/03/upgrade-to-rubygems-bundler-4.html)
+* [4.0.0 Released - RubyGems Blog](https://blog.rubygems.org/2025/12/03/4.0.0-released.html)
+* [4.0.1 Released - RubyGems Blog](https://blog.rubygems.org/2025/12/09/4.0.1-released.html)
+* [4.0.2 Released - RubyGems Blog](https://blog.rubygems.org/2025/12/17/4.0.2-released.html)
+* [4.0.3 Released - RubyGems Blog](https://blog.rubygems.org/2025/12/23/4.0.3-released.html)
+
+## Plataformas suportadas
+
+* Windows
+
+    * Suporte a versões do MSVC anteriores a 14.0 (_MSC_VER 1900) foi removido.
+      Isso significa que o Visual Studio 2015 ou mais recente agora é obrigatório.
+
+## Problemas de compatibilidade
+
+* Os seguintes métodos foram removidos de `Ractor` devido à adição de `Ractor::Port`:
+
+    * `Ractor.yield`
+    * `Ractor#take`
+    * `Ractor#close_incoming`
+    * `Ractor#close_outgoing`
+
+    [[Feature #21262]]
+
+* `ObjectSpace._id2ref` está obsoleto. [[Feature #15408]]
+
+* `Process::Status#&` e `Process::Status#>>` foram removidos.
+  Eles foram marcados como obsoletos no Ruby 3.3. [[Bug #19868]]
+
+* `rb_path_check` foi removida. Essa função era usada para verificação de caminhos
+  com `$SAFE`, que foi removida no Ruby 2.7, e já estava obsoleta.
+  [[Feature #20971]]
+
+* Um backtrace para `ArgumentError` de "wrong number of arguments" agora inclui
+  o nome da classe ou módulo do receiver (por exemplo, em `Foo#bar` em vez de
+  apenas `bar`). [[Bug #21698]]
+
+* Backtraces não exibem mais frames `internal`.
+  Esses métodos agora aparecem como se estivessem no arquivo de código Ruby,
+  consistente com outros métodos implementados em C. [[Bug #20968]]
+
+  Antes:
+  ```
+  ruby -e '[1].fetch_values(42)'
+  <internal:array>:211:in 'Array#fetch': index 42 outside of array bounds: -1...1 (IndexError)
+          from <internal:array>:211:in 'block in Array#fetch_values'
+          from <internal:array>:211:in 'Array#map!'
+          from <internal:array>:211:in 'Array#fetch_values'
+          from -e:1:in '<main>'
+  ```
+
+  Depois:
+  ```
+  $ ruby -e '[1].fetch_values(42)'
+  -e:1:in 'Array#fetch_values': index 42 outside of array bounds: -1...1 (IndexError)
+          from -e:1:in '<main>'
+  ```
+
+## Problemas de compatibilidade da biblioteca padrão
+
+* A biblioteca `CGI` foi removida das gems padrão. Agora fornecemos apenas `cgi/escape`
+  para os seguintes métodos:
+
+    * `CGI.escape` e `CGI.unescape`
+    * `CGI.escapeHTML` e `CGI.unescapeHTML`
+    * `CGI.escapeURIComponent` e `CGI.unescapeURIComponent`
+    * `CGI.escapeElement` e `CGI.unescapeElement`
+
+    [[Feature #21258]]
+
+* Com a mudança de `Set` da biblioteca padrão para classe principal,
+  `set/sorted_set.rb` foi removido e `SortedSet` não é mais uma constante carregada
+  sob demanda. Por favor, instale a gem `sorted_set` e faça
+  `require 'sorted_set'` para usar `SortedSet`. [[Feature #21287]]
+
+* Net::HTTP
+
+    * O comportamento padrão de configurar automaticamente o cabeçalho
+      `Content-Type` como `application/x-www-form-urlencoded` para requisições
+      com corpo (por exemplo, `POST`, `PUT`) quando o cabeçalho não era definido
+      explicitamente foi removido. Se sua aplicação dependia desse padrão
+      automático, agora as requisições serão enviadas sem um cabeçalho
+      `Content-Type`, o que pode quebrar compatibilidade com alguns servidores.
+      [[GH-net-http #205]]
+
+## Atualizações da C API
+
+* IO
+
+    * `rb_thread_fd_close` está obsoleta e agora é um no‑op. Se você precisar
+      expor descritores de arquivo de extensões C para código Ruby, crie uma
+      instância de `IO` usando `RUBY_IO_MODE_EXTERNAL` e use `rb_io_close(io)` para
+      fechá‑la (isso também interrompe e aguarda todas as operações pendentes na
+      instância de `IO`). Fechar descritores de arquivo diretamente não interrompe
+      operações pendentes e pode levar a comportamento indefinido. Em outras
+      palavras, se dois objetos `IO` compartilham o mesmo descritor de arquivo,
+      fechar um não afeta o outro. [[Feature #18455]]
+
+* GVL
+
+    * `rb_thread_call_with_gvl` agora funciona com ou sem o GVL.
+      Isso permite que gems evitem verificar `ruby_thread_has_gvl_p`.
+      Ainda assim, é importante ser cuidadoso com o GVL. [[Feature #20750]]
+
+* Set
+
+    * Uma API em C para `Set` foi adicionada. Os seguintes métodos são suportados:
+      [[Feature #21459]]
+
+        * `rb_set_foreach`
+        * `rb_set_new`
+        * `rb_set_new_capa`
+        * `rb_set_lookup`
+        * `rb_set_add`
+        * `rb_set_clear`
+        * `rb_set_delete`
+        * `rb_set_size`
+
+## Melhorias na implementação
+
+* `Class#new` (por exemplo, `Object.new`) está mais rápido em todos os casos, mas
+  especialmente ao passar argumentos de palavra‑chave. Isso também foi integrado
+  ao YJIT e ao ZJIT. [[Feature #21254]]
+* Heaps do GC de pools de tamanhos diferentes agora crescem de forma independente,
+  reduzindo o uso de memória quando apenas alguns pools contêm objetos de vida longa.
+* A varredura (sweeping) do GC está mais rápida em páginas de objetos grandes.
+* Objetos de "generic ivar" (String, Array, `TypedData`, etc.) agora usam um novo
+  objeto interno de "fields" para acesso mais rápido a variáveis de instância.
+* O GC evita manter uma tabela interna `id2ref` até que seja usada pela primeira vez,
+  tornando a alocação de `object_id` e a varredura do GC mais rápidas.
+* `object_id` e `hash` estão mais rápidos em objetos `Class` e `Module`.
+* Inteiros bignum maiores agora podem permanecer embutidos usando alocação de
+  largura variável.
+* `Random`, `Enumerator::Product`, `Enumerator::Chain`, `Addrinfo`,
+  `StringScanner` e alguns objetos internos agora são protegidos por write‑barrier,
+  o que reduz a sobrecarga do GC.
+
+### Ractor
+
+Muito trabalho foi feito para tornar Ractors mais estáveis, performáticos e utilizáveis.
+Essas melhorias aproximam a implementação de Ractor de deixar o status experimental.
+
+* Melhorias de desempenho
+    * Strings congeladas e a tabela de símbolos usam internamente um hash set
+      lock‑free. [[Feature #21268]]
+    * A busca no cache de métodos evita bloqueios na maioria dos casos.
+    * O acesso a variáveis de instância de classes (e generic ivar) está mais
+      rápido e evita bloqueios.
+    * A contenção de cache de CPU é evitada na alocação de objetos usando um
+      contador por Ractor.
+    * A contenção de cache de CPU é evitada em `xmalloc`/`xfree` usando um
+      contador local à thread.
+    * `object_id` evita bloqueios na maioria dos casos.
+* Correções de bugs e estabilidade
+    * Correções de deadlocks potenciais ao combinar Ractors e Threads.
+    * Correções em problemas com `require` e `autoload` em Ractor.
+    * Correções em problemas de codificação/transcodificação entre Ractors.
+    * Correções em condições de corrida em operações do GC e invalidação de métodos.
+    * Correções em problemas com processos que fazem fork após iniciar um Ractor.
+    * Contagens de alocação do GC agora são precisas sob Ractors.
+    * Correção de TracePoints que não funcionavam após o GC. [[Bug #19112]]
+
+## JIT
+
+* ZJIT
+    * Introduz um [compilador JIT baseado em métodos](https://docs.ruby-lang.org/en/master/jit/zjit_md.html)
+      experimental. Onde disponível, o ZJIT pode ser habilitado em tempo de execução
+      com a opção `--zjit` ou chamando `RubyVM::ZJIT.enable`.
+      Ao compilar o Ruby, é necessário Rust 1.85.0 ou mais recente para incluir
+      suporte ao ZJIT.
+    * A partir do Ruby 4.0.0, o ZJIT é mais rápido que o interpretador, mas ainda
+      não é tão rápido quanto o YJIT. Incentivamos a experimentação com o ZJIT,
+      mas recomendamos não usá‑lo em produção por enquanto.
+    * Nosso objetivo é tornar o ZJIT mais rápido que o YJIT e pronto para produção
+      no Ruby 4.1.
+* YJIT
+    * `RubyVM::YJIT.runtime_stats`
+        * `ratio_in_yjit` não funciona mais na build padrão.
+          Use `--enable-yjit=stats` em `configure` para habilitá‑lo com
+          `--yjit-stats`.
+        * Adiciona `invalidate_everything` às estatísticas padrão, que é
+          incrementada quando todo o código é invalidado por TracePoint.
+    * Adiciona opções `mem_size:` e `call_threshold:` a `RubyVM::YJIT.enable`.
+* RJIT
+    * `--rjit` foi removido. A implementação da API de JIT de terceiros será
+      movida para o repositório
+      [ruby/rjit](https://github.com/ruby/rjit).
+
+Veja [NEWS](https://docs.ruby-lang.org/en/{{ release.tag }}/NEWS_md.html)
+ou [logs de commits](https://github.com/ruby/ruby/compare/v3_4_0...{{ release.tag }})
+para mais detalhes.
+
+Com essas mudanças,
+[{{ release.stats.files_changed }} arquivos alterados, {{ release.stats.insertions }} inserções(+), {{ release.stats.deletions }} deleções(-)](https://github.com/ruby/ruby/compare/v3_4_0...{{ release.tag }}#file_bucket)
+desde Ruby 3.4.0!
+
+Feliz Natal, um Próspero Ano Novo e aproveite a programação com Ruby 4.0!
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## O que é Ruby
+
+Ruby foi desenvolvido pela primeira vez por Matz (Yukihiro Matsumoto) em 1993,
+e agora é desenvolvido como Open Source. Ele roda em várias plataformas
+e é usado em todo o mundo, especialmente para desenvolvimento web.
+
+[Feature #15408]: https://bugs.ruby-lang.org/issues/15408
+[Feature #17473]: https://bugs.ruby-lang.org/issues/17473
+[Feature #18455]: https://bugs.ruby-lang.org/issues/18455
+[Bug #19112]:     https://bugs.ruby-lang.org/issues/19112
+[Feature #19630]: https://bugs.ruby-lang.org/issues/19630
+[Bug #19868]:     https://bugs.ruby-lang.org/issues/19868
+[Feature #19908]: https://bugs.ruby-lang.org/issues/19908
+[Feature #20610]: https://bugs.ruby-lang.org/issues/20610
+[Feature #20724]: https://bugs.ruby-lang.org/issues/20724
+[Feature #20750]: https://bugs.ruby-lang.org/issues/20750
+[Feature #20884]: https://bugs.ruby-lang.org/issues/20884
+[Feature #20925]: https://bugs.ruby-lang.org/issues/20925
+[Bug #20968]:     https://bugs.ruby-lang.org/issues/20968
+[Feature #20971]: https://bugs.ruby-lang.org/issues/20971
+[Bug #20974]:     https://bugs.ruby-lang.org/issues/20974
+[Feature #21047]: https://bugs.ruby-lang.org/issues/21047
+[Bug #21049]:     https://bugs.ruby-lang.org/issues/21049
+[Feature #21166]: https://bugs.ruby-lang.org/issues/21166
+[Bug #21174]:     https://bugs.ruby-lang.org/issues/21174
+[Bug #21175]:     https://bugs.ruby-lang.org/issues/21175
+[Bug #21185]:     https://bugs.ruby-lang.org/issues/21185
+[Feature #21205]: https://bugs.ruby-lang.org/issues/21205
+[Feature #21216]: https://bugs.ruby-lang.org/issues/21216
+[Feature #21219]: https://bugs.ruby-lang.org/issues/21219
+[Feature #21254]: https://bugs.ruby-lang.org/issues/21254
+[Feature #21258]: https://bugs.ruby-lang.org/issues/21258
+[Feature #21268]: https://bugs.ruby-lang.org/issues/21268
+[Feature #21262]: https://bugs.ruby-lang.org/issues/21262
+[Feature #21275]: https://bugs.ruby-lang.org/issues/21275
+[Feature #21287]: https://bugs.ruby-lang.org/issues/21287
+[Feature #21311]: https://bugs.ruby-lang.org/issues/21311
+[Feature #21347]: https://bugs.ruby-lang.org/issues/21347
+[Feature #21360]: https://bugs.ruby-lang.org/issues/21360
+[Misc #21385]:    https://bugs.ruby-lang.org/issues/21385
+[Feature #21389]: https://bugs.ruby-lang.org/issues/21389
+[Feature #21390]: https://bugs.ruby-lang.org/issues/21390
+[Feature #21459]: https://bugs.ruby-lang.org/issues/21459
+[Feature #21527]: https://bugs.ruby-lang.org/issues/21527
+[Feature #21543]: https://bugs.ruby-lang.org/issues/21543
+[Feature #21550]: https://bugs.ruby-lang.org/issues/21550
+[Feature #21552]: https://bugs.ruby-lang.org/issues/21552
+[Feature #21557]: https://bugs.ruby-lang.org/issues/21557
+[Bug #21633]:     https://bugs.ruby-lang.org/issues/21633
+[Bug #21654]:     https://bugs.ruby-lang.org/issues/21654
+[Feature #21678]: https://bugs.ruby-lang.org/issues/21678
+[Bug #21698]:     https://bugs.ruby-lang.org/issues/21698
+[Feature #21701]: https://bugs.ruby-lang.org/issues/21701
+[Bug #21789]:     https://bugs.ruby-lang.org/issues/21789
+[GH-net-http #205]: https://github.com/ruby/net-http/issues/205
+[ostruct-v0.6.2]: https://github.com/ruby/ostruct/releases/tag/v0.6.2
+[ostruct-v0.6.3]: https://github.com/ruby/ostruct/releases/tag/v0.6.3
+[pstore-v0.2.0]: https://github.com/ruby/pstore/releases/tag/v0.2.0
+[benchmark-v0.4.1]: https://github.com/ruby/benchmark/releases/tag/v0.4.1
+[benchmark-v0.5.0]: https://github.com/ruby/benchmark/releases/tag/v0.5.0
+[logger-v1.6.5]: https://github.com/ruby/logger/releases/tag/v1.6.5
+[logger-v1.6.6]: https://github.com/ruby/logger/releases/tag/v1.6.6
+[logger-v1.7.0]: https://github.com/ruby/logger/releases/tag/v1.7.0
+[rdoc-v6.14.1]: https://github.com/ruby/rdoc/releases/tag/v6.14.1
+[rdoc-v6.14.2]: https://github.com/ruby/rdoc/releases/tag/v6.14.2
+[rdoc-v6.15.0]: https://github.com/ruby/rdoc/releases/tag/v6.15.0
+[rdoc-v6.15.1]: https://github.com/ruby/rdoc/releases/tag/v6.15.1
+[rdoc-v6.16.0]: https://github.com/ruby/rdoc/releases/tag/v6.16.0
+[rdoc-v6.16.1]: https://github.com/ruby/rdoc/releases/tag/v6.16.1
+[rdoc-v6.17.0]: https://github.com/ruby/rdoc/releases/tag/v6.17.0
+[rdoc-v7.0.0]: https://github.com/ruby/rdoc/releases/tag/v7.0.0
+[rdoc-v7.0.1]: https://github.com/ruby/rdoc/releases/tag/v7.0.1
+[rdoc-v7.0.2]: https://github.com/ruby/rdoc/releases/tag/v7.0.2
+[rdoc-v7.0.3]: https://github.com/ruby/rdoc/releases/tag/v7.0.3
+[win32ole-v1.9.2]: https://github.com/ruby/win32ole/releases/tag/v1.9.2
+[irb-v1.15.0]: https://github.com/ruby/irb/releases/tag/v1.15.0
+[irb-v1.15.1]: https://github.com/ruby/irb/releases/tag/v1.15.1
+[irb-v1.15.2]: https://github.com/ruby/irb/releases/tag/v1.15.2
+[irb-v1.15.3]: https://github.com/ruby/irb/releases/tag/v1.15.3
+[irb-v1.16.0]: https://github.com/ruby/irb/releases/tag/v1.16.0
+[reline-v0.6.1]: https://github.com/ruby/reline/releases/tag/v0.6.1
+[reline-v0.6.2]: https://github.com/ruby/reline/releases/tag/v0.6.2
+[reline-v0.6.3]: https://github.com/ruby/reline/releases/tag/v0.6.3
+[fiddle-v1.1.7]: https://github.com/ruby/fiddle/releases/tag/v1.1.7
+[fiddle-v1.1.8]: https://github.com/ruby/fiddle/releases/tag/v1.1.8
+[date-v3.5.0]: https://github.com/ruby/date/releases/tag/v3.5.0
+[date-v3.5.1]: https://github.com/ruby/date/releases/tag/v3.5.1
+[delegate-v0.5.0]: https://github.com/ruby/delegate/releases/tag/v0.5.0
+[delegate-v0.6.0]: https://github.com/ruby/delegate/releases/tag/v0.6.0
+[delegate-v0.6.1]: https://github.com/ruby/delegate/releases/tag/v0.6.1
+[digest-v3.2.1]: https://github.com/ruby/digest/releases/tag/v3.2.1
+[english-v0.8.1]: https://github.com/ruby/english/releases/tag/v0.8.1
+[erb-v5.1.2]: https://github.com/ruby/erb/releases/tag/v5.1.2
+[erb-v5.1.3]: https://github.com/ruby/erb/releases/tag/v5.1.3
+[erb-v6.0.0]: https://github.com/ruby/erb/releases/tag/v6.0.0
+[erb-v6.0.1]: https://github.com/ruby/erb/releases/tag/v6.0.1
+[fcntl-v1.3.0]: https://github.com/ruby/fcntl/releases/tag/v1.3.0
+[fileutils-v1.8.0]: https://github.com/ruby/fileutils/releases/tag/v1.8.0
+[forwardable-v1.4.0]: https://github.com/ruby/forwardable/releases/tag/v1.4.0
+[io-console-v0.8.2]: https://github.com/ruby/io-console/releases/tag/v0.8.2
+[io-wait-v0.3.3]: https://github.com/ruby/io-wait/releases/tag/v0.3.3
+[io-wait-v0.3.5.test1]: https://github.com/ruby/io-wait/releases/tag/v0.3.5.test1
+[io-wait-v0.3.5]: https://github.com/ruby/io-wait/releases/tag/v0.3.5
+[io-wait-v0.3.6]: https://github.com/ruby/io-wait/releases/tag/v0.3.6
+[io-wait-v0.4.0]: https://github.com/ruby/io-wait/releases/tag/v0.4.0
+[json-v2.10.0]: https://github.com/ruby/json/releases/tag/v2.10.0
+[json-v2.10.1]: https://github.com/ruby/json/releases/tag/v2.10.1
+[json-v2.10.2]: https://github.com/ruby/json/releases/tag/v2.10.2
+[json-v2.11.0]: https://github.com/ruby/json/releases/tag/v2.11.0
+[json-v2.11.1]: https://github.com/ruby/json/releases/tag/v2.11.1
+[json-v2.11.2]: https://github.com/ruby/json/releases/tag/v2.11.2
+[json-v2.11.3]: https://github.com/ruby/json/releases/tag/v2.11.3
+[json-v2.12.0]: https://github.com/ruby/json/releases/tag/v2.12.0
+[json-v2.12.1]: https://github.com/ruby/json/releases/tag/v2.12.1
+[json-v2.12.2]: https://github.com/ruby/json/releases/tag/v2.12.2
+[json-v2.13.0]: https://github.com/ruby/json/releases/tag/v2.13.0
+[json-v2.13.1]: https://github.com/ruby/json/releases/tag/v2.13.1
+[json-v2.13.2]: https://github.com/ruby/json/releases/tag/v2.13.2
+[json-v2.14.0]: https://github.com/ruby/json/releases/tag/v2.14.0
+[json-v2.14.1]: https://github.com/ruby/json/releases/tag/v2.14.1
+[json-v2.15.0]: https://github.com/ruby/json/releases/tag/v2.15.0
+[json-v2.15.1]: https://github.com/ruby/json/releases/tag/v2.15.1
+[json-v2.15.2]: https://github.com/ruby/json/releases/tag/v2.15.2
+[json-v2.16.0]: https://github.com/ruby/json/releases/tag/v2.16.0
+[json-v2.17.0]: https://github.com/ruby/json/releases/tag/v2.17.0
+[json-v2.17.1]: https://github.com/ruby/json/releases/tag/v2.17.1
+[json-v2.18.0]: https://github.com/ruby/json/releases/tag/v2.18.0
+[net-http-v0.7.0]: https://github.com/ruby/net-http/releases/tag/v0.7.0
+[net-http-v0.8.0]: https://github.com/ruby/net-http/releases/tag/v0.8.0
+[net-http-v0.9.0]: https://github.com/ruby/net-http/releases/tag/v0.9.0
+[net-http-v0.9.1]: https://github.com/ruby/net-http/releases/tag/v0.9.1
+[openssl-v3.3.2]: https://github.com/ruby/openssl/releases/tag/v3.3.2
+[openssl-v4.0.0]: https://github.com/ruby/openssl/releases/tag/v4.0.0
+[optparse-v0.7.0]: https://github.com/ruby/optparse/releases/tag/v0.7.0
+[optparse-v0.8.0]: https://github.com/ruby/optparse/releases/tag/v0.8.0
+[optparse-v0.8.1]: https://github.com/ruby/optparse/releases/tag/v0.8.1
+[pp-v0.6.3]: https://github.com/ruby/pp/releases/tag/v0.6.3
+[prism-v1.6.0]: https://github.com/ruby/prism/releases/tag/v1.6.0
+[prism-v1.7.0]: https://github.com/ruby/prism/releases/tag/v1.7.0
+[psych-v5.2.3]: https://github.com/ruby/psych/releases/tag/v5.2.3
+[psych-v5.2.4]: https://github.com/ruby/psych/releases/tag/v5.2.4
+[psych-v5.2.5]: https://github.com/ruby/psych/releases/tag/v5.2.5
+[psych-v5.2.6]: https://github.com/ruby/psych/releases/tag/v5.2.6
+[psych-v5.3.0]: https://github.com/ruby/psych/releases/tag/v5.3.0
+[psych-v5.3.1]: https://github.com/ruby/psych/releases/tag/v5.3.1
+[resolv-v0.6.3]: https://github.com/ruby/resolv/releases/tag/v0.6.3
+[resolv-v0.7.0]: https://github.com/ruby/resolv/releases/tag/v0.7.0
+[stringio-v3.1.3]: https://github.com/ruby/stringio/releases/tag/v3.1.3
+[stringio-v3.1.4]: https://github.com/ruby/stringio/releases/tag/v3.1.4
+[stringio-v3.1.5]: https://github.com/ruby/stringio/releases/tag/v3.1.5
+[stringio-v3.1.6]: https://github.com/ruby/stringio/releases/tag/v3.1.6
+[stringio-v3.1.7]: https://github.com/ruby/stringio/releases/tag/v3.1.7
+[stringio-v3.1.8]: https://github.com/ruby/stringio/releases/tag/v3.1.8
+[stringio-v3.1.9]: https://github.com/ruby/stringio/releases/tag/v3.1.9
+[stringio-v3.2.0]: https://github.com/ruby/stringio/releases/tag/v3.2.0
+[strscan-v3.1.3]: https://github.com/ruby/strscan/releases/tag/v3.1.3
+[strscan-v3.1.4]: https://github.com/ruby/strscan/releases/tag/v3.1.4
+[strscan-v3.1.5]: https://github.com/ruby/strscan/releases/tag/v3.1.5
+[strscan-v3.1.6]: https://github.com/ruby/strscan/releases/tag/v3.1.6
+[time-v0.4.2]: https://github.com/ruby/time/releases/tag/v0.4.2
+[timeout-v0.4.4]: https://github.com/ruby/timeout/releases/tag/v0.4.4
+[timeout-v0.5.0]: https://github.com/ruby/timeout/releases/tag/v0.5.0
+[timeout-v0.6.0]: https://github.com/ruby/timeout/releases/tag/v0.6.0
+[uri-v1.1.0]: https://github.com/ruby/uri/releases/tag/v1.1.0
+[uri-v1.1.1]: https://github.com/ruby/uri/releases/tag/v1.1.1
+[weakref-v0.1.4]: https://github.com/ruby/weakref/releases/tag/v0.1.4
+[zlib-v3.2.2]: https://github.com/ruby/zlib/releases/tag/v3.2.2
+[power_assert-v3.0.0]: https://github.com/ruby/power_assert/releases/tag/v3.0.0
+[power_assert-v3.0.1]: https://github.com/ruby/power_assert/releases/tag/v3.0.1
+[rake-v13.3.0]: https://github.com/ruby/rake/releases/tag/v13.3.0
+[rake-v13.3.1]: https://github.com/ruby/rake/releases/tag/v13.3.1
+[test-unit-3.6.8]: https://github.com/test-unit/test-unit/releases/tag/3.6.8
+[test-unit-3.6.9]: https://github.com/test-unit/test-unit/releases/tag/3.6.9
+[test-unit-3.7.0]: https://github.com/test-unit/test-unit/releases/tag/3.7.0
+[test-unit-3.7.1]: https://github.com/test-unit/test-unit/releases/tag/3.7.1
+[test-unit-3.7.2]: https://github.com/test-unit/test-unit/releases/tag/3.7.2
+[test-unit-3.7.3]: https://github.com/test-unit/test-unit/releases/tag/3.7.3
+[test-unit-3.7.4]: https://github.com/test-unit/test-unit/releases/tag/3.7.4
+[test-unit-3.7.5]: https://github.com/test-unit/test-unit/releases/tag/3.7.5
+[rss-0.3.2]: https://github.com/ruby/rss/releases/tag/0.3.2
+[net-ftp-v0.3.9]: https://github.com/ruby/net-ftp/releases/tag/v0.3.9
+[net-imap-v0.5.9]: https://github.com/ruby/net-imap/releases/tag/v0.5.9
+[net-imap-v0.5.10]: https://github.com/ruby/net-imap/releases/tag/v0.5.10
+[net-imap-v0.5.11]: https://github.com/ruby/net-imap/releases/tag/v0.5.11
+[net-imap-v0.5.12]: https://github.com/ruby/net-imap/releases/tag/v0.5.12
+[net-imap-v0.5.13]: https://github.com/ruby/net-imap/releases/tag/v0.5.13
+[net-imap-v0.6.0]: https://github.com/ruby/net-imap/releases/tag/v0.6.0
+[net-imap-v0.6.1]: https://github.com/ruby/net-imap/releases/tag/v0.6.1
+[net-imap-v0.6.2]: https://github.com/ruby/net-imap/releases/tag/v0.6.2
+[net-smtp-v0.5.1]: https://github.com/ruby/net-smtp/releases/tag/v0.5.1
+[matrix-v0.4.3]: https://github.com/ruby/matrix/releases/tag/v0.4.3
+[prime-v0.1.4]: https://github.com/ruby/prime/releases/tag/v0.1.4
+[rbs-v3.8.1]: https://github.com/ruby/rbs/releases/tag/v3.8.1
+[rbs-v3.9.0.dev.1]: https://github.com/ruby/rbs/releases/tag/v3.9.0.dev.1
+[rbs-v3.9.0.pre.1]: https://github.com/ruby/rbs/releases/tag/v3.9.0.pre.1
+[rbs-v3.9.0.pre.2]: https://github.com/ruby/rbs/releases/tag/v3.9.0.pre.2
+[rbs-v3.9.0]: https://github.com/ruby/rbs/releases/tag/v3.9.0
+[rbs-v3.9.1]: https://github.com/ruby/rbs/releases/tag/v3.9.1
+[rbs-v3.9.2]: https://github.com/ruby/rbs/releases/tag/v3.9.2
+[rbs-v3.9.3]: https://github.com/ruby/rbs/releases/tag/v3.9.3
+[rbs-v3.9.4]: https://github.com/ruby/rbs/releases/tag/v3.9.4
+[rbs-v3.9.5]: https://github.com/ruby/rbs/releases/tag/v3.9.5
+[rbs-v3.10.0.pre.1]: https://github.com/ruby/rbs/releases/tag/v3.10.0.pre.1
+[rbs-v3.10.0.pre.2]: https://github.com/ruby/rbs/releases/tag/v3.10.0.pre.2
+[rbs-v3.10.0]: https://github.com/ruby/rbs/releases/tag/v3.10.0
+[debug-v1.11.1]: https://github.com/ruby/debug/releases/tag/v1.11.1
+[base64-v0.3.0]: https://github.com/ruby/base64/releases/tag/v0.3.0
+[bigdecimal-v3.2.0]: https://github.com/ruby/bigdecimal/releases/tag/v3.2.0
+[bigdecimal-v3.2.1]: https://github.com/ruby/bigdecimal/releases/tag/v3.2.1
+[bigdecimal-v3.2.2]: https://github.com/ruby/bigdecimal/releases/tag/v3.2.2
+[bigdecimal-v3.2.3]: https://github.com/ruby/bigdecimal/releases/tag/v3.2.3
+[bigdecimal-v3.3.0]: https://github.com/ruby/bigdecimal/releases/tag/v3.3.0
+[bigdecimal-v3.3.1]: https://github.com/ruby/bigdecimal/releases/tag/v3.3.1
+[bigdecimal-v4.0.0]: https://github.com/ruby/bigdecimal/releases/tag/v4.0.0
+[bigdecimal-v4.0.1]: https://github.com/ruby/bigdecimal/releases/tag/v4.0.1
+[drb-v2.2.3]: https://github.com/ruby/drb/releases/tag/v2.2.3
+[syslog-v0.3.0]: https://github.com/ruby/syslog/releases/tag/v0.3.0
+[csv-v3.3.3]: https://github.com/ruby/csv/releases/tag/v3.3.3
+[csv-v3.3.4]: https://github.com/ruby/csv/releases/tag/v3.3.4
+[csv-v3.3.5]: https://github.com/ruby/csv/releases/tag/v3.3.5

--- a/pt_br/news/_posts/2026-01-13-ruby-4-0-1-released.md
+++ b/pt_br/news/_posts/2026-01-13-ruby-4-0-1-released.md
@@ -1,0 +1,51 @@
+---
+layout: news_post
+title: "Ruby 4.0.1 Lançado"
+author: k0kubun
+translator: guicruzzs
+date: 2026-01-13 02:28:48 +0000
+lang: pt_br
+---
+
+Ruby 4.0.1 foi lançado.
+
+Esta versão inclui uma correção de bug para despertares espúrios de `Kernel#sleep` quando um subprocesso é finalizado em outra thread,
+além de outras correções de bugs. Consulte os [lançamentos no GitHub](https://github.com/ruby/ruby/releases/tag/v4.0.1) para mais detalhes.
+
+## Calendário de Lançamentos
+
+Pretendemos lançar a versão estável mais recente do Ruby (atualmente Ruby 4.0) a cada dois meses após o lançamento mais recente.
+Ruby 4.0.2 será lançado em março, 4.0.3 em maio, 4.0.4 em julho, 4.0.5 em setembro e 4.0.6 em novembro.
+
+Se surgir alguma alteração que afete significativamente as pessoas usuárias, um lançamento poderá ocorrer antes do planejado
+e o cronograma subsequente poderá ser ajustado de acordo.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "4.0.1" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário do Lançamento
+
+Muitos committers, desenvolvedores e usuários que forneceram relatórios de bugs nos ajudaram a fazer este lançamento.
+Obrigado pelas contribuições.

--- a/pt_br/news/_posts/2026-01-14-ruby-3-2-10-released.md
+++ b/pt_br/news/_posts/2026-01-14-ruby-3-2-10-released.md
@@ -1,0 +1,42 @@
+---
+layout: news_post
+title: "Ruby 3.2.10 lançado"
+author: "hsbt"
+translator: "guicruzzs"
+date: 2026-01-14 01:22:04 +0000
+lang: pt_br
+---
+
+Ruby 3.2.10 foi lançado.
+
+Consulte a página de [releases no GitHub](https://github.com/ruby/ruby/releases/tag/v3_2_10) para mais detalhes.
+
+## Download
+
+{% assign release = site.data.releases | where: "version", "3.2.10" | first %}
+
+* <{{ release.url.gz }}>
+
+      TAMANHO: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      TAMANHO: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      TAMANHO: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Comentário do lançamento
+
+Muitos committers, desenvolvedores e usuários que enviaram relatórios de bugs ajudaram a tornar este lançamento possível.
+Obrigado pelas contribuições de todos.

--- a/pt_br/security/index.md
+++ b/pt_br/security/index.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: "Segurança"
+lang: pt_br
+---
+
+Aqui você encontrará informações sobre problemas de segurança do Ruby.
+{: .summary}
+
+## Reportando Vulnerabilidades de Segurança
+
+Vulnerabilidades de segurança devem ser reportadas por e-mail
+para o endereço security@ruby-lang.org ([a chave pública PGP](/security.asc)),
+que é uma lista de e-mails privada. Os problemas reportados serão
+publicados após as correções.
+
+Os membros da lista de e-mails são pessoas que mantém o Ruby
+(committers do Ruby e autores de outras implementações do Ruby,
+distribuidores, e plataformas PaaS). Os membros precisam ser
+pessoas individuais, outras listas de e-mail não são permitidas.
+
+## Problemas conhecidos
+
+_See the [English page](/en/security/) for a complete and up-to-date
+list of security vulnerabilities.
+The following list only includes the as yet translated
+security announcements, it might be incomplete or outdated._
+
+Estes são os problemas recentes:
+
+{% include security_posts.html %}
+
+Consulte a [página em inglês](/en/security/) para os posts relacionados
+à segurança mais antigos.


### PR DESCRIPTION
## Summary

closes #3999 
This PR adds and normalizes the Brazilian Portuguese locale for the site.

- Adds Brazilian Portuguese to the language selector
- Uses the `pt_br` route consistently for the Brazilian variant
- Updates the browser locale redirect to map `pt-BR` to `pt_br`
- Localizes the home page and locale wording to Brazilian Portuguese

This keeps the Brazil-specific locale distinct from the Portugal locale while preserving a clean, working route and selector behavior.

### Screenshots

<img width="1887" height="935" alt="Screenshot 2026-08-31 at 6 45 27 PM" src="https://github.com/user-attachments/assets/51a81d04-8313-41ab-b282-5fe91a019c12" />

## Verification

- `bundle exec rake build` ✅
- `bundle exec rake test ` ✅
- `bundle exec rake check:markup` ✅ 
- `bundle exec rake check:links` ✅ 

The site build completed successfully and generated the search index without errors.


### Notes

Even though I am Brazilian, I used github copilot to help me with the file improvements for the Brazilian Portuguese language. 
