### PR TITLE
Fix timezone data dependency on Windows with Ruby 4 and add Toki Pona

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,9 @@ gem "base64"
 
 # Jekyll need this for Ruby 4.0.0+
 gem "logger"
+
+gem "tzinfo", "~> 2.0"
+
+gem "jimmu", "~> 1.0"
+
+gem "tzinfo-data", "~> 1.2026"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jimmu (1.0.0)
     json (2.19.9)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
@@ -129,6 +130,8 @@ GEM
     nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
@@ -180,6 +183,8 @@ GEM
       google-protobuf (~> 4.30)
     sass-embedded (1.86.1-riscv64-linux-musl)
       google-protobuf (~> 4.30)
+    sass-embedded (1.86.1-x64-mingw-ucrt)
+      google-protobuf (~> 4.30)
     sass-embedded (1.86.1-x86_64-darwin)
       google-protobuf (~> 4.30)
     sass-embedded (1.86.1-x86_64-linux-android)
@@ -201,6 +206,10 @@ GEM
       bigdecimal (~> 3.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
     validate-website (1.12.0)
       crass (~> 1)
@@ -234,6 +243,7 @@ PLATFORMS
   riscv64-linux-android
   riscv64-linux-gnu
   riscv64-linux-musl
+  x64-mingw-ucrt
   x86-cygwin
   x86-linux
   x86-linux-android
@@ -252,10 +262,13 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-sitemap
+  jimmu (~> 1.0)
   logger
   minitest
   rake
   rouge
+  tzinfo (~> 2.0)
+  tzinfo-data (~> 1.2026)
   validate-website (~> 1.6)
 
 CHECKSUMS
@@ -304,6 +317,7 @@ CHECKSUMS
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  jimmu (1.0.0) sha256=23fd4f5d0ec7d7949500a971875d832041b5df06aa036df9953035030c84a29a
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
@@ -320,6 +334,7 @@ CHECKSUMS
   nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
   nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
   nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x64-mingw-ucrt) sha256=051da97b8eccfdb5444fed40246a35e10d7298b9efe759b4cd25455ea04c587e
   nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
@@ -348,6 +363,7 @@ CHECKSUMS
   sass-embedded (1.86.1-riscv64-linux-android) sha256=c99ab0c1e5137502d738c05d7e37017e02d4bf9dbb44172f6294f5ae40a415c5
   sass-embedded (1.86.1-riscv64-linux-gnu) sha256=95f91669b6614bdbf2ba6dad2e17f134c4ba87fd47c10ac16bcb307d00b48d57
   sass-embedded (1.86.1-riscv64-linux-musl) sha256=de709c62f36f1c5e612528372b186d563f7a1addf24e10e307c4ea2dbdbf9a7f
+  sass-embedded (1.86.1-x64-mingw-ucrt) sha256=76b8717dca716cf075f017e6696ab3a94380f32589967916a2a63c5d5111e5c6
   sass-embedded (1.86.1-x86_64-darwin) sha256=8af7694c0de4b7fe382f8bda76456ebab70581d6007b7935ec172466d10ce7b7
   sass-embedded (1.86.1-x86_64-linux-android) sha256=dc15d50e5ea5369709726e7460a5d3b3269da29ca332cfb78f25b544ce9c4a6d
   sass-embedded (1.86.1-x86_64-linux-gnu) sha256=873e4e505677549e8b07f49a2fee2fbe09a11a9fb7f78d6d345998df6659d7e6
@@ -359,6 +375,8 @@ CHECKSUMS
   traces (0.15.2) sha256=d2547834b7248bb8c8f4f6532c6b9ba80ef8e2d6068ce16e7873575d7b802d81
   ttfunk (1.8.0) sha256=a7cbc7e489cc46e979dde04d34b5b9e4f5c8f1ee5fc6b1a7be39b829919d20ca
   typhoeus (1.4.1) sha256=1c17db8364bd45ab302dc61e460173c3e69835896be88a3df07c206d5c55ef7c
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  tzinfo-data (1.2026.3) sha256=478fbc5356f13c1004cf8372b1336f3dad4055c96340fc4c881a3738da8cf7f9
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   validate-website (1.12.0) sha256=79f338e69481b8ae8a58c2449f3d77ec6901b22ab7f7276e63328ee4465bbb3d
   w3c_validators (1.3.7) sha256=2785f8138ad4d6c2cf9f2a49693390cc55a815a51f1b0ff40e35eed4ff8be746

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ rescue LoadError => e
   exit(-1)
 end
 
-LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tr ua vi zh_cn zh_tw].freeze
+LANGUAGES = %w[bg de en es fr id it ja ko pl pt ru tok tr ua vi zh_cn zh_tw].freeze
 CONFIG = "_config.yml"
 
 task default: [:build]

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ search:
   fallback: en
   unsupported:
     - bg
+    - tok
 
 url: https://www.ruby-lang.org
 

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -35,6 +35,9 @@
 - code: ru
   name: Russian
   native_name: Русский
+- code: tok
+  name: Toki Pona
+  native_name: toki pona
 - code: tr
   name: Turkish
   native_name: Türkçe

--- a/_data/locales/home/tok.yml
+++ b/_data/locales/home/tok.yml
@@ -1,0 +1,116 @@
+hero:
+  since: "tan"
+  year: "1995"
+  title: "Ruby"
+  latest_version_label: "nanpa sin:"
+  download_button: "kama jo"
+  or: "anu"
+  learn_more: "kama sona e mute"
+  tagline: "jan pona nanpa wan pi jan pali"
+
+try_ruby:
+  title: "o lukin e Ruby!"
+  description: "sina ken kepeken e Ruby lon ilo sona sina — tenpo ni!"
+  button_url: "https://try.ruby-lang.org/"
+  bottom_text: "sina wile kama sona e mute, anu sina wile lukin e Ruby?"
+  bottom_link_url: "https://try.ruby-lang.org/"
+  button_text: "O LUKIN!"
+  bottom_link_text: "o lukin e Ruby"
+
+why_ruby:
+  title: Ruby li pona tan seme?
+  description: jan pali lon ma ale li olin e Ruby. ijo seme li pana e <strong>pilin pona</strong> tawa ona?
+  features:
+    - id: ecosystem
+      title: namako
+      read: namako mute li pona e pali mute.<br />ilo pona li lon, li awen ken kepeken.
+      copy: |
+        Ruby li jo e namako mute (mi toki e ona "gem"), li pona tawa pali lipu, pali sona, e pali ante mute.
+        kulupu li pali e ilo suli sama Rails, li pali e nasin ilo pona mute.
+        tan ni, sina ken pali e ilo pona lon tenpo lili, sina wile ala pali sin e ijo lon ale.
+      comment:
+        author:
+          id: matz
+          name: Yukihiro "Matz" Matsumoto
+          title: jan pi open Ruby
+        content: |
+          tenpo mi pana e Ruby tawa ma ale, mi sona ala e ni: namako mute li kama tan ona.
+          namako 200,000 li lon, sama Ruby on Rails, RSpec, Bundler — kulupu li pali e ijo ni ale, li awen pona e ona.
+          mi wile e ni: jan pali li pilin pona. wile ni li kama lon nasin mi sona ala e ona.
+    - id: simple
+      title: pona
+      read: o sitelen li pona, o lukin li pona.<br />nasin sitelen li sama nasin toki jan.
+      copy: |
+        Ruby li jo e nasin sitelen pona e nasin sitelen sama toki jan lawa.
+        Ruby li weka e sitelen ike e nasin pi mute ike, tan ni sina ken toki e wile sina lon nasin pona.
+        sitelen li lili, li ken lukin pona, tan ni ona li pona tawa jan sin, li pona tawa jan pi sona suli.
+      comment:
+        author:
+          id: dhh
+          name: David Heinemeier Hansson
+          title: jan pi open Ruby on Rails
+        content: |
+          Ruby li toki ilo pi pona mute nanpa wan lon ale mi lukin e ona.<br />
+          mi lukin mute e toki ilo sin, e nasin sin, e ilo sin,
+          taso mi lukin ala e toki ilo ante li sama Ruby lon nasin ona li pona lukin, li pona wan.
+    - id: productivity
+      title: wawa
+      read: sitelen lili li pali e ijo mute.<br />nasin sitelen li pona tawa pali wawa.
+      copy: |
+        nasin sitelen pi Ruby li ken pana e sitelen lili tawa ijo pi nasin suli.
+        kepeken ilo sama metaprogramming e blocks, sina ken weka e sitelen sama, sina ken lukin taso e pali suli.
+        Ruby li jo e ilo alasa-pakala pona mute, tan ni sina ken awen pona lon pali wawa.
+      comment:
+        author:
+          id: pragdave
+          name: Dave Thomas
+          title: jan pi sitelen lipu "The Pragmatic Programmer"
+        content: |
+          Ruby li ante e pilin sona tawa sitelen lon tenpo lili.
+          nasin pona ona li awen e lawa mi; nasin toki ona li ken mi sitelen sama nasin pilin mi.<br />
+          ona li sama toki ilo li weka, li lon taso mi en pali.
+          kepeken ilo pona e namako pona, pilin sona li kama sitelen wawa lon tenpo lili.
+    - id: community
+      title: kulupu
+      read: jan pali lon ma ale li pana pona tawa jan ante.<br />kulupu li seli, li wawa.
+      copy: |
+        kulupu Ruby li kepeken nasin "Matz li pona, tan ni mi ale li pona" (MINASWAN),
+        li open e jan sin en jan pi sona suli. tenpo kulupu lon ma mute li pana e sona en poka pona.
+        ona li kulupu seli, li kulupu awen, jan li pana pona tawa jan ante, li kama suli sama.
+      comment:
+        author:
+          id: amanda
+          name: Amanda Perino
+          title: jan lawa suli pi Rails Foundation
+        content: |
+          kulupu Ruby li jo e sona mute e pali sin mute; jan pali li olin e nasin sitelen pona Ruby, li pali tan pilin pona.
+          ona li kulupu wawa, kulupu open, jan li wile pana e olin ni pi pali sitelen tawa jan ale.
+          pilin seli e pali kulupu ni li ijo suli nanpa wan pi Ruby.
+
+companies:
+  title: "kulupu pali"
+  heart: "♥"
+  subtitle: "Ruby"
+
+community:
+  title: "o kama tawa kulupu"
+  description_1: "jan li kepeken e Ruby, li pali mute lon poka ona, mi kama toki e ona jan Ruby (Rubyist)."
+  description_2: "jan Ruby li olin e Ruby, ale li #rubyfriends pona. pali kulupu li kama suli, li pilin pona."
+  motto_prefix: "toki lawa pi kulupu ale li"
+  motto_minaswan: "MINASWAN"
+  motto_separator: "—"
+  motto_translation: "Matz li pona, tan ni mi ale li pona"
+  links:
+    - text: "o kama sona e mute pi kulupu"
+      url: "/community/"
+    - text: "tenpo kulupu suli kama"
+      url: "https://www.rubyevents.org"
+      external: true
+
+news_security:
+  news:
+    title: "sona sin"
+    more_link: "o lukin e sona sin mute"
+  security:
+    title: "awen pona"
+    more_link: "o lukin e awen pona mute"

