### PR TITLE
Fix href and title in rss link tags

### DIFF
--- a/_includes/rss_discovery.html
+++ b/_includes/rss_discovery.html
@@ -1,6 +1,6 @@
-{% if site.data.locales[page.lang].sidebar %}
-  {% assign syndicate = site.data.locales[page.lang].sidebar.syndicate %}
+{% if site.data.locales[page.lang].syndicate %}
+  {% assign syndicate = site.data.locales[page.lang].syndicate %}
 {% else %}
-  {% assign syndicate = site.data.locales['en'].sidebar.syndicate %}
+  {% assign syndicate = site.data.locales['en'].syndicate %}
 {% endif %}
     <link href="{{ syndicate.recent_news.url }}" rel="alternate" title="{{ syndicate.recent_news.text }}" type="application/rss+xml">


### PR DESCRIPTION
For example in `/en/index.html`:

before:
`<link href="" rel="alternate" title="" type="application/rss+xml">`

after:
`<link href="/en/feeds/news.rss" rel="alternate" title="Recent News (RSS)" type="application/rss+xml">`