--- a/_data/locales/tok.yml
+++ b/_data/locales/tok.yml
@@ -1,0 +1,204 @@
+---
+
+navigation:
+- text: kama jo
+  url: /tok/documentation/installation/
+  submenu:
+  - text: kama jo e Ruby
+    url: /tok/documentation/installation/
+  - text: kama jo
+    url: /tok/downloads/
+  - text: ilo lawa pi namako
+    submenu:
+    - text: rbenv
+      url: https://github.com/rbenv/rbenv
+      external: true
+    - text: RVM
+      url: https://rvm.io/
+      external: true
+    - text: RubyInstaller for Windows
+      url: https://rubyinstaller.org/
+      external: true
+    - text: Bundler
+      url: https://bundler.io/
+      external: true
+- text: lipu sona
+  url: /tok/documentation/
+  submenu:
+  - text: lipu sona
+    url: /tok/documentation/
+  - text: Ruby li seme
+    url: /tok/about/
+  - text: Ruby lon tenpo lili
+    url: /tok/documentation/quickstart/
+  - text: o kama sona e Ruby
+    submenu:
+    - text: TryRuby
+      url: https://try.ruby-lang.org/
+      external: true
+    - text: Ruby Reference Manual
+      url: https://docs.ruby-lang.org/en/4.0/
+      external: true
+    - text: The Ruby Bibliography
+      url: https://rubybib.org/
+      external: true
+- text: namako
+  url: /tok/libraries/
+  submenu:
+  - text: namako
+    url: /tok/libraries/
+  - text: RubyGems
+    submenu:
+    - text: RubyGems.org
+      url: https://rubygems.org/
+      external: true
+    - text: The Ruby Toolbox
+      url: https://www.ruby-toolbox.com/
+      external: true
+  - text: namako suli
+    submenu:
+    - text: Bundler
+      url: https://bundler.io/
+      external: true
+    - text: Ruby on Rails
+      url: https://rubyonrails.org/
+      external: true
+    - text: Rack
+      url: https://github.com/rack/rack
+      external: true
+    - text: Rake
+      url: https://github.com/ruby/rake
+      external: true
+    - text: RSpec
+      url: https://github.com/rspec/rspec
+      external: true
+- text: pana pali
+  url: /tok/community/mailing-lists/
+  submenu:
+  - text: lipu toki
+    url: /tok/community/mailing-lists/
+  - text: ante
+    submenu:
+    - text: ruby/ruby
+      url: https://github.com/ruby/ruby
+      external: true
+    - text: Wiki
+      url: https://github.com/ruby/ruby/wiki
+      external: true
+    - text: Ruby Issue Tracking System
+      url: https://bugs.ruby-lang.org/
+      external: true
+- text: kulupu
+  url: /tok/community/
+  submenu:
+  - text: kulupu
+    url: /tok/community/
+  - text: lipu toki
+    url: /tok/community/mailing-lists/
+  - text: lawa pona pi kulupu
+    url: /tok/conduct/
+  - text: tenpo kulupu
+    submenu:
+    - text: RubyKaigi
+      url: https://rubykaigi.org/
+      external: true
+    - text: Ruby Events
+      url: https://www.rubyevents.org/
+      external: true
+  - text: kulupu lawa
+    submenu:
+    - text: Ruby Association
+      url: https://www.ruby.or.jp/en/
+      external: true
+- text: sona sin
+  url: /tok/news/
+  submenu:
+  - text: sona sin
+    url: /tok/news/
+  - text: awen pona
+    url: /tok/security/
+
+syndicate:
+  text: pana sona
+  recent_news:
+    text: sona sin (RSS)
+    url: /tok/feeds/news.rss
+
+languages_heading: 'lipu ni lon toki ante:'
+
+toc:
+  heading: ale insa
+
+credits: >-
+  <a href="/tok/about/website/">lipu ni</a>
+  li pali pona tan jan pi kulupu Ruby, li awen pona tan ona.
+
+month_names:
+- tenpo mun nanpa wan
+- tenpo mun nanpa tu
+- tenpo mun nanpa tu wan
+- tenpo mun nanpa tu tu
+- tenpo mun nanpa luka
+- tenpo mun nanpa luka wan
+- tenpo mun nanpa luka tu
+- tenpo mun nanpa luka tu wan
+- tenpo mun nanpa luka tu tu
+- tenpo mun nanpa luka luka
+- tenpo mun nanpa luka luka wan
+- tenpo mun nanpa luka luka tu
+
+posted_by: "jan pali: AUTHOR — tenpo: %-d pi mun %b pi sike %Y"
+translated_by: ante toki tan
+
+feed:
+  title: sona sin Ruby
+  description: sona sin li kama tan ruby-lang.org.
+  lang_code: tok
+
+# lipu ni li kama lon insa poki lukin, taso lon lipu pi toki ni li ken ala
+# alasa pona. o lukin lon toki Inglisi.
+search:
+  fallback_notice: >-
+    mi ken ala alasa lon toki pona. mi alasa lon lipu Inglisi taso.
+    o sitelen e nimi alasa sina lon toki Inglisi.
+
+news:
+  other_news: sona sin ante
+  more_news: sona sin mute...
+  continue: o lukin e ale...
+  back_to_year: tawa lipu pi sike %Y
+  recent_news: sona sin
+  yearly_archive_title: "lipu pi sike %Y"
+  monthly_archive_title: "lipu pi mun %B pi sike %Y"
+  yearly_archives: lipu pi sike ale
+  monthly_archives: lipu pi mun ale
+  yearly_archive_link: "sike %Y"
+  monthly_archive_link: "%B %Y"
+  select_year: "--- o wile e sike ---"
+
+footer:
+  links:
+    github:
+      text: ruby/ruby
+      url: https://github.com/ruby/ruby
+    slack:
+      text: ruby-jp.slack.com
+      url: https://ruby-jp.github.io/
+    mailing_list:
+      text: lipu toki
+      url: /tok/community/mailing-lists/
+    security:
+      text: awen pona
+      url: /tok/security/
+    about_website:
+      text: lipu ni li seme
+      url: /tok/about/website/
+    logo_page:
+      text: sitelen nimi Ruby
+      url: /tok/about/logo/
+    news_rss:
+      text: sona sin RSS
+      url: /tok/feeds/news.rss
+    ruby_license:
+      text: lawa kepeken Ruby
+      url: /en/about/license.txt

--- a/tok/about/index.md
+++ b/tok/about/index.md
@@ -1,0 +1,238 @@
+---
+layout: page
+title: "Ruby li seme"
+lang: tok
+---
+
+sina pilin wile e ni: Ruby li kama suli tan seme? jan olin Ruby li toki e
+ona li toki ilo pi lukin pona, li toki ilo pi sitelen pona. taso jan li
+toki sin e ni: ona li ilo pona pali. ni li lon tan seme?
+{: .summary}
+
+### wile pona pi jan pi open Ruby
+
+Ruby li toki ilo pi nasin insa pona. jan pi open ona, [jan Yukihiro
+"Matz" Matsumoto][matz], li kepeken e ijo pona tan toki ilo ante ona li
+olin (Perl, Smalltalk, Eiffel, Ada, en Lisp), li pali e toki ilo sin li
+jo e nasin luka-pali (imperative) en nasin pali-taso (functional), tu li
+lon poki wan.
+
+jan Matz li toki mute e ni: "mi wile e Ruby li sama nasin lon, mi wile
+ala e ona li nasin pona lili taso." nasin ni li sama nasin lon.
+
+kepeken wile ni, ona li toki e:
+
+> Ruby li lukin pona lili, taso ona li ijo pi mute suli lon insa, sama
+> sijelo mi jan.<sup>[1](#fn1)</sup>
+
+### Ruby li kama suli
+
+tan tenpo pi pana lon ma ale (1995), Ruby li kama tawa jan pali mute lon
+ma ale. lon sike 2006, Ruby li kama sona pi jan mute. kulupu jan Ruby li
+kama lon ma suli mute, tenpo kulupu Ruby li jo e jan mute, ken ala jo e
+poki sin.
+
+Ruby-Talk, [lipu toki](/tok/community/mailing-lists/) suli nanpa wan pi
+toki Ruby, li jo e toki 200 lon tenpo suno lon sike 2006. nanpa ni li
+kama lili lon sike kama, tan ni kulupu li kama suli, li kama poki lili
+mute.
+
+Ruby li lon anpa nanpa 10 lon mute lipu nanpa li lukin e nasin kama suli
+pi toki ilo ale (sama [TIOBE index][tiobe]). mute pi kama suli ni li tan
+kama pona pi poki ilo [Ruby on Rails][ror].
+
+Ruby li [ken ala esun]({{ site.license.url }}). ona li ken ala esun taso;
+sina ken kepeken, sina ken pana sin, sina ken ante, sina ken pana tawa
+jan ante.
+
+### ale li ijo
+
+lon open, jan Matz li lukin e toki ilo ante li alasa e nasin sitelen
+pona. ona li toki e ni: "mi wile e toki ilo pi wawa mute tan Perl, taso
+mi wile e toki ilo li kepeken poki (object) mute tan
+Python.<sup>[2](#fn2)</sup>"
+
+lon Ruby, ale li ijo. sona ale e sitelen ale li ken jo e nasin ona e
+pali ona. lon toki ilo pi kepeken poki, nasin li nimi *poki nimi lon
+poki* (instance variables), pali li nimi *nasin pali* (methods). nasin
+Ruby pi "ale li ijo" li ken lukin pona lon sitelen lili ni: ona li pana
+e pali tawa nanpa.
+
+{% highlight ruby %}
+5.times { print "mi olin e Ruby -- ona li pona mute!" }
+{% endhighlight %}
+
+lon toki ilo mute, nanpa en ijo lili ante li ijo ala. Ruby li kepeken
+nasin Smalltalk, li pana e nasin pali en poki nimi tawa nasin ale ona.
+ni li pona e kepeken Ruby, tan ni lawa pi poki li sama lon ale Ruby.
+
+### Ruby li ken ante
+
+jan li lukin e Ruby li toki ilo pi ken ante mute, tan ni ona li ken ante
+e ale ona kepeken wile jan. poki open pi Ruby li ken weka, li ken sin.
+sina ken pana e ijo sin. Ruby li wile ala pana e lawa suli tawa jan
+pali.
+
+sama ni: nasin pana (`+`) li nasin pali pi pana namako. taso sina wile
+e nimi lon `plus`, sina ken pana e nasin pali sin ni tawa poki `Numeric`
+pi Ruby.
+
+{% highlight ruby %}
+class Numeric
+  def plus(x)
+    self.+(x)
+  end
+end
+
+y = 5.plus 6
+# y li nanpa 11 lon tenpo ni
+{% endhighlight %}
+
+nasin pana pi Ruby li nasin pali lon insa; sina ken ante e ona.
+
+### block: ijo pona pi ken mute
+
+block pi Ruby li ijo pona ante pi ken mute. jan pali li ken pana e
+closure tawa nasin pali, li toki e nasin ni li wile pali seme. closure
+ni li nimi *block*, li kama ijo pona nanpa wan tawa jan sin li kama tan
+toki ilo ante sama PHP anu Visual Basic.
+
+block li kama tan nasin toki ilo pali-taso (functional). jan Matz li
+toki e ni: "lon closure pi Ruby, mi wile pana e lawa tawa nasin
+Lisp.<sup>[3](#fn3)</sup>"
+
+{% highlight ruby %}
+search_engines =
+  %w[Google Yahoo MSN].map do |engine|
+    "http://www." + engine.downcase + ".com"
+  end
+{% endhighlight %}
+
+lon sitelen pi anpa ni, block li lon insa pi `do ... end`. nasin pali
+`map` li pana e block tawa lipu nimi. nasin pali mute ante pi Ruby li
+awen open, li wile e ni: jan pali li sitelen e block sin li toki e ni,
+nasin pali li wile pali seme.
+
+### Ruby en poki pali (module)
+
+Ruby li jo e nasin mama wan taso (single inheritance), kepeken wile
+jan pi open. taso Ruby li sona e poki pali (nimi *module*, sama
+Categories lon Objective-C). poki pali li kulupu pi nasin pali.
+
+poki (class) li ken jo e poki pali (mixin), li kama jo e nasin pali ale
+ona, li wile ala sin pali. sama ni: poki li jo e nasin pali `each` la
+ona li ken jo e poki pali `Enumerable`, li kama jo e nasin pali mute li
+kepeken `each` tawa nasin sike (loop).
+
+{% highlight ruby %}
+class MyArray
+  include Enumerable
+end
+{% endhighlight %}
+
+jan Ruby li lukin e nasin ni li pona mute tawa nasin mama mute (multiple
+inheritance), tan ni nasin mama mute li ijo pi mute suli, li ken lawa
+jan mute.
+
+### nasin lukin pi sitelen Ruby
+
+Ruby li kepeken sitelen lili taso, li wile e nimi Inglisi, taso ona li
+kepeken sitelen lili namako tawa nasin pona. Ruby li wile ala e toki
+open pi poki nimi. ona li kepeken nasin nimi pona tawa ni: poki nimi li
+lon ma seme.
+
+* `var` li ken poki nimi lon ma lili (local variable).
+* `@var` li poki nimi pi poki (instance variable).
+* `$var` li poki nimi pi ma ale (global variable).
+
+sitelen lili ni li pona e lukin, tan ni jan pali li ken sona lili e
+nasin poki nimi. ona li weka e wile pana e `self.` lon poki nimi ale.
+
+### ijo ante li lon
+
+Ruby li jo e ijo ante mute, sama ni:
+
+* Ruby li jo e nasin pona pi pakala (exception handling), sama Java anu
+  Python, li pona e pali tawa pakala.
+
+* Ruby li jo e ilo weka pi ijo pakala (garbage collector) pona tawa ijo
+  Ruby ale. sina wile ala awen e nanpa poki lon poki pali namako. jan
+  Matz li toki e ni: "ni li pona mute tawa sijelo sina."
+
+* pali sitelen C lon poki pali Ruby li pona lili tan Perl anu Python,
+  kepeken nasin sitelen pona tawa kama toki Ruby tan C. sina ken pana
+  Ruby lon ilo ante li kepeken ona sama toki ilo lili. ilo SWIG li ken
+  kepeken.
+
+* Ruby li ken kama jo e poki pali namako lon tenpo pali, sina jo e ilo
+  sona li ken.
+
+* Ruby li jo e nasin nasin-sama (threading) li ken lon ilo sona ale,
+  taso ilo sona li jo ala e nasin ni. nasin ni li lon lon ilo sona ale
+  Ruby li ken lon, taso lon MS-DOS!
+
+* Ruby li ken kepeken lon ilo sona mute: mama pali li lon GNU/Linux,
+  taso ona li ken lon UNIX mute, macOS, Windows, DOS, BeOS, OS/2, e ijo
+  ante.
+
+### nasin pali ante pi Ruby
+
+Ruby, sama toki ilo, li jo e nasin pali ante mute. lipu ni li toki lon
+nasin pali nanpa wan (kulupu li toki e ona **MRI** — "Matz's Ruby
+Interpreter" — anu **CRuby** tan ni ona li sitelen lon C), taso nasin
+pali ante li lon. ona li pona lon tenpo namako, li pana e poki tawa toki
+ilo ante, anu li jo e ijo namako li MRI li jo ala e ona.
+
+lipu nimi:
+
+* [JRuby][jruby] li Ruby lon JVM (Java Virtual Machine), kepeken ilo JIT
+  pona, ilo weka pi ijo pakala, nasin nasin-sama, kulupu ilo, en poki
+  namako mute pi JVM.
+* [Rubinius][rubinius] li "Ruby li sitelen kepeken Ruby". ona li pali
+  lon LLVM, li jo e ilo sona (virtual machine) pona li toki ilo ante li
+  ken pali lon ona.
+* [TruffleRuby][truffleruby] li nasin pali Ruby pi wawa suli lon
+  GraalVM.
+* [mruby][mruby] li nasin pali lili pi toki Ruby li ken pana lon poki
+  ilo ante. jan Matz taso li lawa e pali ona.
+* [IronRuby][ironruby] li nasin pali li "kama wan pona tawa .NET
+  Framework".
+* [MagLev][maglev] li "nasin pali Ruby pi wawa awen, li jo e nasin awen
+  sona (object persistence) en poki sona pi kulupu (distributed shared
+  cache)".
+* [Cardinal][cardinal] li "ilo ante pi Ruby tawa [Parrot][parrot]
+  Virtual Machine" (Perl 6).
+
+tawa lipu suli, o lukin [Awesome Rubies][awesome-rubies].
+
+### lipu open
+
+<sup>1</sup> jan Matz, lon lipu toki Ruby-Talk, [tenpo suno 12 pi mun 5,
+sike 2000][blade].
+{: #fn1}
+
+<sup>2</sup> jan Matz, lon [toki kama sona tan jan pi open
+Ruby][linuxdevcenter], tenpo suno 29 pi mun 11, sike 2001.
+{: #fn2}
+
+<sup>3</sup> jan Matz, lon [Blocks and Closures in Ruby][artima], tenpo
+suno 22 pi mun 12, sike 2003.
+{: #fn3}
+
+
+
+[matz]: http://www.rubyist.net/~matz/
+[blade]: https://blade.ruby-lang.org/ruby-talk/2773
+[ror]: http://rubyonrails.org/
+[linuxdevcenter]: http://www.linuxdevcenter.com/pub/a/linux/2001/11/29/ruby.html
+[artima]: http://www.artima.com/intv/closures2.html
+[tiobe]: http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
+[jruby]: http://jruby.org
+[rubinius]: https://rubinius.com
+[truffleruby]: https://github.com/oracle/truffleruby
+[mruby]: http://www.mruby.org/
+[ironruby]: http://www.ironruby.net
+[maglev]: http://maglev.github.io
+[cardinal]: https://github.com/parrot/cardinal
+[parrot]: http://parrot.org
+[awesome-rubies]: https://github.com/planetruby/awesome-rubies

--- a/tok/about/logo/index.md
+++ b/tok/about/logo/index.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: "sitelen nimi Ruby"
+lang: tok
+---
+
+![sitelen nimi Ruby][logo]
+
+sitelen nimi Ruby li ijo pi jan Yukihiro Matsumoto, sike 2006.
+
+ona li lon lawa pi [Creative Commons Attribution-ShareAlike 2.5][cc-by-sa].
+
+
+## kama jo
+
+[Ruby Logo Kit][logo-kit] li jo e sitelen nimi Ruby lon nasin mute
+(PNG, JPG, PDF, AI, SWF, XAR).
+
+
+[logo]: /images/header-ruby-logo.png
+[logo-kit]: https://cache.ruby-lang.org/pub/misc/logo/ruby-logo-kit.zip
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/2.5/

--- a/tok/about/website/index.md
+++ b/tok/about/website/index.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: "lipu ni li seme"
+lang: tok
+---
+
+lipu ni li kama pali kepeken Ruby en [Jekyll][jekyll],<br>
+sitelen open ona li lon [GitHub][github-repo].
+
+## nasin lukin
+
+nasin lukin pi tenpo ni li tan [Taeko Akatsuka][akatsuka].
+lipu li kama sin lon mun 12 pi sike 2025.
+
+<img src="../../../images/about/screenshot.png" alt="Current ruby-lang.org design" width="400" style="border: 1px solid #d6d3d1;" />
+
+nimi "Happy Hacking" lon anpa lipu li sitelen-luka tan [Yukihiro
+Matsumoto (Matz)][matz].
+
+<img src="../../../images/about/screenshot-happy-hacking.png" alt="Happy Hacking on Footer" width="400" style="border: 1px solid #d6d3d1;" />
+
+## nasin lukin pi tenpo pini
+
+nasin lukin pi tenpo pini (lon mun 12 pi sike 2025 la) li tan [Jason
+Zimdars][jzimdars].<br>
+ona li tan nasin lukin pi tenpo open, jan Ruby Visual Identity Team li
+pali e ona.
+
+<img src="../../../images/about/screenshot-ruby-lang-old.png" alt="Previous ruby-lang.org design" width="400" style="border: 1px solid #d6d3d1;" />
+
+## sitelen nimi
+
+[sitelen nimi Ruby][logo] li ijo pi jan Yukihiro Matsumoto, sike 2006.
+
+
+## toki e pakala ##
+
+sina wile toki e pakala la, o kepeken [issue tracker][github-issues]
+anu o toki tawa [jan lawa lipu][webmaster] (kepeken toki Inglisi).
+
+
+## nasin pana pali ##
+
+lipu ni li pali pona tan jan pi kulupu Ruby.
+
+sina wile pana pali la, o lukin e [nasin pana pali][github-wiki], la o
+open lon issue anu pull request!
+
+
+## pilin pona tawa jan ##
+
+mi pana e pilin pona tawa jan pali sitelen ale, jan sitelen toki ale, en
+jan pana pali ale pi lipu ni.
+
+mi pana sin e pilin pona tawa kulupu li pana wawa tawa mi:
+
+<table class="not-prose sponsor-table">
+  <tr>
+    <td><a href="http://www.ruby.or.jp">Ruby Association</a> (hosting)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/ra.png" alt="Ruby Association" /></td>
+  </tr>
+  <tr>
+    <td><a href="http://ruby-no-kai.org/">Ruby no Kai</a> (build server)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/ruby-no-kai.png" alt="Ruby no Kai" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://aws.amazon.com/">AWS</a> (hosting)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/aws.png" alt="AWS" style="width: 150px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.heroku.com/">Heroku</a> (hosting)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/heroku.png" alt="Heroku" style="width: 100px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.ibm.com/">IBM</a> (hosting)</td>
+    <td class="sponsor-logo"><!-- Intentional: Logo is omitted by design. Do not add. Context: https://github.com/ruby/www.ruby-lang.org/issues/3829 --></td>
+  </tr>
+  <tr>
+    <td><a href="http://www.fastly.com">Fastly</a> (CDN)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/fastly.png" alt="Fastly" style="width: 200px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="http://hatenacorp.jp/">Hatena</a> (<a href="https://mackerel.io/">Mackerel</a>, server monitoring)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/mackerel.png" alt="Mackerel" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.datadoghq.com/">Datadog</a> (server monitoring)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/dd.png" alt="Datadog" style="width: 120px;" /></td>
+  </tr>
+  <tr>
+    <td><a href="https://1password.com/">1Password</a> (password manager)</td>
+    <td class="sponsor-logo"><img src="../../../images/about/sponsor/1password.png" alt="1Password" style="width: 250px;" /></td>
+  </tr>
+</table>
+
+[logo]: /tok/about/logo/
+[webmaster]: mailto:webmaster@ruby-lang.org
+[jekyll]: http://www.jekyllrb.com/
+[akatsuka]: https://x.com/ken_c_lo
+[matz]: https://x.com/yukihiro_matz
+[jzimdars]: https://twitter.com/jasonzimdars
+[github-repo]: https://github.com/ruby/www.ruby-lang.org/
+[github-issues]: https://github.com/ruby/www.ruby-lang.org/issues
+[github-wiki]: https://github.com/ruby/www.ruby-lang.org/wiki

--- a/tok/community/index.md
+++ b/tok/community/index.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: "kulupu"
+lang: tok
+---
+
+kulupu li kama suli lon poka pi toki ilo la, ni li ijo wawa nanpa wan
+pi toki ilo. Ruby li jo e kulupu wawa li kama suli, li pona tawa jan
+ale, jan sin en jan pi sona suli.
+{: .summary}
+
+sina wile kama insa la, o lukin e ma pini:
+
+[lipu toki pi Ruby](mailing-lists/)
+: Ruby li jo e lipu toki mute, lon poki nasin mute, lon toki mute. sina
+  jo e wile sona pi Ruby la, o toki lon lipu toki — ni li nasin pona
+  tawa kama jo e sona.
+
+[ilo toki Discord pi Ruby (linja kama)][ruby-discord]
+: ilo toki Discord pi toki Ruby li ma sina ken toki tawa jan Ruby ante,
+  kama jo e pona tawa wile sona sina, anu pana pona tawa jan ante.
+  Discord li ma pona tawa jan pali sin, li ken kama insa lon nasin
+  pona.
+
+[Ruby lon IRC (#ruby)](https://web.libera.chat/#ruby)
+: poki toki IRC pi toki Ruby li nasin pona tawa toki kepeken jan Ruby
+  ante.
+
+[Ruby Central][ruby-central]
+: Ruby Central li kulupu pi pana ala esun li pana wawa tawa kulupu Ruby
+  pi ma ale.
+
+[ruby-central]: http://rubycentral.org/
+[ruby-discord]: https://discord.gg/ad2acQFtkh

--- a/tok/community/mailing-lists/index.md
+++ b/tok/community/mailing-lists/index.md
@@ -1,0 +1,44 @@
+---
+layout: page
+title: "lipu toki"
+lang: tok
+---
+
+lipu toki li nasin pona tawa kama sona e ijo kulupu Ruby li pali lon
+tenpo ni.
+{: .summary}
+
+Ruby li jo e lipu toki Inglisi suli nanpa 4:
+
+Ruby-Talk
+: lipu toki ni li kama suli nanpa wan, li toki e ijo Ruby ale.
+  ([lipu open][3], [lipu kulupu][rubytalk])
+
+Ruby-Core
+: lipu toki ni li toki e ijo insa pi Ruby en nasin pali ona, jan li
+  kepeken ona tawa lukin e sitelen pana (patch). ([lipu open][4])
+
+Ruby-Doc
+: lipu toki ni li toki e nasin pi lipu sona Ruby en ilo ona.
+  ([lipu open][5])
+
+Ruby-CVS
+: lipu toki ni li toki e pali sitelen ale lon poki sitelen Subversion
+  pi Ruby.
+
+poki toki comp.lang.ruby
+: jan li olin e Usenet, li olin ala e lipu toki la, o lukin e
+  [comp.lang.ruby](news:comp.lang.ruby).
+
+## kama insa anu kama weka
+
+o lukin e [https://ml.ruby-lang.org/mailman3/lists/](https://ml.ruby-lang.org/mailman3/lists/)
+tawa sona mute pi lipu toki ale lon ruby-lang.org, kepeken lipu toki pi
+toki Nihongo.
+
+
+
+[3]: https://ml.ruby-lang.org/archives/list/ruby-talk@ml.ruby-lang.org/
+[4]: https://ml.ruby-lang.org/archives/list/ruby-core@ml.ruby-lang.org
+[5]: https://ml.ruby-lang.org/archives/list/ruby-doc@ml.ruby-lang.org/
+[rubytalk]: https://rubytalk.org/

--- a/tok/conduct/index.md
+++ b/tok/conduct/index.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: "lawa pona pi kulupu Ruby"
+lang: tok
+---
+
+mi wile e lawa pona ni, mi kepeken poki open pi lawa pona PostgreSQL
+(CoC), tawa kulupu jan pali Ruby li ken pali insa pona li awen lon
+nasin pi ken ala pakala. kulupu Ruby ante ale (tenpo kulupu, e ijo
+ante) li ken wile e lawa pona sin pi ona taso.
+{: .summary}
+
+lipu ni li pana e lawa pi ma insa pona, ma insa pi ken ala pakala, ma
+insa li pona tawa pali, tawa jan ale li wile pana pali tawa kulupu
+Ruby. lawa ni li lon "ma insa pi pali kulupu" ale, kepeken lipu toki,
+sitelen pana (patch), toki lon commit, e ijo sama.
+
+* jan ale li wile awen kepeken lawa insa la, li ken tuwa e pilin ante
+  jan ante, li ken ala pakala e ona.
+* jan ale li wile e toki e pali ona li jo ala e utala jan, li jo ala e
+  toki ike tawa jan.
+* jan li lukin e toki e pali pi jan ante la, ona li wile pilin e wile
+  pona jan ante, taso.
+* nasin pali li ken lukin e ni: jan li pakala e jan ante kepeken toki
+  (harassment) la, kulupu li wile ala e ona.

--- a/tok/documentation/index.md
+++ b/tok/documentation/index.md
@@ -1,0 +1,252 @@
+---
+layout: page
+title: "lipu sona"
+lang: tok
+---
+
+lipu sona, lipu kama sona, e lipu ante li pona tawa kama sona e Ruby
+mute.
+{: .summary}
+
+### kama jo e Ruby
+
+sina ken [lukin e Ruby lon lipu open sina][1] lon nasin pona, taso sina
+ken lukin e [lipu sona pi kama jo](installation/) tawa pona pi kama jo
+e Ruby.
+
+### lipu sona lawa pi Ruby
+
+[docs.ruby-lang.org/en][docs-rlo]: lipu sona pi Ruby ale li kama pana
+lon tenpo pi sike 2.1 kama.
+
+[docs.ruby-lang.org/en/4.0][docs-rlo-4.0]: lipu sona pi Ruby 4.0.
+
+[docs.ruby-lang.org/en/master][docs-rlo-master]: lipu sona pi lipu
+sitelen "master" pi Ruby.
+
+[C Extension Guide][docs-rlo-extension]: lipu sona pi mute tawa pali
+poki pali C tawa Ruby.
+
+### o open
+
+[Try Ruby][1]
+: sina ken lukin e Ruby lon lipu open sina.
+
+[Learn to Program][8]
+: lipu sona lili pona tan jan Chris Pine, tawa jan sin pi pali sitelen.
+  sina sona ala e pali sitelen la, o open lon ni.
+
+[Ruby in Twenty Minutes][rubyin20]
+: lipu sona lili pi Ruby, li wile tenpo lili taso (mun tenpo 20).
+
+[The Odin Project][odin]
+: lipu sona open pi ale toki ilo.
+
+[Exercism][exercism]
+: pali 120, kepeken lukin sona sin en jan pona sona.
+
+[Codecademy][codecademy]
+: tomo sona sitelen pi lipu open, li jo e ijo mute.
+
+### lipu suli / lipu open
+
+#### jan sin
+
+[Programming Ruby 3.3][pickaxe]
+: lipu suli nanpa wan pi Ruby lon toki Inglisi. ona li kama sin lon
+  Ruby 3.3.
+
+[The Well-Grounded Rubyist][grounded]
+: lipu sona li open lon sitelen Ruby nanpa wan sina, li kama tawa ijo
+  suli sama reflection, nasin nasin-sama, en recursion.
+
+#### insa
+
+[Practical OOD in Ruby (POODR)][poodr]
+: toki jan pali li toki e nasin pi sitelen kepeken poki
+  (object-oriented).
+
+#### jan pi sona suli
+
+[Metaprogramming][meta]
+: toki e metaprogramming lon nasin pona lukin.
+
+[Ruby Under a Microscope (RUM)][microscope]
+: lipu sona sitelen li toki e nasin insa pi Ruby.
+
+### lipu sona pi kulupu
+
+lipu sona ni li lawa pona tan kulupu Ruby.
+
+[RubyDoc.info][16]
+: lipu wan pi lipu sona pi namako Ruby en poki pali GitHub pi Ruby.
+
+[RubyAPI.org][rubyapi-org]
+: o alasa pona e poki, poki pali, e nasin pali pi Ruby.
+
+[ruby-doc.org][39]
+: lipu sona API lon lipu open.
+
+[DevDocs.io][40]
+: lipu sona API lon lipu open.
+
+[Ruby QuickRef][42]
+: lipu sona lili pi Ruby.
+
+[rubyreferences][43]
+: lipu sona suli pi toki ilo, kepeken lipu ante ale.
+
+### lipu sona pi nasin sitelen
+
+[rubystyle.guide][44]
+: lipu sona pi nasin sitelen tan RuboCop.
+
+[RuboCop][45]
+: ilo li lukin e nasin sitelen sina kepeken ilo.
+
+[Shopify][46]
+: lipu sona pi nasin sitelen Ruby tan Shopify.
+
+[GitLab][47]
+: lipu sona pi nasin sitelen Ruby tan Gitlab.
+
+[Airbnb][48]
+: lipu sona pi nasin sitelen Ruby tan Airbnb.
+
+[w3resource][49]
+: lipu sona pi nasin sitelen Ruby tan W3.
+
+# ilo
+
+[IRB][50]
+: ilo toki-pana-toki (REPL) pi Ruby.
+
+[Pry][51]
+: REPL ante pi Ruby.
+
+[Rake][52]
+: ilo pali sama "make" tawa Ruby.
+
+[RI][53]
+: (Ruby Information) ilo linja lipu li pana e lipu sona Ruby lon
+  tenpo lili.
+
+[RBS][54]
+: sitelen pi nasin ijo tawa Ruby.
+
+[TypeProf][55]
+: ilo pi lukin nasin ijo, li pona tawa alasa e nasin sitelen Ruby.
+
+[Steep][56]
+: ilo lukin nasin ijo pi Ruby.
+
+### ilo sitelen
+
+tawa sitelen Ruby, sina ken kepeken ilo sitelen open pi ilo sona sina.
+taso sina wile pali pona la, o alasa e ilo sitelen li jo e nasin pona
+tawa Ruby (sama sitelen kule, lukin poki), anu ilo suli (IDE) li jo e
+nasin pona mute (sama pana sitelen, ante sitelen, lukin pakala).
+
+lipu ni li lipu ilo sitelen li jan Ruby li olin, li kepeken tenpo kama
+sona:
+
+* tenpo suno mute
+  * [Sublime Text][37] (mani)
+  * [Visual Studio Code][vscode]
+  * [Zed][zed]
+* tenpo mun mute
+  * [RubyMine][27] (mani)
+* tenpo sike mute (sina kama sona lon ona lon tenpo sike mute)
+  * [Emacs][20] kepeken [Ruby mode][21] anu [Enhanced Ruby mode][enh-ruby-mode]
+  * [Vim][25] kepeken [vim-ruby][26]
+  * [NeoVim][neovim]
+
+ilo sitelen ale ni li ken kepeken Language Server Protocol (LSP),
+kepeken nasin ona anu poki namako LSP. ilo [ruby-lsp][ruby-lsp] tan
+Shopify li ilo LSP pi jan mute li kepeken, li [pona tawa ilo sitelen
+ale pi sewi][ruby-lsp-supported-editors].
+
+### lipu pi tenpo pini
+
+lipu ni li kama suli lon tenpo pini, taso jan li ante ala e ona lon
+tenpo mute.
+
+[Ruby Koans][2]
+: Koans li kama tawa sina lon nasin pi kama sona Ruby. wile ona li kama
+  sona e toki Ruby, nasin sitelen, poki, en nasin pali ale. ona li
+  pana sin e kulupu Ruby tawa sina.
+
+[Ruby Essentials][7]
+: lipu sona pi ken ala esun, li pona tawa kama sona e Ruby lon nasin
+  lili.
+
+[Why's (Poignant) Guide to Ruby][5]
+: lipu sona ante li pona mute, li kama sona e Ruby kepeken toki insa,
+  nasin lawa, en sitelen musi. jan *why the lucky stiff* li open e ona,
+  lipu ni li awen suli tawa jan sin Ruby.
+
+[Learn Ruby the Hard Way][38]
+: pali mute pona kepeken toki, li kama tawa sina tan open suli pi Ruby
+  tawa OOP en pali lipu open.
+
+[Programming Ruby][9]
+: lipu suli nanpa wan pi Ruby lon toki Inglisi. lipu open nanpa wan pi
+  [lipu Pragmatic Programmers][10] li lon ken ala esun lon insa net.
+
+[The Ruby Programming Wikibook][12]
+: lipu sona pi ken ala esun, jo e ijo tawa jan sin en jan insa, jo sin
+  e lipu sona toki suli.
+
+[1]: https://try.ruby-lang.org/
+[2]: https://rubykoans.com/
+[5]: https://poignant.guide
+[7]: https://www.techotopia.com/index.php/Ruby_Essentials
+[8]: https://pine.fm/LearnToProgram/
+[9]: https://web.archive.org/web/20250512022451/https://ruby-doc.com/docs/ProgrammingRuby/
+[10]: https://pragprog.com/titles/ruby5/programming-ruby-3-3-5th-edition/
+[12]: https://en.wikibooks.org/wiki/Ruby_programming_language
+[16]: https://www.rubydoc.info/
+[20]: https://www.gnu.org/software/emacs/
+[21]: https://www.emacswiki.org/emacs/RubyMode
+[25]: https://www.vim.org/
+[26]: https://github.com/vim-ruby/vim-ruby
+[27]: https://www.jetbrains.com/ruby/
+[37]: https://www.sublimetext.com/
+[38]: https://learncodethehardway.org/ruby/
+[39]: https://ruby-doc.org/
+[40]: https://devdocs.io/ruby/
+[42]: https://www.zenspider.com/ruby/quickref.html
+[43]: https://rubyreferences.github.io/
+[44]: https://rubystyle.guide/
+[45]: https://github.com/rubocop/ruby-style-guide
+[46]: https://ruby-style-guide.shopify.dev/
+[47]: https://docs.gitlab.com/ee/development/backend/ruby_style_guide.html
+[48]: https://github.com/airbnb/ruby
+[49]: https://www.w3resource.com/ruby/ruby-style-guide.php
+[50]: https://github.com/ruby/irb
+[51]: https://github.com/pry/pry
+[52]: https://github.com/ruby/rake
+[53]: https://ruby.github.io/rdoc/RI_md.html
+[54]: https://github.com/ruby/rbs
+[55]: https://github.com/ruby/typeprof
+[56]: https://github.com/soutaro/steep
+[codecademy]: https://www.codecademy.com/learn/learn-ruby
+[docs-rlo]: https://docs.ruby-lang.org/en
+[docs-rlo-4.0]: https://docs.ruby-lang.org/en/4.0
+[docs-rlo-master]: https://docs.ruby-lang.org/en/master
+[docs-rlo-extension]: https://docs.ruby-lang.org/en/master/extension_rdoc.html
+[enh-ruby-mode]: https://github.com/zenspider/enhanced-ruby-mode/
+[exercism]: https://exercism.org/tracks/ruby
+[grounded]: https://www.manning.com/books/the-well-grounded-rubyist-third-edition
+[meta]: https://pragprog.com/titles/ppmetr2/metaprogramming-ruby-2/
+[microscope]: https://patshaughnessy.net/ruby-under-a-microscope
+[neovim]: https://neovim.io/
+[odin]: https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby
+[pickaxe]: https://pragprog.com/titles/ruby5/programming-ruby-3-3-5th-edition/
+[poodr]: https://www.poodr.com/
+[ruby-lsp]: https://github.com/Shopify/ruby-lsp
+[ruby-lsp-supported-editors]: https://shopify.github.io/ruby-lsp/editors.html
+[rubyapi-org]: https://rubyapi.org/
+[rubyin20]: /tok/documentation/quickstart/
+[vscode]: https://code.visualstudio.com/docs/languages/ruby
+[zed]: https://zed.dev/

--- a/tok/documentation/installation/index.md
+++ b/tok/documentation/installation/index.md
@@ -1,0 +1,421 @@
+---
+layout: page
+title: "kama jo e Ruby"
+lang: tok
+---
+
+kepeken ilo lawa namako anu ilo jan ante, sina jo e nasin mute tawa
+kama jo e Ruby en lawa e ona.
+{: .summary}
+
+sina ken jo e Ruby lon ilo sona sina lon tenpo ni. o lukin lon [ilo
+toki][terminal], o sitelen e:
+
+{% highlight sh %}
+ruby -v
+{% endhighlight %}
+
+ni li wile pana e sona pi nanpa Ruby li lon.
+
+## o wile e nasin kama jo sina
+
+nasin mute li lon tawa kama jo e Ruby:
+
+* lon ilo sona sama UNIX, kepeken **ilo lawa namako** pi ilo sona sina
+  li nasin pona lili. taso, nanpa Ruby ona li ken jo ala e nanpa sin
+  nanpa wan.
+* **ilo kama jo** (Installers) li ken pana e nanpa wan anu nanpa mute
+  pi Ruby. ilo kama jo li lon tawa Windows sin.
+* **ilo lawa** (Managers) li pona e ken ante lon nanpa Ruby mute lon
+  ilo sona sina.
+* sina ken pali sin, **pali e Ruby tan sitelen open**.
+
+lon Windows 10, sina ken kepeken [Windows Subsystem for Linux][wsl]
+tawa kama jo e ilo sona Linux, la sina ken kepeken nasin kama jo ale
+pi ilo sona ni.
+
+nasin kama jo li lon:
+
+* [ilo lawa namako](#package-management-systems)
+  * [Debian, Ubuntu](#apt)
+  * [CentOS, Fedora, RHEL](#yum)
+  * [Snap](#snap)
+  * [Gentoo](#portage)
+  * [Arch Linux](#pacman)
+  * [macOS](#homebrew)
+  * [FreeBSD](#freebsd)
+  * [OpenBSD](#openbsd)
+  * [OpenIndiana](#openindiana)
+  * [Windows Package Manager](#winget)
+  * [Chocolatey pi Windows](#chocolatey)
+  * [ilo sona ante](#other-systems)
+* [ilo kama jo](#installers)
+  * [ruby-build](#ruby-build)
+  * [ruby-install](#ruby-install)
+  * [RubyInstaller](#rubyinstaller) (Windows)
+  * [Ruby Stack](#rubystack)
+* [ilo lawa](#managers)
+  * [asdf-vm](#asdf-vm)
+  * [chruby](#chruby)
+  * [mise-en-place](#mise-en-place)
+  * [rbenv](#rbenv)
+  * [rbenv tawa Windows](#rbenv-for-windows)
+  * [RVM](#rvm)
+  * [uru](#uru)
+* [pali tan sitelen open](#building-from-source)
+
+
+## ilo lawa namako
+{: #package-management-systems}
+
+sina ken ala pali e Ruby sina, sina wile ala e ilo jan ante la, sina
+ken kepeken ilo lawa namako pi ilo sona sina.
+
+jan lon kulupu Ruby li pilin e ni: sina wile ala kepeken ilo lawa namako
+tawa kama jo e Ruby, sina wile kepeken ilo namako taso.
+
+ilo lawa namako suli li ken kama jo e nanpa Ruby pini, ala nanpa sin.
+sina wile e nanpa sin la, o lukin e nimi poki li sama nanpa ona. anu o
+kepeken [ilo kama jo][installers] namako.
+
+
+### apt (Debian anu Ubuntu)
+{: #apt}
+
+Debian GNU/Linux en Ubuntu li kepeken ilo lawa apt. sina ken kepeken e
+ona sama ni:
+
+{% highlight sh %}
+$ sudo apt-get install ruby-full
+{% endhighlight %}
+
+
+### yum (CentOS, Fedora, anu RHEL)
+{: #yum}
+
+CentOS, Fedora, en RHEL li kepeken ilo lawa yum. sina ken kepeken e ona
+sama ni:
+
+{% highlight sh %}
+$ sudo yum install ruby
+{% endhighlight %}
+
+nanpa li kama jo li nanpa Ruby sin nanpa wan pi tenpo pana pi ilo sona
+ni.
+
+
+### snap (Ubuntu anu ilo sona Linux ante)
+{: #snap}
+
+Snap li ilo lawa namako tan Canonical. ona li lon Ubuntu lon open, taso
+ona li ken pali lon ilo sona Linux ante mute. sina ken kepeken e ona
+sama ni:
+
+{% highlight sh %}
+$ sudo snap install ruby --classic
+{% endhighlight %}
+
+mi jo e nasin mute tawa lipu Ruby lili ale. sama ni, nasin ni li ante e
+Ruby tawa 2.3:
+
+{% highlight sh %}
+$ sudo snap switch ruby --channel=2.3/stable
+$ sudo snap refresh
+{% endhighlight %}
+
+
+### portage (Gentoo)
+{: #portage}
+
+Gentoo li kepeken ilo lawa portage.
+
+{% highlight sh %}
+$ sudo emerge dev-lang/ruby
+{% endhighlight %}
+
+sina wile e nanpa wan taso la, o ante e `RUBY_TARGETS` lon `make.conf`
+sina. o lukin e [lipu Gentoo Ruby Project][gentoo-ruby] tawa sona mute.
+
+
+### pacman (Arch Linux)
+{: #pacman}
+
+Arch Linux li kepeken ilo lawa li nimi pacman. tawa kama jo e Ruby, o
+pali e ni:
+
+{% highlight sh %}
+$ sudo pacman -S ruby
+{% endhighlight %}
+
+
+### Homebrew (macOS)
+{: #homebrew}
+
+Ruby nanpa 2.0 en nanpa sewi li lon insa pi macOS tan El Capitan (10.11)
+kama.
+
+[Homebrew][homebrew] li ilo lawa namako li jan macOS li kepeken mute.
+kama jo e Ruby kepeken Homebrew li pona lili:
+
+{% highlight sh %}
+$ brew install ruby
+{% endhighlight %}
+
+ni li kama jo e nanpa Ruby sin nanpa wan.
+
+
+### FreeBSD
+{: #freebsd}
+
+FreeBSD li pana e nasin tu: poki kama jo pona, anu sitelen open. sina
+ken kama jo e poki pona kepeken ilo pkg:
+
+{% highlight sh %}
+$ pkg install ruby
+{% endhighlight %}
+
+sina ken pali tan sitelen open kepeken [Ports Collection][freebsd-ports-collection].
+ni li pona sina wile ante e nasin pali.
+
+sona mute pi Ruby lon FreeBSD li lon [lipu FreeBSD Ruby Project][freebsd-ruby].
+
+
+### OpenBSD
+{: #openbsd}
+
+OpenBSD, en lipu adJ ona, li jo e poki tawa nanpa suli Ruby mute (tu
+wan). nasin ni li pana e lukin nanpa lon lon en kama jo e wan:
+
+{% highlight sh %}
+$ doas pkg_add ruby
+{% endhighlight %}
+
+sina ken kama jo e nanpa suli mute lon poki wan, tan ni nimi ilo ona li
+ante (sama `ruby27`, `ruby26`).
+
+lipu `HEAD` pi OpenBSD ports collection li ken jo e nanpa Ruby sin lili
+tenpo lon tenpo suno lili poka pana ona. o lukin e
+[lipu lang/ruby lon ports collection sin][openbsd-current-ruby-ports].
+
+
+### Ruby lon OpenIndiana
+{: #openindiana}
+
+tawa kama jo e Ruby lon [OpenIndiana][openindiana], o kepeken ilo Image
+Packaging System (IPS). ni li kama jo e ilo Ruby en RubyGems tan poki
+sitelen OpenIndiana. ona li pona lili:
+
+{% highlight sh %}
+$ pkg install runtime/ruby
+{% endhighlight %}
+
+taso, ilo jan ante li ken pona lili tawa kama jo e nanpa Ruby sin nanpa
+wan.
+
+### Windows Package Manager
+{: #winget}
+
+lon Windows, sina ken kepeken [Windows Package Manager CLI](https://github.com/microsoft/winget-cli)
+tawa kama jo e Ruby:
+
+{% highlight powershell %}
+> winget install RubyInstallerTeam.Ruby.{MAJOR}.{MINOR}
+# lipu:
+> winget install RubyInstallerTeam.Ruby.3.2
+# tawa lukin e nanpa ale li lon:
+> winget search RubyInstallerTeam.Ruby
+# sona: sina kama jo Ruby tawa pali sina la, sina ken wile kama jo RubyWithDevKit
+> winget install RubyInstallerTeam.RubyWithDevKit.3.2
+{% endhighlight %}
+
+### Chocolatey pi Windows
+{: #chocolatey}
+
+lon Windows sin, sina ken kepeken [Chocolatey Package Manager](https://chocolatey.org/install)
+tawa kama jo e Ruby:
+
+{% highlight sh %}
+> choco install ruby
+{% endhighlight %}
+
+ona li kepeken `msys2` sina jo, anu li kama jo e ona sin, tawa ma pali
+Ruby li jo e ale.
+
+### ilo sona ante
+{: #other-systems}
+
+lon ilo sona ante, o alasa e poki namako pi ilo lawa pi ilo sona Linux
+sina tawa Ruby. anu, sina ken kepeken [ilo kama jo namako][installers].
+
+
+## ilo kama jo
+{: #installers}
+
+nanpa Ruby pi ilo sona sina anu ilo lawa namako sina li tenpo pini la,
+sina ken kama jo e nanpa sin kepeken ilo kama jo namako.
+
+ilo kama jo ante li ken pana e nanpa mute lon ilo sona sama; ilo lawa
+poka ona li pona e ken ante lon insa Ruby mute.
+
+sina wile kepeken [RVM](#rvm) sama ilo lawa nanpa, sina wile ala e ilo
+kama jo ante; RVM li jo e ilo pi ona taso.
+
+
+### ruby-build
+{: #ruby-build}
+
+[ruby-build][ruby-build] li poki namako pi [rbenv](#rbenv) li ken pali
+en kama jo e nanpa Ruby ante mute. ruby-build li ken kepeken lon ken
+ala rbenv. ona li lon macOS, Linux, en ilo sona sama UNIX ante.
+
+
+### ruby-install
+{: #ruby-install}
+
+[ruby-install][ruby-install] li ken pali en kama jo e nanpa Ruby ante
+mute lon lipu ale sina wile. [chruby](#chruby) li ilo poka li ken ante
+lon nanpa Ruby. ona li lon macOS, Linux, en ilo sona sama UNIX ante.
+
+
+### RubyInstaller
+{: #rubyinstaller}
+
+lon Windows, [RubyInstaller][rubyinstaller] li pana e ale sina wile,
+tawa ma pali Ruby li jo e ale.
+
+o kama jo taso, o pali e ona, pini!
+
+
+### Ruby Stack
+{: #rubystack}
+
+sina kama jo Ruby tawa kepeken Ruby on Rails la, sina ken kepeken ilo
+kama jo ni:
+
+* [Bitnami Ruby Stack][rubystack] li pana e ma pali ale tawa Rails. ona
+  li pona lon macOS, Linux, Windows, ilo sona sona (virtual machines),
+  en sitelen lipu awawa (cloud images).
+
+
+## ilo lawa
+{: #managers}
+
+jan Ruby mute li kepeken ilo lawa Ruby tawa lawa e nanpa Ruby mute. ona
+li pana e ken ante lili, anu ken ante sama-sama, lon nanpa Ruby, kepeken
+pali sina. taso kulupu Ruby li lawa ala e ilo ni; sina ken alasa pona
+lon kulupu pi ilo ona taso.
+
+
+### asdf-vm
+{: #asdf-vm}
+
+[asdf-vm][asdf-vm] li ilo lawa nanpa li ken lawa e nanpa toki ilo mute
+lon pali wan wan. sina wile e poki namako [asdf-ruby][asdf-ruby] (ona li
+kepeken [ruby-build](#ruby-build)) tawa kama jo e Ruby.
+
+
+### chruby
+{: #chruby}
+
+[chruby][chruby] li pona e ken ante lon insa Ruby mute. ona li ken lawa
+e Ruby li kama jo tan [ruby-install](#ruby-install) anu tan sitelen
+open.
+
+
+### mise-en-place
+{: #mise-en-place}
+
+[mise-en-place][mise-en-place] li pona e ken ante lon insa Ruby mute,
+sina wile ala e ilo namako. ona li lawa e kama jo lon ken ona taso, li
+jo e [gem backend](https://mise.jdx.dev/dev-tools/backends/gem.html)
+tawa lawa e nanpa ilo CLI li sitelen lon Ruby. ona li pona lon ilo sona
+sama UNIX en lon Windows.
+
+
+### rbenv
+{: #rbenv}
+
+[rbenv][rbenv] li pona e lawa lon insa Ruby mute. ona taso li ken ala
+kama jo e Ruby, taso poki namako ona [ruby-build](#ruby-build) li ken.
+ilo tu ni li lon macOS, Linux, anu ilo sona sama UNIX ante.
+
+
+### rbenv tawa Windows
+{: #rbenv-for-windows}
+
+[rbenv tawa Windows][rbenv-for-windows] li pona e kama jo en lawa lon
+insa Ruby mute lon Windows. ona li sitelen lon PowerShell, tan ni ona
+li nasin lon pona tawa jan Windows. poka ona, nasin toki ilo li sama
+[rbenv][rbenv] lon ilo sona sama UNIX.
+
+
+### RVM ("Ruby Version Manager")
+{: #rvm}
+
+[RVM][rvm] li pona e kama jo en lawa lon insa Ruby mute lon ilo sona
+sina. ona li ken lawa e gemsets ante sin. ona li lon macOS, Linux, anu
+ilo sona sama UNIX ante.
+
+
+### RVM 4 Windows
+{: #rvm-windows}
+
+[RVM 4 Windows][rvm-windows] li pona e kama jo en lawa lon insa Ruby
+mute lon Windows. ona li sama RVM open, li pona lon linja toki open en
+lon Powershell, kepeken nasin toki ilo sama RVM open.
+
+
+### uru
+{: #uru}
+
+[Uru][uru] li ilo linja toki lili li pali lon ma ilo mute, li pona e
+kepeken Ruby mute lon macOS, Linux, anu Windows.
+
+
+## pali tan sitelen open
+{: #building-from-source}
+
+sina ken pali sin, kama jo e Ruby tan sitelen open. o [kama jo][download]
+e poki, o open e ona, la o pali e ni:
+
+{% highlight sh %}
+$ ./configure
+$ make
+$ sudo make install
+{% endhighlight %}
+
+lon open, ni li kama jo e Ruby lon `/usr/local`. sina wile ante e ma
+ni, o pana e `--prefix=DIR` tawa `./configure`.
+
+sona mute pi pali tan sitelen open li lon
+[lawa pi pali Ruby][building-ruby].
+
+taso, kepeken ilo jan ante anu ilo lawa namako li ken pona lili, tan ni
+Ruby li kama jo lon nasin ni li lawa ala kepeken ilo.
+
+
+[rvm]: http://rvm.io/
+[rvm-windows]: https://github.com/magynhard/rvm-windows#readme
+[rbenv]: https://github.com/rbenv/rbenv#readme
+[rbenv-for-windows]: https://github.com/RubyMetric/rbenv-for-windows#readme
+[ruby-build]: https://github.com/rbenv/ruby-build#readme
+[ruby-install]: https://github.com/postmodern/ruby-install#readme
+[chruby]: https://github.com/postmodern/chruby#readme
+[uru]: https://bitbucket.org/jonforums/uru
+[rubyinstaller]: https://rubyinstaller.org/
+[rubystack]: http://bitnami.com/stack/ruby/installer
+[openindiana]: http://openindiana.org/
+[gentoo-ruby]: http://www.gentoo.org/proj/en/prog_lang/ruby/
+[freebsd-ruby]: https://wiki.freebsd.org/Ruby
+[freebsd-ports-collection]: https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html
+[homebrew]: http://brew.sh/
+[terminal]: https://en.wikipedia.org/wiki/List_of_terminal_emulators
+[download]: /tok/downloads/
+[installers]: /tok/documentation/installation/#installers
+[building-ruby]: https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
+[wsl]: https://docs.microsoft.com/en-us/windows/wsl/about
+[asdf-vm]: https://asdf-vm.com/
+[asdf-ruby]: https://github.com/asdf-vm/asdf-ruby
+[mise-en-place]: https://mise.jdx.dev
+[mise-en-place-ruby]: https://mise.jdx.dev/lang/ruby.html
+[openbsd-current-ruby-ports]: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/ruby/?only_with_tag=HEAD

--- a/tok/documentation/quickstart/index.md
+++ b/tok/documentation/quickstart/index.md
@@ -1,0 +1,130 @@
+---
+layout: page
+title: "Ruby lon tenpo lili"
+lang: tok
+---
+
+## o open
+
+lipu sona lili ni li Ruby, li wile tenpo lili taso (mun tenpo 20). mi
+pilin e ni: Ruby li lon insa ilo sona sina. (Ruby li lon ala la, o
+[kama jo][installation] e ona lon open.)
+
+## Ruby pi toki-pana-toki
+
+Ruby li jo e ilo li ken pana e nanpa pi toki Ruby sina pana. o musi
+kepeken sitelen Ruby lon ilo ni — nasin ni li pona mute tawa kama sona
+e toki ilo.
+
+o open e IRB (Interactive Ruby).
+
+* sina kepeken **macOS** la, o open e `Terminal`, o sitelen e `irb`, o
+  luka e Enter.
+* sina kepeken **Linux** la, o open e ilo toki, o sitelen e `irb`, o
+  luka e Enter.
+* sina kepeken **Windows** la, o open e `Interactive Ruby` tan lipu
+  Ruby lon Start Menu sina.
+
+{% highlight irb %}
+irb(main):001:0>
+{% endhighlight %}
+
+pona, ona li open. tenpo ni la seme?
+
+o sitelen e ni: `"Hello World"`
+
+{% highlight irb %}
+irb(main):001:0> "Hello World"
+=> "Hello World"
+{% endhighlight %}
+
+## Ruby li kute e sina!
+
+ijo seme li kama? mi sitelen ala e toki ilo "Hello World" lili nanpa
+wan pi ma ale, la seme? linja tu li nasin pi IRB taso, li toki e nanpa
+pi toki open pini. mi wile sitelen e "Hello World" lon lukin la, mi
+wile e ijo namako:
+
+{% highlight irb %}
+irb(main):002:0> puts "Hello World"
+Hello World
+=> nil
+{% endhighlight %}
+
+`puts` li nasin pali suli tawa sitelen lon lukin, lon Ruby. taso `=>
+nil` li seme? ona li nanpa pi toki. `puts` li pana nanpa `nil` lon
+tenpo ale — `nil` li nanpa Ruby pi "ijo ala" mute.
+
+## ilo nanpa sina, li ken ala esun!
+
+mi jo e mute tawa kepeken IRB sama ilo nanpa (calculator):
+
+{% highlight irb %}
+irb(main):003:0> 3+2
+=> 5
+{% endhighlight %}
+
+nanpa 3 en nanpa 2. pona lili. nanpa 3 kepeken nanpa 2 lon nasin pi
+pana-mute (times) la, seme? sina ken sitelen e ona sin, taso sina ken
+luka e **linja sewi** lon leko sina tawa lukin e linja `3+2` sina
+sitelen pini. sina lukin e ona la, o luka e linja poka tawa lon poka pi
+`+`, o weka e ona, o sitelen e `*`.
+
+{% highlight irb %}
+irb(main):004:0> 3*2
+=> 6
+{% endhighlight %}
+
+kepeken sin, o alasa e nanpa 3 li pana-mute e ona taso (squared):
+
+{% highlight irb %}
+irb(main):005:0> 3**2
+=> 9
+{% endhighlight %}
+
+lon Ruby, `**` li nasin toki pi "wawa tawa". taso sina wile e nasin
+ante, sina wile alasa e "square root" pi nanpa la, seme?
+
+{% highlight irb %}
+irb(main):006:0> Math.sqrt(9)
+=> 3.0
+{% endhighlight %}
+
+pona, o awen — ijo pini seme li lon? sina toki e "ona li alasa e square
+root pi nanpa 9," sina pona. taso o lukin insa e ijo. lon open, `Math`
+li seme?
+
+## poki pali li kama poki e sitelen lon nimi
+
+`Math` li poki pali (module) li lon Ruby lon open, li jo e nasin pali
+pi nanpa. poki pali li jo e nasin tu lon Ruby. ni li nasin wan: ona li
+kama poki e nasin pali sama lon nimi wan. `Math` li jo sin e nasin pali
+sama `sin()` en `tan()`.
+
+lon kama la, sitelen `.` li lon. `.` li seme? `.` li nasin pona tawa
+toki e jan li kama jo e toki sina. toki seme? lon ni, toki li
+`sqrt(9)`, li toki e ni: o kepeken nasin pali `sqrt` (nimi lili pi
+"square root") kepeken nanpa `9`.
+
+nanpa li kama tan nasin pali ni li `3.0`. sina ken lukin e ni: ona li
+`3` taso ala. tan ni: mute pi tenpo la, square root pi nanpa li nanpa
+lipu ala, tan ni nasin pali li pana nanpa "floating-point" lon tenpo
+ale.
+
+mi wile awen e nanpa pi pali ni la, seme? o pana e nanpa tawa poki
+nimi:
+
+{% highlight irb %}
+irb(main):007:0> a = 3 ** 2
+=> 9
+irb(main):008:0> b = 4 ** 2
+=> 16
+irb(main):009:0> Math.sqrt(a+b)
+=> 5.0
+{% endhighlight %}
+
+ilo nanpa ni li pona mute, taso mi weka lili tan toki "Hello World" li
+lipu sona sin ale li wile toki e ona. taso ni li open taso — Ruby li
+lon insa poki, li lon insa lipu sona, li ken ale sina wile pali!
+
+[installation]: /tok/documentation/installation/

--- a/tok/downloads/index.md
+++ b/tok/downloads/index.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: "kama jo e Ruby"
+lang: tok
+---
+
+lon ni sina ken kama jo e Ruby sin nanpa lon nasin sina olin. nanpa
+awen pi tenpo ni li {{ site.data.downloads.stable[0] }}. o lukin e
+[lawa kepeken Ruby][license].
+{: .summary}
+
+### nasin kama jo e Ruby
+
+mi jo e ilo mute tawa ma ilo suli ale, tawa kama jo e Ruby:
+
+* lon Linux/UNIX, sina ken kepeken ilo lawa namako pi ilo sona sina,
+  anu ilo jan ante ([rbenv][rbenv] en [RVM][rvm]).
+* lon macOS, sina ken kepeken ilo jan ante ([rbenv][rbenv] en
+  [RVM][rvm]).
+* lon Windows, sina ken kepeken [RubyInstaller][rubyinstaller].
+
+o lukin e lipu [kama jo][installation] tawa sona mute pi kepeken ilo
+lawa namako anu ilo jan ante.
+
+sina ken pana sin, kama jo e Ruby tan sitelen open (source code) lon ma
+ilo ale.
+
+### pali e Ruby tan sitelen open
+
+kama jo tan sitelen open li pona la sina sona mute e ilo sona sina,
+anu sina wile e nasin namako tawa ma sina. ona li pona sin lon tenpo
+ilo sina jo ala e poki kama jo pona.
+
+o lukin e lipu [kama jo][installation] tawa sona mute pi pali Ruby tan
+sitelen open. sina jo e pakala lon pali Ruby la, o alasa kepeken ilo
+jan ante li toki lon sewi. ona li ken pana pona.
+
+* **nanpa awen (stable):**{% for version in site.data.downloads.stable %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+
+{% if site.data.downloads.preview %}
+* **nanpa lukin-open (preview):**{% for version in site.data.downloads.preview %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+{% endif %}
+
+{% if site.data.downloads.security_maintenance %}
+* **lon tenpo awen pona taso (kama pini lon tenpo lili!):**{% for version in site.data.downloads.security_maintenance %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+{% endif %}
+
+{% if site.data.downloads.eol %}
+* **kama pini pona (EOL):**{% for version in site.data.downloads.eol %}{% assign release = site.data.releases | where: "version", version | first %}
+  * [Ruby {{ release.version }}]({{ release.url.gz }})<br>
+    sha256: {{ release.sha256.gz }}{% endfor %}
+{% endif %}
+
+* **sitelen open pi tenpo ni (Snapshots):**{% for snapshot in site.data.downloads.stable_snapshots %}
+  * [Stable Snapshot pi lipu {{ snapshot.branch }}]({{ snapshot.url.gz }}):
+    ni li poki sitelen pi tenpo pini nanpa wan, tan lipu `{{ snapshot.branch }}` pi tenpo ni.{% endfor %}
+  * [Nightly Snapshot]({{ site.data.downloads.nightly_snapshot.url.gz }}):
+    ni li poki sitelen tan Git, li kama sin lon tenpo pimeja ale.
+    ona li ken jo e pakala, o kepeken kepeken lawa sina!
+
+tawa sona mute pi nanpa sin, e nanpa pini, e nanpa lukin-open, o lukin
+e [lipu Releases][releases] (toki Inglisi). sona pi tenpo awen pi lipu
+Ruby mute li lon [lipu Branches][branches] (toki Inglisi).
+
+tawa sona pi poki sitelen Ruby (Subversion en Git), o lukin e lipu
+[Ruby Core](/en/community/ruby-core/) (toki Inglisi).
+
+sitelen open pi Ruby li lon [ma Mirror Sites][mirrors] (toki Inglisi)
+pi ma ale. o alasa kepeken mirror li lon poka sina.
+
+
+
+[license]: {{ site.license.url }}
+[installation]: /tok/documentation/installation/
+[releases]: /en/downloads/releases/
+[branches]: /en/downloads/branches/
+[mirrors]: /en/downloads/mirrors/
+[rvm]: http://rvm.io/
+[rbenv]: https://github.com/rbenv/rbenv
+[rubyinstaller]: https://rubyinstaller.org/

--- a/tok/examples/cities.md
+++ b/tok/examples/cities.md
@@ -1,0 +1,20 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# Ruby li sona e wile sina,
+# taso sina wile pali nanpa
+# lon Array ale
+cities  = %w[ London
+              Oslo
+              Paris
+              Amsterdam
+              Berlin ]
+visited = %w[Berlin Oslo]
+
+puts "mi wile awen " +
+     "tawa lukin e ma " +
+     "ni:",
+     cities - visited
+{% endhighlight %}

--- a/tok/examples/greeter.md
+++ b/tok/examples/greeter.md
@@ -1,0 +1,22 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# poki Greeter (jan toki)
+class Greeter
+  def initialize(name)
+    @name = name.capitalize
+  end
+
+  def salute
+    puts "toki #{@name}!"
+  end
+end
+
+# o pali e ijo sin
+g = Greeter.new("ma")
+
+# ona li sitelen e "toki Ma!"
+g.salute
+{% endhighlight %}

--- a/tok/examples/hello_world.md
+++ b/tok/examples/hello_world.md
@@ -1,0 +1,18 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# toki ilo "Hello World" li
+# suli mute, taso lon Ruby
+# ona li pona lili. sina
+# wile ala e:
+#
+# * nasin pali "main"
+# * linja sin
+# * sitelen ";"
+#
+# sitelen ni li lon:
+
+puts "Hello World!"
+{% endhighlight %}

--- a/tok/examples/i_love_ruby.md
+++ b/tok/examples/i_love_ruby.md
@@ -1,0 +1,17 @@
+---
+layout: null
+---
+
+{% highlight ruby %}
+# ona li sitelen e "mi olin e Ruby"
+say = "mi olin e Ruby"
+puts say
+
+# ona li sitelen e "mi *OLIN* E RUBY"
+say = say.sub("olin", "*olin*")
+puts say.upcase
+
+# ona li sitelen e "mi *olin* e Ruby"
+# nanpa luka
+5.times { puts say }
+{% endhighlight %}

--- a/tok/feeds/news.rss
+++ b/tok/feeds/news.rss
@@ -1,0 +1,4 @@
+---
+layout: news_feed
+lang: tok
+---

--- a/tok/index.html
+++ b/tok/index.html
@@ -1,0 +1,15 @@
+---
+layout: homepage
+title: "Ruby Programming Language"
+lang: tok
+---
+
+{% include home/hero.html %}
+
+
+{% include home/why_ruby.html %}
+
+
+{% include home/community.html %}
+
+{% include home/news_security.html %}

--- a/tok/libraries/index.md
+++ b/tok/libraries/index.md
@@ -1,0 +1,127 @@
+---
+layout: page
+title: "namako"
+lang: tok
+---
+
+sama toki ilo mute, Ruby li kepeken namako mute tan jan ante.
+{: .summary}
+
+namako ale (li sama ale) li kama lon nasin **gem** (mi toki e ona
+"namako"), poki namako wan anu ilo wan li ken kama jo kepeken ilo li
+nimi [**RubyGems**][1].
+
+RubyGems li ilo lawa namako pi Ruby, li pona e pali, e pana tawa jan
+ante, en kama jo pi namako (lon nasin ante, ona li sama ilo lawa namako
+`apt-get`, taso ona li tawa Ruby taso). Ruby li jo e RubyGems lon open
+tan nanpa 1.9 kama; nanpa Ruby pi tenpo pini li wile e sina [kama jo
+kepeken luka][2].
+
+namako ante li kama lon poki sitelen (.zip anu .tar.gz) pi **sitelen
+open**. nasin kama jo li ken ante ante; poki `README` anu `INSTALL` li
+lon mute, li jo e nasin toki.
+
+o lukin e nasin alasa e namako en kama jo e ona tawa kepeken sina.
+
+### alasa e namako
+
+ma suli tawa namako li [**RubyGems.org**][1], poki namako pi jan ale li
+ken alasa en kama jo lon ilo sona sina. sina ken alasa e namako lon
+lipu RubyGems, anu kepeken nasin pali `gem`.
+
+kepeken `gem search -r`, sina ken alasa lon poki RubyGems. sama ni,
+`gem search -r rails` li pana e lipu namako li poka Rails. kepeken
+`--local` (`-l`), sina alasa lon namako sina jo pini. tawa kama jo e
+namako, o kepeken `gem install [namako]`. tawa lukin e namako sina jo,
+o kepeken `gem list`. tawa sona mute pi nasin pali `gem`, o lukin lon
+anpa anu o tawa [lipu sona RubyGems][3].
+
+ma ante li lon tawa namako. [**GitHub**][5] li ma suli nanpa wan tawa
+sitelen Ruby. mute pi tenpo la, sitelen open pi namako li lon GitHub,
+taso ona li kama namako sin lon RubyGems.org.
+
+[**The Ruby Toolbox**][6] li pali li pona e alasa e pali Ruby pi ken ala
+esun. ona li jo e poki mute tawa pali suli mute, li jo e sona mute pi
+pali (pana sin, pali sitelen) anu poki poka ona, li lukin e pali kepeken
+nasin jan li kepeken ona lon RubyGems.org en GitHub. ni li pona e alasa
+e namako li pona tawa pakala wan (sama poki ilo lipu, ilo lipu sona,
+namako pi pona sitelen).
+
+### toki lili sin pi RubyGems
+
+o lukin e toki lili pi nasin pali `gem`, tawa kepeken sina lon tenpo
+suno ale. [lipu sona mute][7] li lon, li toki e ale pi ilo namako ni.
+
+#### alasa e namako lon insa namako ale
+
+nasin pali **search** li ken alasa e namako, kepeken nimi lili. namako
+li open kepeken nimi lili sina pana li kama lon lipu. sama ni, tawa
+alasa e namako li poka "html":
+
+{% highlight sh %}
+$ gem search -r html
+
+*** REMOTE GEMS ***
+
+html-sample (1.0, 1.1)
+{% endhighlight %}
+
+sitelen `--remote` / `-r` li toki e ni: mi wile lukin e poki lawa
+RubyGems.org (nasin lon open). kepeken `--local` / `-l`, sina alasa lon
+namako sina jo pini.
+
+#### kama jo e namako
+
+sina sona e namako sina wile **kama jo**, sama poki pali suli Ruby on
+Rails:
+
+{% highlight sh %}
+$ gem install rails
+{% endhighlight %}
+
+sina ken kama jo e nanpa wan taso, kepeken `--version` / `-v`:
+
+{% highlight sh %}
+$ gem install rails --version 5.0
+{% endhighlight %}
+
+#### lipu pi namako ale
+
+tawa **lipu** pi namako ale sina jo pini:
+
+{% highlight sh %}
+$ gem list
+{% endhighlight %}
+
+tawa lipu suli (suli mute!) pi namako ale lon RubyGems.org:
+
+{% highlight sh %}
+$ gem list -r
+{% endhighlight %}
+
+#### pana pona!
+
+lipu sona li lon insa ilo toki sina:
+
+{% highlight sh %}
+$ gem help
+{% endhighlight %}
+
+sama ni, `gem help commands` li pona mute, tan ni ona li pana e lipu pi
+nasin pali `gem` ale.
+
+#### pali e namako sina
+
+RubyGems.org li jo e [lipu sona mute][3] pi ijo ni. sina ken lukin sin e
+[Bundler][9], ilo li pona e lawa e namako sina wile tawa pali wan, li
+ken kepeken poka RubyGems.
+
+
+
+[1]: https://rubygems.org/
+[2]: https://rubygems.org/pages/download/
+[3]: http://guides.rubygems.org/
+[5]: https://github.com/
+[6]: https://www.ruby-toolbox.com/
+[7]: http://guides.rubygems.org/command-reference/
+[9]: http://bundler.io/

--- a/tok/news/_posts/2026-09-10-toki-pona-lon-lipu-Ruby.md
+++ b/tok/news/_posts/2026-09-10-toki-pona-lon-lipu-Ruby.md
@@ -1,0 +1,25 @@
+---
+layout: news_post
+title: "toki pona li lon lipu Ruby!"
+author: "Toki Pona Translators"
+translator:
+date: 2026-09-10 12:00:00 +0000
+lang: tok
+---
+
+tenpo ni la, mi pana e [lipu Ruby lon toki pona][1] tawa jan ale!
+
+lipu sin ni li toki e Ruby li seme, li toki e nasin kama jo, li toki e
+lipu sona pi open, e kulupu, e awen pona, e namako, e ijo mute ante —
+ale lon toki pona.
+
+sina wile pana pali tawa kulupu Ruby la, sina ken pona e lipu ni! o
+tawa [ruby-lang.org lon GitHub][2], o open e issue anu pull request
+lon tenpo ni!
+
+toki pona li ale li pona.
+
+
+
+[1]: {{ site.url }}/tok/
+[2]: https://github.com/ruby/www.ruby-lang.org/

--- a/tok/security/index.md
+++ b/tok/security/index.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: "awen pona"
+lang: tok
+---
+
+lon ni sina ken kama jo e sona pi awen pona Ruby.
+{: .summary}
+
+## o toki e pakala awen
+
+sina lukin e pakala awen lon toki ilo Ruby la, o toki e ona lon
+[lipu HackerOne](https://hackerone.com/ruby) mi, anu kepeken sitelen
+lipu tawa security@ruby-lang.org
+([nasin PGP](/security.asc)), lipu toki pi ken ala jan ale lukin. o
+lukin e sona pi ken lipu mi lon open, o toki pini. pakala ale li lon,
+li lon toki mi la, mi pana e sona pi pakala ni lon lipu ale, tenpo pona
+li pana pini.
+
+sina lukin e pakala lon lipu mi (website) wan la, o toki e ona
+[kepeken GitHub](https://github.com/ruby/www.ruby-lang.org/issues/new).
+
+sina lukin e pakala lon namako pi kulupu Ruby taso la, o kepeken
+[nasin lon RubyGems.org](http://guides.rubygems.org/security/#reporting-security-vulnerabilities).
+
+## lipu toki pi awen pona
+
+jan lon lipu toki security@ruby-lang.org li jan li pana e Ruby (jan
+committer pi Ruby, jan pi nasin pali Ruby ante, jan pana namako, jan
+PaaS).
+
+jan lon lipu toki li wile jan wan taso; lipu toki ante li ken ala jan
+lon insa. sina lawa e kulupu ni la, o toki tawa mi tawa kama insa.
+
+## pakala li sona pini
+
+_o lukin e [lipu Inglisi](/en/security/) tawa lipu pi pakala awen ale
+li sin lon tenpo ni. lipu ni li jo e sona sin taso mi ante toki pini,
+tan ni ona li ken jo ala e ale, anu li ken tenpo pini._
+
+pakala sin li lon ni:
+
+{% include security_posts.html %}


### PR DESCRIPTION
## Summary

Add the timezone data dependency required for the website to build on Windows with Ruby 4, and add Toki Pona support to the website.

## Problem

When running the development server on Windows with Ruby 4, Jekyll fails because TZInfo cannot find a timezone data source.

In addition, Toki Pona content was added to the website and needs to be included in this change.

## Changes

* Add `tzinfo-data` as a dependency.
* Allow the Jekyll development server to find timezone data on Windows.
* Add Toki Pona language support and related website content.
* Add the necessary Toki Pona translations and localization data.

## Testing

Tested with:

* Windows
* Ruby 4
* `bundle exec rake serve`

The Jekyll development server now proceeds without the `TZInfo::DataSourceNotFound` error.

The newly added Toki Pona content was also checked to ensure it is included correctly in the website.
